### PR TITLE
🐛(frontend) prevent validate MessageForm when attachments are not dirty

### DIFF
--- a/src/frontend/src/features/forms/components/message-form/attachment-uploader.tsx
+++ b/src/frontend/src/features/forms/components/message-form/attachment-uploader.tsx
@@ -88,7 +88,9 @@ export const AttachmentUploader = ({
             blobId: attachment.blobId,
             name: attachment.name
         })), { shouldDirty: true });
-        debouncedOnChange();
+        if (form.formState.dirtyFields.attachments) {
+            debouncedOnChange();
+        }
     }, [attachments]);
 
     return (

--- a/src/frontend/src/features/forms/components/message-form/index.tsx
+++ b/src/frontend/src/features/forms/components/message-form/index.tsx
@@ -25,7 +25,6 @@ interface MessageFormProps {
     onClose?: () => void;
     // For new message mode
     showSubject?: boolean;
-    showMailboxes?: boolean;
     onSuccess?: () => void;
 }
 

--- a/src/frontend/src/pages/mailbox/new/index.tsx
+++ b/src/frontend/src/pages/mailbox/new/index.tsx
@@ -36,7 +36,6 @@ const NewMessageFormPage = () => {
             <MessageForm
                 showSubject={true}
                 onSuccess={() => router.push('/')}
-                showMailboxes
                 onClose={handleClose}
             />
         </div>


### PR DESCRIPTION
## Purpose

Currently when the AttachmentsUploader field is mounted, the form is validated that is weird. Before triggering onChange callback in this component we check if attachments has changed (the field is marked as dirty).

Then we remove a deprecated props.