### PR TITLE
🚸(frontend) display thread access count in widget

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-accesses-widget/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-accesses-widget/index.tsx
@@ -112,6 +112,9 @@ export const ThreadAccessesWidget = ({ accesses }: ThreadAccessesWidgetProps) =>
             {accesses.length > 1 ? (
                 <Button color="tertiary-text" size="small" className="thread-accesses-widget" onClick={() => setIsShareModalOpen(true)}>
                     <ThreadAccessesList accesses={accesses} />
+                    <div className="thread-accesses-widget__item thread-accesses-widget__item--count">
+                        {accesses.length}
+                    </div>
                 </Button>
             ) : (
                 <Button color="tertiary-text" size="small" icon={<span className="material-icons">supervised_user_circle</span>} onClick={() => setIsShareModalOpen(true)}>


### PR DESCRIPTION
## Purpose

We recently add a widget to manage thread accesses but we forgot to display the total count of thread accesses. This is now fixed.
