### PR TITLE
🐛(frontend) prevent form submittion on attachment selection

### DIFF
--- a/src/frontend/src/features/forms/components/message-form/attachment-uploader.tsx
+++ b/src/frontend/src/features/forms/components/message-form/attachment-uploader.tsx
@@ -113,6 +113,7 @@ export const AttachmentUploader = ({
                 <Button
                     color="tertiary"
                     icon={<span className="material-icons">attach_file</span>}
+                    type="button"
                 >
                     {t("message_form.attachments_uploader.input_label")}
                 </Button>

--- a/src/frontend/src/features/forms/components/message-form/index.tsx
+++ b/src/frontend/src/features/forms/components/message-form/index.tsx
@@ -312,7 +312,6 @@ export const MessageForm = ({
     const handleKeyDown = (event: React.KeyboardEvent) => {
         if (event.key === 'Enter') {
             event.preventDefault();
-            form.handleSubmit(saveDraft)();
         }
     }
 
@@ -343,7 +342,12 @@ export const MessageForm = ({
 
     return (
         <FormProvider {...form}>
-            <form className="message-form" onSubmit={form.handleSubmit(handleSubmit)} onKeyDown={handleKeyDown}>
+            <form
+                className="message-form"
+                onSubmit={form.handleSubmit(handleSubmit)}
+                onBlur={form.handleSubmit(saveDraft)}
+                onKeyDown={handleKeyDown}
+            >
                 <div className={clsx("form-field-row", {'form-field-row--hidden': hideFromField})}>
                     <RhfSelect
                         name="from"


### PR DESCRIPTION
## Purpose

Currently the button to open the file dialog in the attachment uploader component has no type so as it is embedded into a form it is considered by default as a submit button so each time the user clicks on this button the form is submitted...
