### PR TITLE
💄(frontend) display mailbox in a select

### DIFF
--- a/src/frontend/src/features/i18n/translations.json
+++ b/src/frontend/src/features/i18n/translations.json
@@ -8,6 +8,7 @@
       "my_account": "My Account",
       "no_mailbox": "No mailbox.",
       "no_threads": "No threads.",
+      "mailbox": "Mailbox",
       "new_message_form": {
         "title": "New message"
       },
@@ -68,6 +69,7 @@
       "my_account": "Mon Compte",
       "no_mailbox": "Aucune boîte aux lettres.",
       "no_threads": "Aucune conversation.",
+      "mailbox": "Boîte aux lettres",
       "new_message_form": {
         "title": "Nouveau message"
       },

--- a/src/frontend/src/features/layouts/components/mailbox-panel/_index.scss
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/_index.scss
@@ -5,9 +5,12 @@
 }
 
 .mailbox-panel__mailbox-title {
-    font-size: 1rem;
-    font-weight: 600;
     margin: 0;
     padding-inline: var(--c--theme--spacings--sm);
     padding-top: var(--c--theme--spacings--sm);
+    margin-bottom: var(--c--theme--spacings--sm);
+
+    & .c__select__inner__value {
+        font-weight: 600;
+    }
 }

--- a/src/frontend/src/features/layouts/components/mailbox-panel/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/index.tsx
@@ -2,9 +2,21 @@ import { HorizontalSeparator, Spinner } from "@gouvfr-lasuite/ui-kit"
 import { MailboxPanelActions } from "./components/mailbox-actions"
 import { MailboxList } from "./components/mailbox-list"
 import { useMailboxContext } from "@/features/mailbox/provider";
+import { Select } from "@openfun/cunningham-react";
+import { useTranslation } from "react-i18next";
 
 export const MailboxPanel = () => {
-    const { selectedMailbox, status} = useMailboxContext();
+    const { t } = useTranslation();
+    const { selectedMailbox, mailboxes, status} = useMailboxContext();
+
+    const getMailboxOptions = () => {
+        if(!mailboxes) return [];
+        return mailboxes.map((mailbox) => ({
+            label: mailbox.email,
+            value: mailbox.id
+        }));
+    }
+
     return (
         <div className="mailbox-panel">
             <div className="mailbox-panel__header">
@@ -15,7 +27,16 @@ export const MailboxPanel = () => {
             (
                 <>
                     {/* FIXME: For now we consider user has always only one mailbox */}
-                    <h2 className="mailbox-panel__mailbox-title">{selectedMailbox.email}</h2>
+                    <Select
+                        className="mailbox-panel__mailbox-title"
+                        options={getMailboxOptions()}
+                        defaultValue={selectedMailbox.id}
+                        label={t('mailbox')}
+                        clearable={false}
+                        compact
+                        fullWidth
+                        showLabelWhenSelected={false}
+                    />
                     <MailboxList />
                 </>
             )}


### PR DESCRIPTION
## Purpose

In order to improve layout, we display mailbox in a select. It prepares the future by allowing to list all mailbox a user has access

<img width="307" alt="image" src="https://github.com/user-attachments/assets/a0d5f8cc-7cee-4ad3-b145-d5ac19c6ce3a" />