### PR TITLE
🐛(backend) fix ThreadViewset list ordering

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -322,9 +322,13 @@ class ThreadViewSet(
         """Restrict results to threads of the current user's mailboxes."""
         mailbox_id = self.request.GET.get("mailbox_id")
         accesses = self.request.user.mailbox_accesses.all()
-        queryset = models.Thread.objects.filter(
-            mailbox__id__in=accesses.values_list("mailbox_id", flat=True)
-        ).order_by("-messages__created_at")
+        queryset = (
+            models.Thread.objects.filter(
+                mailbox_id__in=accesses.values_list("mailbox_id", flat=True)
+            )
+            .annotate(latest_message_created_at=db.Max("messages__created_at"))
+            .order_by("-latest_message_created_at")
+        )
         if mailbox_id:
             return queryset.filter(mailbox__id=mailbox_id)
         return queryset

--- a/src/backend/core/tests/api/test_messages_list.py
+++ b/src/backend/core/tests/api/test_messages_list.py
@@ -75,6 +75,13 @@ class TestApiThreads:
         assert response.data["count"] == 3
         assert len(response.data["results"]) == 3
 
+        # Assert the threads are sorted by latest message
+        assert [thread["id"] for thread in response.data["results"]] == [
+            str(thread2.id),
+            str(thread3.id),
+            str(thread1.id),
+        ]
+
         # Assert the thread data is correct (first thread is the one with the last new message)
         thread_data = response.data["results"][0]
         assert thread_data["id"] == str(thread2.id)


### PR DESCRIPTION
## Purpose

We are ordering threads list by message creation date. The current queryset was ordering on all thread messages so if a thread had the two latest message it was returned twice in the queryset. Instead we annotate the queryset with the latest message creation date
 for each thread then order threads through this property