### PR TITLE
💚(ci) fix lint-back job

### DIFF
--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Upgrade pip and setuptools
+        run: pip install --upgrade pip setuptools
       - name: Install development dependencies
         run: pip install --user .[dev]
       - name: Check code formatting with ruff


### PR DESCRIPTION
## Purpose

Since we added a setup.py module, the lint-back was failing as setuptools was not install in the ci job