### PR TITLE
endpoints to manage labels and retrieve label list in a tree structure

### DIFF
--- a/src/backend/core/api/openapi.json
+++ b/src/backend/core/api/openapi.json
@@ -1345,6 +1345,492 @@
                 }
             }
         },
+        "/api/v1.0/labels/": {
+            "get": {
+                "operationId": "labels_list",
+                "description": "\n        List all labels accessible to the user in a hierarchical structure.\n        \n        The response returns labels in a tree structure where:\n        - Labels are ordered alphabetically by name\n        - Each label includes its children (sub-labels)\n        - The hierarchy is determined by the label's name (e.g., \"Inbox/Important\" is a child of \"Inbox\")\n        \n        You can filter labels by mailbox using the mailbox_id query parameter.\n        ",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "mailbox_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "\n                Filter labels by mailbox ID. If not provided, returns labels from all accessible mailboxes.\n                "
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "labels"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "count",
+                                        "results"
+                                    ],
+                                    "properties": {
+                                        "count": {
+                                            "type": "integer",
+                                            "example": 123
+                                        },
+                                        "next": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "format": "uri",
+                                            "example": "http://api.example.org/accounts/?page=4"
+                                        },
+                                        "previous": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "format": "uri",
+                                            "example": "http://api.example.org/accounts/?page=2"
+                                        },
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "string",
+                                                            "format": "uuid"
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "Full name of the label (e.g., 'Inbox/Important')"
+                                                        },
+                                                        "slug": {
+                                                            "type": "string",
+                                                            "description": "URL-friendly version of the name"
+                                                        },
+                                                        "color": {
+                                                            "type": "string",
+                                                            "description": "Color code for the label"
+                                                        },
+                                                        "display_name": {
+                                                            "type": "string",
+                                                            "description": "Base name of the label (last part of the path)"
+                                                        },
+                                                        "children": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/components/schemas/Label"
+                                                            },
+                                                            "description": "Child labels, ordered alphabetically by name"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "name",
+                                                        "slug",
+                                                        "color",
+                                                        "display_name",
+                                                        "children"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": "List of labels in hierarchical structure"
+                    },
+                    "400": {
+                        "description": "Invalid mailbox_id parameter"
+                    },
+                    "403": {
+                        "description": "User does not have access to the specified mailbox"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "labels_create",
+                "description": "View and manage labels",
+                "tags": [
+                    "labels"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LabelRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LabelRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "format": "uuid"
+                                            },
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Full name of the label (e.g., 'Inbox/Important')"
+                                            },
+                                            "slug": {
+                                                "type": "string",
+                                                "description": "URL-friendly version of the name"
+                                            },
+                                            "color": {
+                                                "type": "string",
+                                                "description": "Color code for the label"
+                                            },
+                                            "display_name": {
+                                                "type": "string",
+                                                "description": "Base name of the label (last part of the path)"
+                                            },
+                                            "parent_name": {
+                                                "type": "string",
+                                                "description": "Name of the parent label, or null for root labels",
+                                                "nullable": true
+                                            },
+                                            "depth": {
+                                                "type": "integer",
+                                                "description": "Depth in the hierarchy (0 for root labels,\n                                  1 for direct children, etc.)",
+                                                "minimum": 0
+                                            },
+                                            "children": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/Label"
+                                                },
+                                                "description": "Child labels, ordered alphabetically by name"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "name",
+                                            "slug",
+                                            "color",
+                                            "display_name",
+                                            "parent_name",
+                                            "depth",
+                                            "children"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Created labels in hierarchical structure"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "detail": "Validation error"
+                                }
+                            }
+                        },
+                        "description": "Invalid input data"
+                    }
+                }
+            }
+        },
+        "/api/v1.0/labels/{id}/": {
+            "put": {
+                "operationId": "labels_update",
+                "description": "View and manage labels",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "labels"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LabelRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LabelRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Label"
+                                }
+                            }
+                        },
+                        "description": "Label updated successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "detail": "Validation error"
+                                }
+                            }
+                        },
+                        "description": "Invalid input data"
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "labels_partial_update",
+                "description": "View and manage labels",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "labels"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedLabelRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedLabelRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Label"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "labels_destroy",
+                "description": "View and manage labels",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "labels"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1.0/labels/{id}/add-threads/": {
+            "post": {
+                "operationId": "labels_add_threads_create",
+                "description": "View and manage labels",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "labels"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "thread_ids": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "format": "uuid"
+                                        },
+                                        "description": "List of thread IDs to add to this label"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Label"
+                                }
+                            }
+                        },
+                        "description": "Threads added to label successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "detail": "Validation error"
+                                }
+                            }
+                        },
+                        "description": "Invalid input data"
+                    }
+                }
+            }
+        },
+        "/api/v1.0/labels/{id}/remove-threads/": {
+            "post": {
+                "operationId": "labels_remove_threads_create",
+                "description": "View and manage labels",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "labels"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "thread_ids": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "format": "uuid"
+                                        },
+                                        "description": "List of thread IDs to remove from this label"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Label"
+                                }
+                            }
+                        },
+                        "description": "Threads removed from label successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "detail": "Validation error"
+                                }
+                            }
+                        },
+                        "description": "Invalid input data"
+                    }
+                }
+            }
+        },
         "/api/v1.0/mailboxes/": {
             "get": {
                 "operationId": "mailboxes_list",
@@ -3211,6 +3697,88 @@
                     "username"
                 ]
             },
+            "Label": {
+                "type": "object",
+                "description": "Serializer for Label model.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "primary key for the record as UUID"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the label/folder (can use slashes for hierarchy, e.g. 'Work/Projects')",
+                        "maxLength": 255
+                    },
+                    "slug": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "URL-friendly version of the name",
+                        "pattern": "^[-a-zA-Z0-9_]+$"
+                    },
+                    "color": {
+                        "type": "string",
+                        "description": "Color of the label in hex format (e.g. #FF0000)",
+                        "maxLength": 7
+                    },
+                    "mailbox": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Mailbox that owns this label"
+                    },
+                    "threads": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "Threads that have this label"
+                    }
+                },
+                "required": [
+                    "id",
+                    "mailbox",
+                    "name",
+                    "slug"
+                ]
+            },
+            "LabelRequest": {
+                "type": "object",
+                "description": "Serializer for Label model.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Name of the label/folder (can use slashes for hierarchy, e.g. 'Work/Projects')",
+                        "maxLength": 255
+                    },
+                    "color": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Color of the label in hex format (e.g. #FF0000)",
+                        "maxLength": 7
+                    },
+                    "mailbox": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Mailbox that owns this label"
+                    },
+                    "threads": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "Threads that have this label"
+                    }
+                },
+                "required": [
+                    "mailbox",
+                    "name"
+                ]
+            },
             "MailDomainAdmin": {
                 "type": "object",
                 "description": "Serialize MailDomain basic information for admin listing.",
@@ -3848,6 +4416,37 @@
                         "items": {
                             "$ref": "#/components/schemas/Thread"
                         }
+                    }
+                }
+            },
+            "PatchedLabelRequest": {
+                "type": "object",
+                "description": "Serializer for Label model.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Name of the label/folder (can use slashes for hierarchy, e.g. 'Work/Projects')",
+                        "maxLength": 255
+                    },
+                    "color": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Color of the label in hex format (e.g. #FF0000)",
+                        "maxLength": 7
+                    },
+                    "mailbox": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Mailbox that owns this label"
+                    },
+                    "threads": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "Threads that have this label"
                     }
                 }
             },

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -7,6 +7,7 @@ from django.db.models import Count, Exists, OuterRef, Q
 
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 
 from core import models
 
@@ -534,3 +535,25 @@ class ThreadLabelSerializer(serializers.ModelSerializer):
         model = models.Label
         fields = ["id", "name", "slug", "color"]
         read_only_fields = ["id", "slug"]
+
+
+class LabelSerializer(serializers.ModelSerializer):
+    """Serializer for Label model."""
+
+    class Meta:
+        model = models.Label
+        fields = ["id", "name", "slug", "color", "mailbox", "threads"]
+        read_only_fields = ["id", "slug"]
+
+    def validate_mailbox(self, value):
+        """Validate that user has access to the mailbox."""
+        user = self.context["request"].user
+        if not value.accesses.filter(
+            user=user,
+            role__in=[
+                models.MailboxRoleChoices.ADMIN,
+                models.MailboxRoleChoices.EDITOR,
+            ],
+        ).exists():
+            raise PermissionDenied("You don't have access to this mailbox")
+        return value

--- a/src/backend/core/api/viewsets/label.py
+++ b/src/backend/core/api/viewsets/label.py
@@ -1,0 +1,509 @@
+"""API ViewSet for Label model."""
+# pylint: disable=line-too-long
+
+from django.db.models import Exists, OuterRef
+from django.shortcuts import get_object_or_404
+from django.utils.text import slugify
+
+import rest_framework as drf
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+)
+from rest_framework import mixins, status, viewsets
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
+
+from core import models
+
+from .. import permissions, serializers
+
+
+@extend_schema(tags=["labels"], description="View and manage labels")
+class LabelViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+):
+    """ViewSet for Label model."""
+
+    serializer_class = serializers.LabelSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    lookup_field = "pk"
+    lookup_url_kwarg = "pk"
+
+    def get_object(self):
+        """Get the object and check basic mailbox access."""
+        obj = get_object_or_404(models.Label, pk=self.kwargs["pk"])
+        # Check basic mailbox access
+        if not obj.mailbox.accesses.filter(user=self.request.user).exists():
+            raise PermissionDenied("You don't have access to this mailbox")
+        return obj
+
+    def get_queryset(self):
+        """Restrict results to labels in mailboxes accessible by the current user."""
+        user = self.request.user
+        mailbox_id = self.request.GET.get("mailbox_id")
+
+        # For read operations, allow any role
+        queryset = models.Label.objects.filter(
+            Exists(
+                models.MailboxAccess.objects.filter(
+                    mailbox=OuterRef("mailbox"),
+                    user=user,
+                )
+            )
+        )
+
+        if mailbox_id:
+            queryset = queryset.filter(mailbox_id=mailbox_id)
+
+        return queryset.distinct()
+
+    def check_mailbox_permissions(self, mailbox):
+        """Check if user has EDITOR or ADMIN role for the mailbox."""
+        if not mailbox.accesses.filter(
+            user=self.request.user,
+            role__in=[
+                models.MailboxRoleChoices.ADMIN,
+                models.MailboxRoleChoices.EDITOR,
+            ],
+        ).exists():
+            raise PermissionDenied("You need EDITOR or ADMIN role to manage labels")
+
+    @extend_schema(
+        description="""
+        List all labels accessible to the user in a hierarchical structure.
+        
+        The response returns labels in a tree structure where:
+        - Labels are ordered alphabetically by name
+        - Each label includes its children (sub-labels)
+        - The hierarchy is determined by the label's name (e.g., "Inbox/Important" is a child of "Inbox")
+        
+        You can filter labels by mailbox using the mailbox_id query parameter.
+        """,
+        parameters=[
+            OpenApiParameter(
+                name="mailbox_id",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                description="""
+                Filter labels by mailbox ID. If not provided, returns labels from all accessible mailboxes.
+                """,
+            )
+        ],
+        responses={
+            200: OpenApiResponse(
+                response={
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string", "format": "uuid"},
+                            "name": {
+                                "type": "string",
+                                "description": "Full name of the label (e.g., 'Inbox/Important')",
+                            },
+                            "slug": {
+                                "type": "string",
+                                "description": "URL-friendly version of the name",
+                            },
+                            "color": {
+                                "type": "string",
+                                "description": "Color code for the label",
+                            },
+                            "display_name": {
+                                "type": "string",
+                                "description": "Base name of the label (last part of the path)",
+                            },
+                            "children": {
+                                "type": "array",
+                                "items": {"$ref": "#/components/schemas/Label"},
+                                "description": "Child labels, ordered alphabetically by name",
+                            },
+                        },
+                        "required": [
+                            "id",
+                            "name",
+                            "slug",
+                            "color",
+                            "display_name",
+                            "children",
+                        ],
+                    },
+                },
+                description="List of labels in hierarchical structure",
+            ),
+            400: OpenApiResponse(description="Invalid mailbox_id parameter"),
+            403: OpenApiResponse(
+                description="User does not have access to the specified mailbox"
+            ),
+        },
+    )
+    def list(self, request, *args, **kwargs):
+        """List labels in a hierarchical structure, ordered alphabetically by name."""
+        queryset = self.get_queryset().order_by("name")
+
+        # Get all labels and build the tree structure
+        labels = list(queryset)
+        label_dict = {}
+        root_labels = []
+
+        # First pass: create dictionary of all labels
+        for label in labels:
+            label_dict[label.id] = {
+                "id": str(label.id),
+                "name": label.name,
+                "slug": label.slug,
+                "color": label.color,
+                "display_name": label.name.split("/")[-1],
+                "children": [],
+            }
+
+        # Second pass: build the tree structure
+        for label in labels:
+            label_data = label_dict[label.id]
+            parts = label.name.split("/")
+
+            if len(parts) == 1:
+                # This is a root label
+                root_labels.append(label_data)
+            else:
+                # This is a child label
+                parent_name = "/".join(parts[:-1])
+                # Find parent label
+                for potential_parent in labels:
+                    if potential_parent.name == parent_name:
+                        label_dict[potential_parent.id]["children"].append(label_data)
+                        break
+
+        # Sort children alphabetically by name
+        for label_data in label_dict.values():
+            label_data["children"].sort(key=lambda x: x["name"])
+
+        # Sort root labels alphabetically
+        root_labels.sort(key=lambda x: x["name"])
+
+        return Response(root_labels)
+
+    @extend_schema(
+        request=serializers.LabelSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=serializers.LabelSerializer,
+                description="Label updated successfully",
+            ),
+            400: OpenApiResponse(
+                response={"detail": "Validation error"},
+                description="Invalid input data",
+            ),
+            403: OpenApiResponse(
+                response={"detail": "You need EDITOR or ADMIN role to manage labels"},
+                description="Permission denied",
+            ),
+        },
+    )
+    def update(self, request, *args, **kwargs):
+        """Update a label, including its slug if the name changes."""
+        instance = self.get_object()  # Check basic access
+        self.check_mailbox_permissions(instance.mailbox)  # Check EDITOR/ADMIN role
+        partial = kwargs.pop("partial", False)
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+
+        # If name is being updated, update the slug
+        if "name" in serializer.validated_data:
+            serializer.validated_data["slug"] = slugify(
+                serializer.validated_data["name"].replace("/", "-")
+            )
+
+        self.perform_update(serializer)
+        return drf.response.Response(serializer.data)
+
+    @extend_schema(
+        request=serializers.LabelSerializer,
+        responses={
+            201: OpenApiResponse(
+                response={
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string", "format": "uuid"},
+                            "name": {
+                                "type": "string",
+                                "description": "Full name of the label (e.g., 'Inbox/Important')",
+                            },
+                            "slug": {
+                                "type": "string",
+                                "description": "URL-friendly version of the name",
+                            },
+                            "color": {
+                                "type": "string",
+                                "description": "Color code for the label",
+                            },
+                            "display_name": {
+                                "type": "string",
+                                "description": "Base name of the label (last part of the path)",
+                            },
+                            "parent_name": {
+                                "type": "string",
+                                "description": "Name of the parent label, or null for root labels",
+                                "nullable": True,
+                            },
+                            "depth": {
+                                "type": "integer",
+                                "description": "Depth in the hierarchy (0 for root labels, 1 for direct children, etc.)",
+                                "minimum": 0,
+                            },
+                            "children": {
+                                "type": "array",
+                                "items": {"$ref": "#/components/schemas/Label"},
+                                "description": "Child labels, ordered alphabetically by name",
+                            },
+                        },
+                        "required": [
+                            "id",
+                            "name",
+                            "slug",
+                            "color",
+                            "display_name",
+                            "parent_name",
+                            "depth",
+                            "children",
+                        ],
+                    },
+                },
+                description="Created labels in hierarchical structure",
+            ),
+            400: OpenApiResponse(
+                response={"detail": "Validation error"},
+                description="Invalid input data",
+            ),
+            403: OpenApiResponse(
+                response={"detail": "You need EDITOR or ADMIN role to manage labels"},
+                description="Permission denied",
+            ),
+        },
+    )
+    def create(self, request, *args, **kwargs):
+        """Create a label, ensuring parent labels exist in the hierarchy."""
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        # Get the validated data
+        name = serializer.validated_data["name"]
+        mailbox = serializer.validated_data["mailbox"]
+
+        # Check if user has EDITOR or ADMIN role for the mailbox
+        self.check_mailbox_permissions(mailbox)
+
+        color = serializer.validated_data.get(
+            "color",
+            models.Label._meta.get_field("color").default,  # noqa: SLF001
+        )
+
+        # Split the name into parts to handle hierarchy
+        parts = name.split("/")
+
+        # Create parent labels if they don't exist
+        current_path = []
+        created_labels = []  # Track all labels created (including parents)
+        for part in parts[:-1]:  # Exclude the last part (the actual label)
+            current_path.append(part)
+            parent_name = "/".join(current_path)
+
+            # Check if parent label exists
+            parent_label = models.Label.objects.filter(
+                name=parent_name, mailbox=mailbox
+            ).first()
+
+            if not parent_label:
+                # Create parent label with color if provided, otherwise use model default
+                parent_label = models.Label.objects.create(
+                    name=parent_name,
+                    mailbox=mailbox,
+                    color=color,
+                )
+                created_labels.append(parent_label)
+
+        # Create the actual label with color if provided, otherwise use model default
+        label = models.Label.objects.create(
+            name=name,
+            mailbox=mailbox,
+            color=color,
+        )
+        created_labels.append(label)
+
+        # Get all labels for the mailbox to build the tree structure
+        all_labels = models.Label.objects.filter(mailbox=mailbox).order_by("name")
+        label_dict = {}
+        root_labels = []
+
+        # Build the tree structure
+        for label in all_labels:
+            label_data = {
+                "id": str(label.id),
+                "name": label.name,
+                "slug": label.slug,
+                "color": label.color,
+                "display_name": label.basename,
+                "parent_name": label.parent_name,
+                "depth": label.depth,
+                "children": [],
+            }
+            label_dict[label.id] = label_data
+
+            # Add to root labels or parent's children
+            if label.parent_name is None:
+                root_labels.append(label_data)
+            else:
+                # Find parent label by name
+                parent_label = next(
+                    (l for l in all_labels if l.name == label.parent_name), None
+                )
+                if parent_label:
+                    label_dict[parent_label.id]["children"].append(label_data)
+
+        # Sort children alphabetically by name
+        for label_data in label_dict.values():
+            label_data["children"].sort(key=lambda x: x["name"])
+
+        # Sort root labels alphabetically
+        root_labels.sort(key=lambda x: x["name"])
+
+        return Response(root_labels, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        responses={
+            204: OpenApiResponse(description="Label deleted successfully"),
+            403: OpenApiResponse(
+                response={"detail": "You need EDITOR or ADMIN role to manage labels"},
+                description="Permission denied",
+            ),
+            404: OpenApiResponse(description="Label not found"),
+        },
+    )
+    def destroy(self, request, *args, **kwargs):
+        """Delete a label."""
+        instance = self.get_object()  # Check basic access
+        self.check_mailbox_permissions(instance.mailbox)  # Check EDITOR/ADMIN role
+        self.perform_destroy(instance)
+        return drf.response.Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        request={
+            "application/json": {
+                "type": "object",
+                "properties": {
+                    "thread_ids": {
+                        "type": "array",
+                        "items": {"type": "string", "format": "uuid"},
+                        "description": "List of thread IDs to add to this label",
+                    },
+                },
+            }
+        },
+        responses={
+            200: OpenApiResponse(
+                response=serializers.LabelSerializer,
+                description="Threads added to label successfully",
+            ),
+            400: OpenApiResponse(
+                response={"detail": "Validation error"},
+                description="Invalid input data",
+            ),
+            403: OpenApiResponse(
+                response={"detail": "You need EDITOR or ADMIN role to manage labels"},
+                description="Permission denied",
+            ),
+        },
+    )
+    @drf.decorators.action(
+        detail=True,
+        methods=["post"],
+        url_path="add-threads",
+        url_name="add-threads",
+    )
+    def add_threads(self, request, pk=None):  # pylint: disable=unused-argument
+        """Add threads to a label."""
+        label = self.get_object()  # Check basic access
+        self.check_mailbox_permissions(label.mailbox)  # Check EDITOR/ADMIN role
+        thread_ids = request.data.get("thread_ids", [])
+        if not thread_ids:
+            return drf.response.Response(
+                {"detail": "No thread IDs provided"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        accessible_threads = models.Thread.objects.filter(
+            Exists(
+                models.ThreadAccess.objects.filter(
+                    mailbox__accesses__user=request.user,
+                    thread=OuterRef("pk"),
+                )
+            ),
+            id__in=thread_ids,
+        )
+        label.threads.add(*accessible_threads)
+        serializer = self.get_serializer(label)
+        return drf.response.Response(serializer.data)
+
+    @extend_schema(
+        request={
+            "application/json": {
+                "type": "object",
+                "properties": {
+                    "thread_ids": {
+                        "type": "array",
+                        "items": {"type": "string", "format": "uuid"},
+                        "description": "List of thread IDs to remove from this label",
+                    },
+                },
+            }
+        },
+        responses={
+            200: OpenApiResponse(
+                response=serializers.LabelSerializer,
+                description="Threads removed from label successfully",
+            ),
+            400: OpenApiResponse(
+                response={"detail": "Validation error"},
+                description="Invalid input data",
+            ),
+            403: OpenApiResponse(
+                response={"detail": "You need EDITOR or ADMIN role to manage labels"},
+                description="Permission denied",
+            ),
+        },
+    )
+    @drf.decorators.action(
+        detail=True,
+        methods=["post"],
+        url_path="remove-threads",
+        url_name="remove-threads",
+    )
+    def remove_threads(self, request, pk=None):  # pylint: disable=unused-argument
+        """Remove threads from a label."""
+        label = self.get_object()  # Check basic access
+        self.check_mailbox_permissions(label.mailbox)  # Check EDITOR/ADMIN role
+        thread_ids = request.data.get("thread_ids", [])
+        if not thread_ids:
+            return drf.response.Response(
+                {"detail": "No thread IDs provided"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        accessible_threads = models.Thread.objects.filter(
+            Exists(
+                models.ThreadAccess.objects.filter(
+                    mailbox__accesses__user=request.user,
+                    thread=OuterRef("pk"),
+                )
+            ),
+            id__in=thread_ids,
+        )
+        label.threads.remove(*accessible_threads)
+        serializer = self.get_serializer(label)
+        return drf.response.Response(serializer.data)

--- a/src/backend/core/tests/api/test_labels.py
+++ b/src/backend/core/tests/api/test_labels.py
@@ -1,0 +1,904 @@
+"""Tests for the label API endpoints."""
+
+# pylint: disable=redefined-outer-name, unused-argument, too-many-public-methods
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import models
+from core.factories import (
+    LabelFactory,
+    MailboxFactory,
+    ThreadFactory,
+    UserFactory,
+)
+
+
+@pytest.fixture
+def user():
+    """Create a test user."""
+    return UserFactory()
+
+
+@pytest.fixture
+def mailbox(user):
+    """Create a test mailbox with admin access for the user."""
+    mailbox = MailboxFactory()
+    mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.ADMIN)
+    return mailbox
+
+
+@pytest.fixture
+def api_client(user):
+    """Create an authenticated API client."""
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def label(mailbox):
+    """Create a test label."""
+    return LabelFactory(mailbox=mailbox)
+
+
+@pytest.mark.django_db
+class TestLabelSerializer:
+    """Test the LabelSerializer."""
+
+    @pytest.mark.parametrize(
+        "role", [models.MailboxRoleChoices.ADMIN, models.MailboxRoleChoices.EDITOR]
+    )
+    def test_create_label_valid_data(self, api_client, role, user):
+        """Test creating a label with valid data."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(user=user, role=role)
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects/Urgent",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # there should be 3 labels created: Work, Work/Projects, Work/Projects/Urgent
+        assert models.Label.objects.count() == 3
+
+        label = models.Label.objects.get(name="Work/Projects/Urgent")
+        assert label.name == "Work/Projects/Urgent"
+        assert label.slug == "work-projects-urgent"
+        assert label.color == "#FF0000"
+        assert label.mailbox == mailbox
+
+        assert label.parent_name == "Work/Projects"
+        parent = models.Label.objects.get(name="Work/Projects")
+        assert parent.parent_name == "Work"
+        assert parent.color == "#FF0000"
+        assert parent.mailbox == mailbox
+
+        grandparent = models.Label.objects.get(name="Work")
+        assert grandparent.parent_name is None
+        assert grandparent.color == "#FF0000"
+        assert grandparent.mailbox == mailbox
+
+    @pytest.mark.parametrize(
+        "role", [models.MailboxRoleChoices.ADMIN, models.MailboxRoleChoices.EDITOR]
+    )
+    def test_create_label_valid_data_similar_to_existing_parent(
+        self, api_client, role, user
+    ):
+        """Test creating a label with valid data."""
+        mailbox = MailboxFactory()
+
+        # create a label with the same name as a parent
+        LabelFactory(name="Work", mailbox=mailbox, color="#000000")
+        assert models.Label.objects.count() == 1
+
+        mailbox.accesses.create(user=user, role=role)
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects/Urgent",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # there should be 2 more labels created: Work/Projects, Work/Projects/Urgent
+        assert models.Label.objects.count() == 3
+
+        label = models.Label.objects.get(name="Work/Projects/Urgent")
+        assert label.name == "Work/Projects/Urgent"
+        assert label.slug == "work-projects-urgent"
+        assert label.color == "#FF0000"
+        assert label.mailbox == mailbox
+
+        assert label.parent_name == "Work/Projects"
+        parent = models.Label.objects.get(name="Work/Projects")
+        assert parent.parent_name == "Work"
+        assert parent.color == "#FF0000"
+        assert parent.mailbox == mailbox
+
+        grandparent = models.Label.objects.get(name="Work")
+        assert grandparent.parent_name is None
+        assert grandparent.color == "#000000"
+        assert grandparent.mailbox == mailbox
+
+    @pytest.mark.parametrize("role", [models.MailboxRoleChoices.VIEWER])
+    def test_create_label_invalid_mailbox_access(self, api_client, role, user):
+        """Test creating a label for a mailbox the user doesn't have proper access to."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(user=user, role=role)
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "You don't have access to this mailbox" in str(response.data["detail"])
+
+    def test_create_label_mailbox_no_access(self, api_client):
+        """Test creating a label for a mailbox the user doesn't have access to."""
+        other_mailbox = MailboxFactory()
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects",
+            "mailbox": str(other_mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "You don't have access to this mailbox" in str(response.data["detail"])
+
+    def test_create_label_missing_required_fields(self, api_client):
+        """Test creating a label with missing required fields."""
+        url = reverse("labels-list")
+        data = {"color": "#FF0000"}  # Missing name and mailbox
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "name" in response.data
+        assert "mailbox" in response.data
+
+    def test_create_label_duplicate_name_in_mailbox(self, api_client, mailbox):
+        """Test creating a label with a name that already exists in the mailbox."""
+        LabelFactory(name="Work", mailbox=mailbox)
+        url = reverse("labels-list")
+        data = {
+            "name": "Work",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Label with this Slug and Mailbox already exists." in str(
+            response.data["__all__"]
+        )
+
+    def test_create_label_with_parents(self, api_client, mailbox):
+        """Test that creating a label with slashes automatically creates parent labels."""
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects/Urgent",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify all labels were created
+        assert models.Label.objects.filter(name="Work").exists()
+        assert models.Label.objects.filter(name="Work/Projects").exists()
+        assert models.Label.objects.filter(name="Work/Projects/Urgent").exists()
+
+        # Verify colors
+        work_label = models.Label.objects.get(name="Work")
+        projects_label = models.Label.objects.get(name="Work/Projects")
+        urgent_label = models.Label.objects.get(name="Work/Projects/Urgent")
+
+        assert work_label.color == "#FF0000"
+        assert projects_label.color == "#FF0000"
+        assert urgent_label.color == "#FF0000"
+
+    def test_create_label_with_existing_parents(self, api_client, mailbox):
+        """Test creating a label when some parent labels already exist."""
+        # Create some existing parent labels
+        LabelFactory(mailbox=mailbox, name="Work", color="#0000FF")
+        LabelFactory(mailbox=mailbox, name="Work/Projects", color="#00FF00")
+
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects/New",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify existing labels weren't modified
+        work_label = models.Label.objects.get(name="Work")
+        projects_label = models.Label.objects.get(name="Work/Projects")
+        assert work_label.color == "#0000FF"
+        assert projects_label.color == "#00FF00"
+
+        # Verify new label was created
+        new_label = models.Label.objects.get(name="Work/Projects/New")
+        assert new_label.color == "#FF0000"
+
+    def test_create_label_with_same_name_as_parent(self, api_client, mailbox):
+        """Test creating a label that has the same name as a potential parent."""
+        # First create a parent label
+        LabelFactory(mailbox=mailbox, name="Work/Projects", color="#0000FF")
+
+        # Try to create a label with the same name
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects",  # Same name as existing label
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Label with this Slug and Mailbox already exists" in str(response.data)
+
+    def test_create_label_with_special_characters(self, api_client, mailbox):
+        """Test creating labels with special characters in the hierarchy."""
+        url = reverse("labels-list")
+        data = {
+            "name": "Root/With/Special@Chars/And Spaces",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify all labels were created with proper names
+        assert models.Label.objects.filter(name="Root").exists()
+        assert models.Label.objects.filter(name="Root/With").exists()
+        assert models.Label.objects.filter(name="Root/With/Special@Chars").exists()
+        assert models.Label.objects.filter(
+            name="Root/With/Special@Chars/And Spaces"
+        ).exists()
+
+        # Verify slugs were generated correctly
+        root_label = models.Label.objects.get(name="Root")
+        special_label = models.Label.objects.get(name="Root/With/Special@Chars")
+        spaces_label = models.Label.objects.get(
+            name="Root/With/Special@Chars/And Spaces"
+        )
+
+        assert root_label.slug == "root"
+        assert special_label.slug == "root-with-specialchars"
+        assert spaces_label.slug == "root-with-specialchars-and-spaces"
+
+    def test_create_label_in_different_mailbox(self, api_client, mailbox, user):
+        """Test creating labels with hierarchy across different mailboxes."""
+        # Create another mailbox
+        other_mailbox = MailboxFactory()
+        other_mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.ADMIN)
+
+        # Create a label in the first mailbox
+        LabelFactory(mailbox=mailbox, name="Work", color="#0000FF")
+
+        # Try to create a label in the second mailbox with same hierarchy
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects",
+            "mailbox": str(other_mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify labels were created in correct mailboxes
+        assert models.Label.objects.filter(name="Work", mailbox=mailbox).exists()
+        assert models.Label.objects.filter(name="Work", mailbox=other_mailbox).exists()
+        assert models.Label.objects.filter(
+            name="Work/Projects", mailbox=other_mailbox
+        ).exists()
+        assert not models.Label.objects.filter(
+            name="Work/Projects", mailbox=mailbox
+        ).exists()
+
+    def test_create_label_returns_tree_structure(self, api_client, mailbox):
+        """Test that creating a label returns the complete tree structure."""
+        # Create some existing labels first
+        LabelFactory(mailbox=mailbox, name="Existing", color="#000000")
+        LabelFactory(mailbox=mailbox, name="Existing/Child", color="#111111")
+
+        url = reverse("labels-list")
+        data = {
+            "name": "New/Root/Child",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+
+        # Response should be a list of root labels
+        assert isinstance(data, list)
+
+        # Should have two root labels: "Existing" and "New"
+        assert len(data) == 2
+
+        # Find the "Existing" label and verify its structure
+        existing_label = next(label for label in data if label["name"] == "Existing")
+        assert existing_label["color"] == "#000000"
+        assert existing_label["display_name"] == "Existing"
+        assert existing_label["parent_name"] is None
+        assert existing_label["depth"] == 0
+        assert len(existing_label["children"]) == 1
+
+        # Verify "Existing/Child"
+        existing_child = existing_label["children"][0]
+        assert existing_child["name"] == "Existing/Child"
+        assert existing_child["color"] == "#111111"
+        assert existing_child["display_name"] == "Child"
+        assert existing_child["parent_name"] == "Existing"
+        assert existing_child["depth"] == 1
+        assert len(existing_child["children"]) == 0
+
+        # Find the "New" label and verify its structure
+        new_label = next(label for label in data if label["name"] == "New")
+        assert new_label["color"] == "#FF0000"
+        assert new_label["display_name"] == "New"
+        assert new_label["parent_name"] is None
+        assert new_label["depth"] == 0
+        assert len(new_label["children"]) == 1
+
+        # Verify "New/Root"
+        new_root = new_label["children"][0]
+        assert new_root["name"] == "New/Root"
+        assert new_root["color"] == "#FF0000"
+        assert new_root["display_name"] == "Root"
+        assert new_root["parent_name"] == "New"
+        assert new_root["depth"] == 1
+        assert len(new_root["children"]) == 1
+
+        # Verify "New/Root/Child"
+        new_child = new_root["children"][0]
+        assert new_child["name"] == "New/Root/Child"
+        assert new_child["color"] == "#FF0000"
+        assert new_child["display_name"] == "Child"
+        assert new_child["parent_name"] == "New/Root"
+        assert new_child["depth"] == 2
+        assert len(new_child["children"]) == 0
+
+    def test_create_label_returns_tree_structure_with_existing_parents(
+        self, api_client, mailbox
+    ):
+        """Test that creating a label returns the tree structure when some parents already exist."""
+        # Create some existing labels first
+        LabelFactory(mailbox=mailbox, name="Work", color="#000000")
+        LabelFactory(mailbox=mailbox, name="Work/Projects", color="#111111")
+
+        url = reverse("labels-list")
+        data = {
+            "name": "Work/Projects/New",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+
+        # Response should be a list of root labels
+        assert isinstance(data, list)
+
+        # Should have one root label: "Work"
+        assert len(data) == 1
+
+        # Find the "Work" label and verify its structure
+        work_label = data[0]
+        assert work_label["name"] == "Work"
+        assert work_label["color"] == "#000000"
+        assert work_label["display_name"] == "Work"
+        assert work_label["parent_name"] is None
+        assert work_label["depth"] == 0
+        assert len(work_label["children"]) == 1
+
+        # Verify "Work/Projects"
+        projects_label = work_label["children"][0]
+        assert projects_label["name"] == "Work/Projects"
+        assert projects_label["color"] == "#111111"
+        assert projects_label["display_name"] == "Projects"
+        assert projects_label["parent_name"] == "Work"
+        assert projects_label["depth"] == 1
+        assert len(projects_label["children"]) == 1
+
+        # Verify "Work/Projects/New"
+        new_label = projects_label["children"][0]
+        assert new_label["name"] == "Work/Projects/New"
+        assert new_label["color"] == "#FF0000"
+        assert new_label["display_name"] == "New"
+        assert new_label["parent_name"] == "Work/Projects"
+        assert new_label["depth"] == 2
+        assert len(new_label["children"]) == 0
+
+
+@pytest.mark.django_db
+class TestLabelViewSet:
+    """Test the LabelViewSet."""
+
+    @pytest.mark.parametrize(
+        "role",
+        [
+            models.MailboxRoleChoices.ADMIN,
+            models.MailboxRoleChoices.EDITOR,
+            models.MailboxRoleChoices.VIEWER,
+        ],
+    )
+    def test_list_labels(self, api_client, role, user):
+        """Test listing labels. All users with access to the mailbox should be able to list labels."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(user=user, role=role)
+        # Create exactly 3 labels
+        LabelFactory.create_batch(3, mailbox=mailbox)
+        url = reverse("labels-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 3  # The response is a list of labels
+
+    def test_list_labels_no_access(self, api_client, user):
+        """Test listing labels when user doesn't have access to the mailbox."""
+        url = reverse("labels-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 0
+
+    def test_list_labels_filter_by_mailbox(self, api_client, mailbox, user):
+        """Test listing labels filtered by mailbox."""
+        # Create exactly one label in the target mailbox
+        LabelFactory(mailbox=mailbox)
+        other_mailbox = MailboxFactory()
+        other_mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.ADMIN)
+        LabelFactory(mailbox=other_mailbox)
+
+        url = reverse("labels-list")
+        response = api_client.get(url, {"mailbox_id": str(mailbox.id)})
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1  # Should only get the label from the target mailbox
+
+    @pytest.mark.parametrize(
+        "role",
+        [
+            models.MailboxRoleChoices.ADMIN,
+            models.MailboxRoleChoices.EDITOR,
+        ],
+    )
+    def test_update_label(self, api_client, label, role, user):
+        """Test updating a label."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(user=user, role=role)  # Add access to the mailbox
+        label.mailbox = mailbox  # Set the label's mailbox to the new mailbox
+        label.save()  # Save the label to the new mailbox
+        url = reverse("labels-detail", args=[label.pk])
+        data = {
+            "name": "Updated Label",
+            "mailbox": str(mailbox.id),
+            "color": "#00FF00",
+        }
+
+        response = api_client.put(url, data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+
+        label.refresh_from_db()
+        assert label.name == "Updated Label"
+        assert label.slug == "updated-label"
+        assert label.color == "#00FF00"
+
+    def test_update_label_access_denied(self, api_client, label, user):
+        """Test updating a label when user doesn't have proper access."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.VIEWER)
+        label.mailbox = mailbox
+        label.save()
+
+        url = reverse("labels-detail", args=[label.pk])
+        data = {
+            "name": "Updated Label",
+            "mailbox": str(mailbox.id),
+            "color": "#00FF00",
+        }
+
+        response = api_client.put(url, data, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "You need EDITOR or ADMIN role to manage labels" in str(
+            response.data["detail"]
+        )
+
+    def test_update_label_no_access(self, api_client, mailbox, label):
+        """Test updating a label when user doesn't have any access."""
+        # Create a new user without access
+        other_user = UserFactory()
+        api_client.force_authenticate(user=other_user)
+
+        url = reverse("labels-detail", args=[label.pk])
+        data = {
+            "name": "Updated Label",
+            "mailbox": str(mailbox.id),
+            "color": "#00FF00",
+        }
+
+        response = api_client.put(url, data, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "You don't have access to this mailbox" in str(response.data["detail"])
+
+    def test_delete_label(self, api_client, label):
+        """Test deleting a label."""
+        url = reverse("labels-detail", args=[label.pk])
+        response = api_client.delete(url)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not models.Label.objects.filter(pk=label.pk).exists()
+
+    def test_delete_label_access_denied(self, api_client, label, user):
+        """Test deleting a label when user doesn't have proper access."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.VIEWER)
+        label.mailbox = mailbox
+        label.save()
+        url = reverse("labels-detail", args=[label.pk])
+        response = api_client.delete(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "You need EDITOR or ADMIN role to manage labels" in str(
+            response.data["detail"]
+        )
+
+    def test_delete_label_no_access(self, api_client, label):
+        """Test deleting a label when user doesn't have proper access."""
+        # Create a new user without access
+        other_user = UserFactory()
+        api_client.force_authenticate(user=other_user)
+
+        url = reverse("labels-detail", args=[label.pk])
+        response = api_client.delete(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "You don't have access to this mailbox" in str(response.data["detail"])
+        assert models.Label.objects.filter(pk=label.pk).exists()
+
+    @pytest.mark.parametrize(
+        "role",
+        [
+            models.MailboxRoleChoices.ADMIN,
+            models.MailboxRoleChoices.EDITOR,
+        ],
+    )
+    def test_add_threads_to_label(self, api_client, label, role):
+        """Test adding threads to a label."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(user=label.mailbox.accesses.first().user, role=role)
+        threads = ThreadFactory.create_batch(3)
+        for thread in threads:
+            thread.accesses.create(
+                mailbox=mailbox,
+                role=models.ThreadAccessRoleChoices.EDITOR,
+            )
+
+        url = reverse("labels-add-threads", args=[label.pk])
+        data = {"thread_ids": [str(thread.id) for thread in threads]}
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert label.threads.count() == 3
+
+    def test_add_threads_to_label_access_denied(self, api_client, label, user):
+        """Test adding threads to a label when user doesn't have proper access."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.VIEWER)
+        label.mailbox = mailbox
+        label.save()
+
+        thread = ThreadFactory()
+        thread.accesses.create(
+            mailbox=mailbox, role=models.ThreadAccessRoleChoices.VIEWER
+        )
+
+        url = reverse("labels-add-threads", args=[label.pk])
+        data = {"thread_ids": [str(thread.id)]}
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "You need EDITOR or ADMIN role to manage labels" in str(
+            response.data["detail"]
+        )
+        assert label.threads.count() == 0  # Thread not added
+
+    def test_add_threads_to_label_no_access(self, api_client, label, user):
+        """Test adding threads to a label when user doesn't have any access."""
+        mailbox = MailboxFactory()
+        label.mailbox = mailbox
+        label.save()
+
+        thread = ThreadFactory()
+        thread.accesses.create(
+            mailbox=mailbox, role=models.ThreadAccessRoleChoices.VIEWER
+        )
+
+        url = reverse("labels-add-threads", args=[label.pk])
+        data = {"thread_ids": [str(thread.id)]}
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "You don't have access to this mailbox" in str(response.data["detail"])
+        assert label.threads.count() == 0  # Thread not added
+
+    @pytest.mark.parametrize(
+        "mailbox_role",
+        [
+            models.MailboxRoleChoices.ADMIN,
+            models.MailboxRoleChoices.EDITOR,
+        ],
+    )
+    def test_remove_threads_from_label(self, api_client, label, mailbox_role):
+        """Test removing threads from a label."""
+        mailbox = MailboxFactory()
+        mailbox.accesses.create(
+            user=label.mailbox.accesses.first().user, role=mailbox_role
+        )
+        threads = ThreadFactory.create_batch(3)
+        for thread in threads:
+            thread.accesses.create(
+                mailbox=mailbox,
+                role=models.ThreadAccessRoleChoices.EDITOR,
+            )
+            label.threads.add(thread)
+
+        url = reverse("labels-remove-threads", args=[label.pk])
+        data = {"thread_ids": [str(thread.id) for thread in threads]}
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert label.threads.count() == 0
+
+    def test_remove_threads_from_label_access_denied(self, api_client, label):
+        """Test removing threads from a label when user doesn't have access."""
+        other_mailbox = MailboxFactory()
+        thread = ThreadFactory()
+        thread.accesses.create(
+            mailbox=other_mailbox,
+            role=models.ThreadAccessRoleChoices.EDITOR,
+        )
+        label.threads.add(thread)
+
+        url = reverse("labels-remove-threads", args=[label.pk])
+        data = {"thread_ids": [str(thread.id)]}
+
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert label.threads.count() == 1  # Thread not removed
+
+    def test_label_hierarchy(self, mailbox):
+        """Test label hierarchy with slash-based naming."""
+        parent_label = LabelFactory(name="Work", mailbox=mailbox)
+        child_label = LabelFactory(name="Work/Projects", mailbox=mailbox)
+
+        assert parent_label.parent_name is None
+        assert parent_label.basename == "Work"
+        assert parent_label.depth == 0
+
+        assert child_label.parent_name == "Work"
+        assert child_label.basename == "Projects"
+        assert child_label.depth == 1
+
+    def test_label_unique_constraint(self, api_client, mailbox):
+        """Test that labels must have unique names within a mailbox."""
+        models.Label.objects.all().delete()
+        LabelFactory(name="Work", mailbox=mailbox)
+        url = reverse("labels-list")
+        data = {
+            "name": "Work",
+            "mailbox": str(mailbox.id),
+            "color": "#FF0000",
+        }
+        response = api_client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Label with this Slug and Mailbox already exists." in str(
+            response.data["__all__"]
+        )
+
+    def test_list_labels_hierarchical_structure(self, api_client, mailbox, user):
+        """Test that labels are returned in a proper hierarchical structure."""
+        # Create a hierarchical structure of labels
+        LabelFactory(mailbox=mailbox, name="Root1", color="#FF0000")
+        LabelFactory(mailbox=mailbox, name="Root1/Child1", color="#00FF00")
+        LabelFactory(mailbox=mailbox, name="Root1/Child2", color="#0000FF")
+        LabelFactory(mailbox=mailbox, name="Root2", color="#FFFF00")
+
+        # Create labels in another mailbox
+        other_mailbox = MailboxFactory()
+        other_mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.ADMIN)
+        LabelFactory(mailbox=other_mailbox, name="Root3", color="#FF00FF")
+        LabelFactory(mailbox=other_mailbox, name="Root3/Child1", color="#00FFFF")
+
+        url = reverse("labels-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Should only get labels from mailboxes user has access to
+        assert len(data) == 3  # Root1, Root2, Root3
+
+        # Find Root1 and verify its structure
+        root1_data = next(label for label in data if label["name"] == "Root1")
+        assert len(root1_data["children"]) == 2
+        assert root1_data["color"] == "#FF0000"
+        assert root1_data["display_name"] == "Root1"
+
+        # Verify children are sorted alphabetically
+        assert root1_data["children"][0]["name"] == "Root1/Child1"
+        assert root1_data["children"][1]["name"] == "Root1/Child2"
+
+        # Verify Root2 has no children
+        root2_data = next(label for label in data if label["name"] == "Root2")
+        assert len(root2_data["children"]) == 0
+
+        # Verify Root3 and its child
+        root3_data = next(label for label in data if label["name"] == "Root3")
+        assert len(root3_data["children"]) == 1
+        assert root3_data["children"][0]["name"] == "Root3/Child1"
+
+    def test_list_labels_hierarchical_filter_by_mailbox(
+        self, api_client, mailbox, user
+    ):
+        """Test filtering hierarchical labels by mailbox_id."""
+        # Create labels in mailbox1
+        LabelFactory(mailbox=mailbox, name="Root1", color="#FF0000")
+        LabelFactory(mailbox=mailbox, name="Root1/Child1", color="#00FF00")
+        LabelFactory(mailbox=mailbox, name="Root2", color="#FFFF00")
+
+        # Create labels in another mailbox
+        other_mailbox = MailboxFactory()
+        other_mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.ADMIN)
+        LabelFactory(mailbox=other_mailbox, name="Root3", color="#FF00FF")
+
+        url = reverse("labels-list")
+
+        # Test filtering by mailbox1
+        response = api_client.get(f"{url}?mailbox_id={mailbox.id}")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Should only get labels from mailbox1
+        assert len(data) == 2  # Root1, Root2
+        assert all(label["name"] in ["Root1", "Root2"] for label in data)
+
+        # Test filtering by other_mailbox
+        response = api_client.get(f"{url}?mailbox_id={other_mailbox.id}")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Should only get labels from other_mailbox
+        assert len(data) == 1  # Root3
+        assert data[0]["name"] == "Root3"
+
+    def test_list_labels_hierarchical_inaccessible_mailbox(
+        self, api_client, mailbox, user
+    ):
+        """Test that labels from inaccessible mailboxes are not returned in hierarchical view."""
+        # Create a label in an inaccessible mailbox
+        inaccessible_mailbox = MailboxFactory()
+        LabelFactory(mailbox=inaccessible_mailbox, name="Inaccessible", color="#000000")
+
+        url = reverse("labels-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Verify inaccessible label is not in the response
+        assert not any(label["name"] == "Inaccessible" for label in data)
+
+        # Try to filter by inaccessible mailbox
+        response = api_client.get(f"{url}?mailbox_id={inaccessible_mailbox.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 0
+
+    def test_list_labels_hierarchical_unauthorized(self, api_client):
+        """Test that unauthorized users cannot access hierarchical labels."""
+        api_client.force_authenticate(user=None)
+        url = reverse("labels-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_list_labels_hierarchical_deep_nesting(self, api_client, mailbox):
+        """Test handling of deeply nested labels."""
+        # Create a deeply nested label structure
+        LabelFactory(mailbox=mailbox, name="Level1", color="#FF0000")
+        LabelFactory(mailbox=mailbox, name="Level1/Level2", color="#00FF00")
+        LabelFactory(mailbox=mailbox, name="Level1/Level2/Level3", color="#0000FF")
+        LabelFactory(
+            mailbox=mailbox, name="Level1/Level2/Level3/Level4", color="#FFFF00"
+        )
+
+        url = reverse("labels-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Verify the hierarchy is maintained
+        level1 = next(label for label in data if label["name"] == "Level1")
+        assert len(level1["children"]) == 1
+
+        level2 = level1["children"][0]
+        assert level2["name"] == "Level1/Level2"
+        assert len(level2["children"]) == 1
+
+        level3 = level2["children"][0]
+        assert level3["name"] == "Level1/Level2/Level3"
+        assert len(level3["children"]) == 1
+
+        level4 = level3["children"][0]
+        assert level4["name"] == "Level1/Level2/Level3/Level4"
+        assert len(level4["children"]) == 0
+
+    def test_list_labels_hierarchical_special_characters(self, api_client, mailbox):
+        """Test handling of labels with special characters in names."""
+        # Create the complete label hierarchy
+        LabelFactory(mailbox=mailbox, name="Root", color="#000000")
+        LabelFactory(
+            mailbox=mailbox, name="Root/With", color="#CCCCCC"
+        )  # Create intermediate label
+        LabelFactory(mailbox=mailbox, name="Root/With/Slashes", color="#FF0000")
+        LabelFactory(mailbox=mailbox, name="Root/With/Special@Chars", color="#00FF00")
+        LabelFactory(mailbox=mailbox, name="Root/With/Spaces And More", color="#0000FF")
+
+        # Verify labels were created in the database
+        assert models.Label.objects.filter(name="Root").exists()
+        assert models.Label.objects.filter(name="Root/With").exists()
+        assert models.Label.objects.filter(name="Root/With/Slashes").exists()
+        assert models.Label.objects.filter(name="Root/With/Special@Chars").exists()
+        assert models.Label.objects.filter(name="Root/With/Spaces And More").exists()
+
+        url = reverse("labels-list")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Find the root label that should contain our special character labels
+        root_label = next((label for label in data if label["name"] == "Root"), None)
+        assert root_label is not None, "Root label not found in response"
+
+        # Verify the hierarchy
+        assert len(root_label["children"]) == 1, "Root should have one child (With)"
+        with_label = root_label["children"][0]
+        assert with_label["name"] == "Root/With"
+        assert len(with_label["children"]) == 3, "With label should have three children"
+
+        # Convert children to dict for easier lookup
+        children_by_name = {child["name"]: child for child in with_label["children"]}
+
+        # Verify each special character label exists and has correct display name
+        assert "Root/With/Slashes" in children_by_name
+        assert children_by_name["Root/With/Slashes"]["display_name"] == "Slashes"
+
+        assert "Root/With/Special@Chars" in children_by_name
+        assert (
+            children_by_name["Root/With/Special@Chars"]["display_name"]
+            == "Special@Chars"
+        )
+
+        assert "Root/With/Spaces And More" in children_by_name
+        assert (
+            children_by_name["Root/With/Spaces And More"]["display_name"]
+            == "Spaces And More"
+        )

--- a/src/backend/core/urls.py
+++ b/src/backend/core/urls.py
@@ -10,6 +10,7 @@ from core.api.viewsets.config import ConfigView
 from core.api.viewsets.draft import DraftMessageView
 from core.api.viewsets.flag import ChangeFlagViewSet
 from core.api.viewsets.import_message import ImportViewSet
+from core.api.viewsets.label import LabelViewSet
 from core.api.viewsets.mailbox import MailboxViewSet
 from core.api.viewsets.mailbox_access import MailboxAccessViewSet
 
@@ -31,6 +32,7 @@ router.register("users", UserViewSet, basename="users")
 router.register("messages", MessageViewSet, basename="messages")
 router.register("blob", BlobViewSet, basename="blob")
 router.register("threads", ThreadViewSet, basename="threads")
+router.register("labels", LabelViewSet, basename="labels")
 router.register("mailboxes", MailboxViewSet, basename="mailboxes")
 router.register("maildomains", MailDomainAdminViewSet, basename="maildomains")
 


### PR DESCRIPTION
Allow to create, update and delete Label and add or delete label to a thread.
Display list of labels as tree structure.

TODO:

- [x] à la création d'un label si il s'agit d'une arbo renvoyer dans la response la structure arbo pour mettre à jour le front
- [x] check openapi schema et ne pas oublier de le regénérer (`make back-api-update`)


