### PR TITLE
🐛(frontend) prevent to create draft message twice

### DIFF
--- a/src/frontend/src/features/forms/components/message-form/index.tsx
+++ b/src/frontend/src/features/forms/components/message-form/index.tsx
@@ -154,7 +154,6 @@ export const MessageForm = ({
             onSuccess: async (response) => {
                 const taskId = (response as sendCreateResponse200).data.task_id;
                 addQueuedMessage(taskId);
-                invalidateThreadMessages();
                 onSuccess?.();
                 onClose?.();
             }
@@ -410,7 +409,7 @@ export const MessageForm = ({
                 <footer className="form-footer">
                     <Button
                         color="primary"
-                        disabled={pendingSubmit}
+                        disabled={!draft || pendingSubmit}
                         icon={pendingSubmit ? <Spinner size="sm" /> : undefined}
                         type="submit"
                     >


### PR DESCRIPTION
## Purpose

Currently if a draft is not yet created and the user quickly click on the send button, two draft messages can be created. We disable the send button until a draft message is created to prevent this behavior.