### PR TITLE
✨(api) new thread created from current user has to be already read

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -372,6 +372,7 @@ class MessageCreateView(APIView):
                 subject=subject,
                 # TODO: enhance to use htmlBody if is the only one provided
                 snippet=request.data.get("textBody")[:100],
+                is_read=True,
             )
 
         recipients = {

--- a/src/backend/core/tests/api/test_messages_create.py
+++ b/src/backend/core/tests/api/test_messages_create.py
@@ -104,6 +104,7 @@ class TestApiMessageNewCreate:
         assert thread.snippet == "test"
         assert thread.messages.count() == 1
         assert thread.messages.get().id == message.id
+        assert thread.is_read is True
 
     @pytest.mark.parametrize(
         "permission",


### PR DESCRIPTION
Don't forget to set is_read field of new thread created to True
