### PR TITLE
✨(frontend) allow to trash a message and undo trash action

### DIFF
--- a/src/frontend/src/features/i18n/translations.json
+++ b/src/frontend/src/features/i18n/translations.json
@@ -29,6 +29,8 @@
         "close_thread": "Close this thread",
         "cancel": "Cancel",
         "delete": "Delete",
+        "undelete": "Undelete",
+        "undo": "Undo",
         "send": "Send",
         "archive": "Archive",
         "refresh": "Refresh",
@@ -80,6 +82,10 @@
         "sent": "Message sent successfully",
         "error": "The message could not be sent.",
         "not_found": "No sending message found."
+      },
+      "trash": {
+        "message_deleted": "The message has been deleted",
+        "thread_deleted": "The conversation has been deleted"
       },
       "message_editor": {
         "start_typing": "Start typing..."
@@ -140,6 +146,8 @@
         "reply_all": "Répondre à tous",
         "cancel": "Annuler",
         "delete": "Supprimer",
+        "undelete": "Restaurer",
+        "undo": "Annuler",
         "send": "Envoyer",
         "archive": "Archiver",
         "forward": "Transférer",
@@ -155,7 +163,6 @@
         "has_attachments": "Cette email contient une pièce jointe",
         "more_options": "Plus d'options",
         "reply": "Répondre"
-        
       },
       "thread_message": {
         "from": "De : ",
@@ -192,6 +199,10 @@
         "error": "Le message n'a pas pu être envoyé.",
         "not_found": "Aucun message en cours d'envoi trouvé.",
         "sent_too_long": "Le message n'a pas pu être envoyé. Veuillez réessayer plus tard."
+      },
+      "trash": {
+        "message_deleted": "Le message a bien été supprimé",
+        "thread_deleted": "La conversation a bien été supprimée"
       },
       "message_editor": {
         "start_typing": "Commencer à écrire..."

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-action-bar/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-action-bar/index.tsx
@@ -12,7 +12,7 @@ export const ActionBar = () => {
     const { t } = useTranslation();
     const { selectedThread, unselectThread } = useMailboxContext();
     const { markAsUnread } = useRead();
-    const { markAsTrashed } = useTrash();
+    const { markAsTrashed, markAsUntrashed } = useTrash();
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
     return (
@@ -38,15 +38,29 @@ export const ActionBar = () => {
                         onClick={() => markAsUnread({ threadIds: [selectedThread!.id], onSuccess: unselectThread })}
                     />
                 </Tooltip>
-                <Tooltip content={t('actions.delete')}>
-                    <Button
-                        color="primary-text"
-                        aria-label={t('actions.delete')}
-                        size="small"
-                        icon={<span className="material-icons">delete</span>}
-                        onClick={() => markAsTrashed({ threadIds: [selectedThread!.id], onSuccess: unselectThread })}
-                    />
-                </Tooltip>
+                {
+                    selectedThread!.count_trashed < selectedThread!.count_messages ? (
+                        <Tooltip content={t('actions.delete')}>
+                            <Button
+                                color="primary-text"
+                                aria-label={t('actions.delete')}
+                                size="small"
+                                icon={<span className="material-icons">delete</span>}
+                                onClick={() => markAsTrashed({ threadIds: [selectedThread!.id], onSuccess: unselectThread })}
+                            />
+                        </Tooltip>
+                    ) : (
+                        <Tooltip content={t('actions.undelete')}>
+                            <Button
+                                color="primary-text"
+                                aria-label={t('actions.undelete')}
+                                size="small"
+                                icon={<span className="material-icons">restore</span>}
+                                onClick={() => markAsUntrashed({ threadIds: [selectedThread!.id], onSuccess: unselectThread })}
+                            />
+                        </Tooltip>
+                    )
+                }
                 <DropdownMenu
                     isOpen={isDropdownOpen}
                     onOpenChange={setIsDropdownOpen}

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
@@ -8,6 +8,7 @@ import { DropdownMenu } from "@gouvfr-lasuite/ui-kit";
 import useRead from "@/features/message/use-read";
 import { useMailboxContext } from "@/features/providers/mailbox";
 import { Badge } from "@/features/ui/components/badge";
+import useTrash from "@/features/message/use-trash";
 type ThreadMessageProps = {
     message: Message,
     isLatest: boolean,
@@ -22,6 +23,8 @@ export const ThreadMessage = forwardRef<HTMLElement, ThreadMessageProps>(
             return null;
         })
         const { markAsUnread } = useRead()
+        const { markAsTrashed } = useTrash()
+
         const { unselectThread, selectedThread, messages, queryStates } = useMailboxContext()
         const isFetchingMessages = queryStates.messages.isFetching;
         const [isDropdownOpen, setIsDropdownOpen] = useState(false)
@@ -103,6 +106,11 @@ export const ThreadMessage = forwardRef<HTMLElement, ThreadMessageProps>(
                                             label: hasSiblingMessages ? t('actions.mark_as_unread_from_here') : t('actions.mark_as_unread'),
                                             icon: <span className="material-icons">mark_email_unread</span>,
                                             callback: () => markAsUnreadFrom(message.id)
+                                        },
+                                        {
+                                            label: t('actions.delete'),
+                                            icon: <span className="material-icons">delete</span>,
+                                            callback: () => markAsTrashed({messageIds: [message.id]})
                                         },
                                     ]}
                                 >

--- a/src/frontend/src/features/ui/components/toaster/_index.scss
+++ b/src/frontend/src/features/ui/components/toaster/_index.scss
@@ -22,6 +22,7 @@
       gap: 8px;
       align-items: center;
       flex-grow: 1;
+      justify-content: space-between;
     }
 
     &--info {
@@ -38,7 +39,4 @@
       --toastify-color-progress-light: var(--c--theme--colors--danger-800);
     }
   }
-}
-
-:root {
 }


### PR DESCRIPTION
## Purpose

Currently, user was allowed to trash only threads, now it is able to trash a single message. Furthermore to improve UX, when a thread or a message is moved to trash, a toast is displayed and allow the user to undo its action.


https://github.com/user-attachments/assets/ed084992-71cb-4df2-8fd0-40401f8fc217

