### PR TITLE
🐛(backend) prevent duplicate threads during message import

### DIFF
--- a/src/backend/core/api/viewsets/import_message.py
+++ b/src/backend/core/api/viewsets/import_message.py
@@ -61,7 +61,7 @@ class ImportViewSet(viewsets.ViewSet):
         The import is processed asynchronously and returns a task ID for tracking.
         The file must be a valid EML or MBOX format. The recipient mailbox must exist
         and the user must have access to it.
-        """
+        """,
     )
     @action(detail=False, methods=["post"], url_path="file")
     def import_file(self, request):
@@ -127,7 +127,7 @@ class ImportViewSet(viewsets.ViewSet):
         - use_ssl: Whether to use SSL for the connection (default: true)
         - folder: IMAP folder to import from (default: "INBOX")
         - max_messages: Maximum number of messages to import (default: 0, meaning all messages)
-        """
+        """,
     )
     @action(detail=False, methods=["post"], url_path="imap")
     def import_imap(self, request):


### PR DESCRIPTION
Avoid duplicate threads when importing the same file multiple times.

Changes:
- Moved duplicate message check to the start of deliver_inbound_message
- Added special thread finding logic for imports that:
  - First checks for existing threads by message IDs (in_reply_to and references)
  - Falls back to subject-based matching if no message IDs are found
  - Uses canonical subject matching to handle reply/forward prefixes
- Maintains proper threading relationships while preventing duplicate threads
- Preserves existing behavior for normal message delivery

This ensures that:
- Messages are properly threaded during import
- No duplicate threads are created when importing the same file multiple times
- Threading is maintained even when messages are processed in different orders
- Existing threads are reused when appropriate

Test coverage:
- Updated existing import tests to check thread counts
- Verified that duplicate imports don't create new threads
