### PR TITLE
✨(admin) add missing admin register for MessageRecipientAdmin

### DIFF
--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -142,6 +142,7 @@ class ContactAdmin(admin.ModelAdmin):
     list_display = ("id", "name", "email")
 
 
+@admin.register(models.MessageRecipient)
 class MessageRecipientAdmin(admin.ModelAdmin):
     """Admin class for the MessageRecipient model"""
 


### PR DESCRIPTION
Decorator is missing to display MessageRecipient table in django admin.
