### PR TITLE
🐛(frontend) do not use react-email render method

### DIFF
--- a/src/frontend/src/features/utils/__tests__/mail-helper.test.tsx
+++ b/src/frontend/src/features/utils/__tests__/mail-helper.test.tsx
@@ -6,8 +6,8 @@ describe('MailHelper', () => {
       const markdown = '**Hello World**';
       const html = await MailHelper.markdownToHtml(markdown);
       expect(html).toMatchInlineSnapshot(`
-        "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><!--$--><div data-id="react-email-markdown"><p><strong style="font-weight:bold">Hello World</strong></p>
-        </div><!--/$-->"
+        "<div data-id="react-email-markdown"><p><strong style="font-weight:bold">Hello World</strong></p>
+        </div>"
       `);
     });
   });

--- a/src/frontend/src/features/utils/mail-helper.tsx
+++ b/src/frontend/src/features/utils/mail-helper.tsx
@@ -1,4 +1,5 @@
-import { Markdown, render } from "@react-email/components";
+import { renderToString } from "react-dom/server";
+import { Markdown } from "@react-email/components";
 import React from "react";
 
 /** An helper which aims to gather all utils related write and send a message */
@@ -9,7 +10,7 @@ class MailHelper {
      * then render HTML ready for email through react-email.
      */
     static async markdownToHtml(markdown: string) {
-        return render(<Markdown>{markdown}</Markdown>);
+        return renderToString(<Markdown>{markdown}</Markdown>);
     }
 
     /**


### PR DESCRIPTION
## Purpose

render method of react-email is not compatible with Safari. As a workaround to render the Markdown component as a string we can use the `renderToString` of react-dom/server.

https://github.com/resend/react-email/issues/1732