### PR TITLE
🐛(frontend) fix issue at first load thread view

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/index.tsx
@@ -10,8 +10,8 @@ export const ThreadView = () => {
     const { threads, selectedThread, selectThread, messages } = useMailboxContext();
 
     useEffect(() => {
-        if (selectedThread?.id !== params.threadId) {
-            const thread = threads?.results.find(({id}) => id === params.threadId);
+        if (selectedThread?.id !== params?.threadId) {
+            const thread = threads?.results.find(({ id }) => id === params.threadId);
             if (thread) {
                 selectThread(thread);
             }


### PR DESCRIPTION
## Purpose

If a user tries to go the thread view through a link, at first load an error is raised as params is not found. We have to ensure this parameters exist before trying to find the selectedThread
