### PR TITLE
🔧(docker) update celery-dev service build context and target

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -127,8 +127,8 @@ services:
 
   celery-dev:
     build:
-      context: .
-      target: backend-development
+      context: src/backend
+      target: runtime-dev
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
     user: ${DOCKER_USER:-1000}


### PR DESCRIPTION
## Purpose

Currently the `celery-dev` service is not able to build as the context is wrong so the Dockerfile cannot be found. Furthermore we also fix the target.