### PR TITLE
🚸(frontend) improve attachment-uploader file dialog open management

### DIFF
--- a/src/frontend/src/features/forms/components/message-form/_index.scss
+++ b/src/frontend/src/features/forms/components/message-form/_index.scss
@@ -41,6 +41,7 @@
     transition: border var(--c--theme--transitions--duration) var(--c--theme--transitions--ease-out), border-radius var(--c--theme--transitions--duration) var(--c--theme--transitions--ease-out);
     box-sizing: border-box;
     position: relative;
+    cursor: pointer;
 }
 
 .attachment-uploader__dropzone {

--- a/src/frontend/src/features/forms/components/message-form/index.tsx
+++ b/src/frontend/src/features/forms/components/message-form/index.tsx
@@ -306,6 +306,16 @@ export const MessageForm = ({
         });
     };
 
+    /**
+     * Prevent the Enter key press to trigger onClick on input children (like file input)
+     */
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            form.handleSubmit(saveDraft)();
+        }
+    }
+
     useEffect(() => {
         if (draftMessage) form.setFocus("subject");
         else form.setFocus("to")
@@ -333,7 +343,7 @@ export const MessageForm = ({
 
     return (
         <FormProvider {...form}>
-            <form className="message-form" onSubmit={form.handleSubmit(handleSubmit)} onBlur={form.handleSubmit(saveDraft)}>
+            <form className="message-form" onSubmit={form.handleSubmit(handleSubmit)} onKeyDown={handleKeyDown}>
                 <div className={clsx("form-field-row", {'form-field-row--hidden': hideFromField})}>
                     <RhfSelect
                         name="from"


### PR DESCRIPTION
## Purpose

Currently, when the user press the enter anywhere in the message form, the file dialog was opened that was weird. Furthermore, the attachment uploader was not fully clickable to open the file dialog that was also weird. So we improve all of that.
