### PR TITLE
🔧(bin) fix update_openapi_schema script

### DIFF
--- a/bin/update_openapi_schema
+++ b/bin/update_openapi_schema
@@ -7,6 +7,6 @@ _dc_run \
     app-dev \
     python manage.py spectacular \
     --api-version 'v1.0' \
-    --urlconf 'impress.api_urls' \
+    --urlconf 'core.urls' \
     --format openapi-json \
     --file /app/core/tests/swagger/swagger.json


### PR DESCRIPTION
## Purpose

Update the script `update_openapi_schema` to be able to find api urls which are declared in `core.urls` module.