### PR TITLE
🔧(frontend) disable TypeScript build error

### DIFF
--- a/src/frontend/next.config.ts
+++ b/src/frontend/next.config.ts
@@ -4,6 +4,10 @@ const nextConfig: NextConfig = {
   output: "export",
   debug: process.env.NODE_ENV === "development",
   reactStrictMode: false,
+  // FIXME: Ignore build errors until we have all the model types
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Purpose

Temporarily ignore TypeScript build errors in the Next.js configuration to facilitate development until all model types are defined.