### PR TITLE
🐛(backend) fix task response returned

### DIFF
--- a/src/backend/core/api/viewsets/task.py
+++ b/src/backend/core/api/viewsets/task.py
@@ -79,13 +79,18 @@ class TaskDetailView(APIView):
             "error": None,
         }
 
-        # Include result or error information if available
-        if task_result.successful():
+        # If the result is a dict with status/result/error, unpack and propagate status
+        if isinstance(task_result.result, dict) and set(task_result.result.keys()) >= {
+            "status",
+            "result",
+            "error",
+        }:
+            result_data["status"] = task_result.result["status"]
+            result_data["result"] = task_result.result["result"]
+            result_data["error"] = task_result.result["error"]
+        else:
             result_data["result"] = task_result.result
-        elif task_result.failed():
-            result_data["status"] = "FAILURE"
-            result_data["error"] = str(task_result.result)
-        elif task_result.state == "PROGRESS" and task_result.info:
+        if task_result.state == "PROGRESS" and task_result.info:
             result_data.update(task_result.info)
 
         return Response(result_data)

--- a/src/backend/core/tasks.py
+++ b/src/backend/core/tasks.py
@@ -313,31 +313,24 @@ def process_mbox_file_task(
         recipient = Mailbox.objects.get(id=recipient_id)
     except Mailbox.DoesNotExist:
         error_msg = f"Recipient mailbox {recipient_id} not found"
+        result = {
+            "message_status": "Failed to process messages",
+            "total_messages": 0,
+            "success_count": 0,
+            "failure_count": 0,
+            "type": "mbox",
+            "current_message": 0,
+        }
         self.update_state(
             state="FAILURE",
             meta={
-                "status": "FAILURE",
-                "result": {
-                    "message_status": "Failed to process messages",
-                    "total_messages": 0,
-                    "success_count": 0,
-                    "failure_count": 0,
-                    "type": "mbox",
-                    "current_message": 0,
-                },
+                "result": result,
                 "error": error_msg,
             },
         )
         return {
             "status": "FAILURE",
-            "result": {
-                "message_status": "Failed to process messages",
-                "total_messages": 0,
-                "success_count": 0,
-                "failure_count": 0,
-                "type": "mbox",
-                "current_message": 0,
-            },
+            "result": result,
             "error": error_msg,
         }
 
@@ -349,18 +342,18 @@ def process_mbox_file_task(
         current_message = i
         try:
             # Update task state with progress
+            result = {
+                "message_status": f"Processing message {i} of {total_messages}",
+                "total_messages": total_messages,
+                "success_count": success_count,
+                "failure_count": failure_count,
+                "type": "mbox",
+                "current_message": i,
+            }
             self.update_state(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
-                    "result": {
-                        "message_status": f"Processing message {i} of {total_messages}",
-                        "total_messages": total_messages,
-                        "success_count": success_count,
-                        "failure_count": failure_count,
-                        "type": "mbox",
-                        "current_message": i,
-                    },
+                    "result": result,
                     "error": None,
                 },
             )
@@ -394,7 +387,6 @@ def process_mbox_file_task(
     self.update_state(
         state="SUCCESS",
         meta={
-            "status": "SUCCESS",
             "result": result,
             "error": None,
         },
@@ -490,31 +482,25 @@ def import_imap_messages_task(
         status, messages = imap.select(folder)
         if status != "OK":
             error_msg = f"Failed to select folder {folder}: {messages}"
+            result = {
+                "message_status": "Failed to process messages",
+                "total_messages": 0,
+                "success_count": 0,
+                "failure_count": 0,
+                "type": "imap",
+                "current_message": 0,
+            }
+            logger.info("FAILURE !!!!!!!")
             self.update_state(
                 state="FAILURE",
                 meta={
-                    "status": "FAILURE",
-                    "result": {
-                        "message_status": "Failed to process messages",
-                        "total_messages": 0,
-                        "success_count": 0,
-                        "failure_count": 0,
-                        "type": "imap",
-                        "current_message": 0,
-                    },
+                    "result": result,
                     "error": error_msg,
                 },
             )
             return {
                 "status": "FAILURE",
-                "result": {
-                    "message_status": "Failed to process messages",
-                    "total_messages": 0,
-                    "success_count": 0,
-                    "failure_count": 0,
-                    "type": "imap",
-                    "current_message": 0,
-                },
+                "result": result,
                 "error": error_msg,
             }
 
@@ -522,31 +508,24 @@ def import_imap_messages_task(
         status, message_numbers = imap.search(None, "ALL")
         if status != "OK":
             error_msg = f"Failed to search messages: {message_numbers}"
+            result = {
+                "message_status": "Failed to process messages",
+                "total_messages": 0,
+                "success_count": 0,
+                "failure_count": 0,
+                "type": "imap",
+                "current_message": 0,
+            }
             self.update_state(
                 state="FAILURE",
                 meta={
-                    "status": "FAILURE",
-                    "result": {
-                        "message_status": "Failed to process messages",
-                        "total_messages": 0,
-                        "success_count": 0,
-                        "failure_count": 0,
-                        "type": "imap",
-                        "current_message": 0,
-                    },
+                    "result": result,
                     "error": error_msg,
                 },
             )
             return {
                 "status": "FAILURE",
-                "result": {
-                    "message_status": "Failed to process messages",
-                    "total_messages": 0,
-                    "success_count": 0,
-                    "failure_count": 0,
-                    "type": "imap",
-                    "current_message": 0,
-                },
+                "result": result,
                 "error": error_msg,
             }
 
@@ -567,18 +546,18 @@ def import_imap_messages_task(
             current_message = i
             try:
                 # Update task state
+                result = {
+                    "message_status": f"Processing message {i} of {total_messages}",
+                    "total_messages": total_messages,
+                    "success_count": success_count,
+                    "failure_count": failure_count,
+                    "type": "imap",
+                    "current_message": i,
+                }
                 self.update_state(
                     state="PROGRESS",
                     meta={
-                        "status": "PROGRESS",
-                        "result": {
-                            "message_status": f"Processing message {i} of {total_messages}",
-                            "total_messages": total_messages,
-                            "success_count": success_count,
-                            "failure_count": failure_count,
-                            "type": "imap",
-                            "current_message": i,
-                        },
+                        "result": result,
                         "error": None,
                     },
                 )
@@ -648,7 +627,6 @@ def import_imap_messages_task(
         self.update_state(
             state="FAILURE",
             meta={
-                "status": "FAILURE",
                 "result": result,
                 "error": error_msg,
             },
@@ -678,48 +656,40 @@ def process_eml_file_task(
         recipient = Mailbox.objects.get(id=recipient_id)
     except Mailbox.DoesNotExist:
         error_msg = f"Recipient mailbox {recipient_id} not found"
+        result = {
+            "message_status": "Failed to process message",
+            "total_messages": 1,
+            "success_count": 0,
+            "failure_count": 0,
+            "type": "eml",
+            "current_message": 0,
+        }
         self.update_state(
             state="FAILURE",
             meta={
-                "status": "FAILURE",
-                "result": {
-                    "message_status": "Failed to process message",
-                    "total_messages": 1,
-                    "success_count": 0,
-                    "failure_count": 0,
-                    "type": "eml",
-                    "current_message": 0,
-                },
+                "result": result,
                 "error": error_msg,
             },
         )
         return {
-            "status": "FAILURE",
-            "result": {
-                "message_status": "Failed to process message",
-                "total_messages": 1,
-                "success_count": 0,
-                "failure_count": 0,
-                "type": "eml",
-                "current_message": 0,
-            },
+            "result": result,
             "error": error_msg,
         }
 
     try:
         # Update progress state
+        progress_result = {
+            "message_status": "Processing message 1 of 1",
+            "total_messages": 1,
+            "success_count": 0,
+            "failure_count": 0,
+            "type": "eml",
+            "current_message": 1,
+        }
         self.update_state(
             state="PROGRESS",
             meta={
-                "status": "PROGRESS",
-                "result": {
-                    "message_status": "Processing message 1 of 1",
-                    "total_messages": 1,
-                    "success_count": 0,
-                    "failure_count": 0,
-                    "type": "eml",
-                    "current_message": 1,
-                },
+                "result": progress_result,
                 "error": None,
             },
         )
@@ -744,7 +714,6 @@ def process_eml_file_task(
             self.update_state(
                 state="SUCCESS",
                 meta={
-                    "status": "SUCCESS",
                     "result": result,
                     "error": None,
                 },
@@ -759,7 +728,6 @@ def process_eml_file_task(
         self.update_state(
             state="FAILURE",
             meta={
-                "status": "FAILURE",
                 "result": result,
                 "error": error_msg,
             },
@@ -788,7 +756,6 @@ def process_eml_file_task(
         self.update_state(
             state="FAILURE",
             meta={
-                "status": "FAILURE",
                 "result": result,
                 "error": error_msg,
             },

--- a/src/backend/core/tests/import_messages/test_imap_import.py
+++ b/src/backend/core/tests/import_messages/test_imap_import.py
@@ -191,7 +191,6 @@ def test_imap_import_task_success(
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": f"Processing message {i} of 3",
                         "total_messages": 3,
@@ -262,7 +261,6 @@ def test_imap_import_task_login_failure(mailbox):
         )
 
         # Verify task result
-        assert task_result["status"] == "FAILURE"
         assert task_result["result"]["message_status"] == "Failed to process messages"
         assert task_result["result"]["type"] == "imap"
         assert task_result["result"]["total_messages"] == 0
@@ -275,7 +273,10 @@ def test_imap_import_task_login_failure(mailbox):
         assert mock_task.update_state.call_count == 1
         mock_task.update_state.assert_called_once_with(
             state="FAILURE",
-            meta=task_result,
+            meta={
+                "result": task_result["result"],
+                "error": task_result["error"],
+            },
         )
 
         # Verify no messages were created
@@ -325,7 +326,10 @@ def test_imap_import_task_folder_not_found(mailbox):
         assert mock_task.update_state.call_count == 1
         mock_task.update_state.assert_called_once_with(
             state="FAILURE",
-            meta=task_result,
+            meta={
+                "result": task_result["result"],
+                "error": task_result["error"],
+            },
         )
 
         # Verify no messages were created
@@ -377,7 +381,6 @@ def test_imap_import_task_max_messages(
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": f"Processing message {i} of 2",
                         "total_messages": 2,
@@ -447,7 +450,6 @@ def test_imap_import_task_message_fetch_failure(
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": f"Processing message {i} of 3",
                         "total_messages": 3,

--- a/src/backend/core/tests/services/test_import_service.py
+++ b/src/backend/core/tests/services/test_import_service.py
@@ -147,7 +147,6 @@ def test_import_file_eml_by_superuser_sync(admin_user, mailbox, eml_file):
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": "Processing message 1 of 1",
                         "total_messages": 1,
@@ -163,7 +162,10 @@ def test_import_file_eml_by_superuser_sync(admin_user, mailbox, eml_file):
             # Verify success update
             mock_task.update_state.assert_called_with(
                 state="SUCCESS",
-                meta=task_result,
+                meta={
+                    "result": task_result["result"],
+                    "error": None,
+                },
             )
 
             # Verify message was created
@@ -252,7 +254,6 @@ def test_import_file_eml_by_user_with_access_sync(
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": "Processing message 1 of 1",
                         "total_messages": 1,
@@ -268,7 +269,10 @@ def test_import_file_eml_by_user_with_access_sync(
             # Verify success update
             mock_task.update_state.assert_called_with(
                 state="SUCCESS",
-                meta=task_result,
+                meta={
+                    "result": task_result["result"],
+                    "error": None,
+                },
             )
 
             # Verify message was created

--- a/src/backend/core/tests/test_tasks.py
+++ b/src/backend/core/tests/test_tasks.py
@@ -105,7 +105,6 @@ class TestProcessMboxFileTask:
                 mock_task.update_state.assert_any_call(
                     state="PROGRESS",
                     meta={
-                        "status": "PROGRESS",
                         "result": {
                             "message_status": "Processing message 1 of 3",
                             "total_messages": 3,
@@ -122,7 +121,6 @@ class TestProcessMboxFileTask:
                 mock_task.update_state.assert_any_call(
                     state="PROGRESS",
                     meta={
-                        "status": "PROGRESS",
                         "result": {
                             "message_status": "Processing message 2 of 3",
                             "total_messages": 3,
@@ -139,7 +137,6 @@ class TestProcessMboxFileTask:
                 mock_task.update_state.assert_any_call(
                     state="PROGRESS",
                     meta={
-                        "status": "PROGRESS",
                         "result": {
                             "message_status": "Processing message 3 of 3",
                             "total_messages": 3,
@@ -155,7 +152,10 @@ class TestProcessMboxFileTask:
                 # Verify success update
                 mock_task.update_state.assert_called_with(
                     state="SUCCESS",
-                    meta=task_result,
+                    meta={
+                        "result": task_result["result"],
+                        "error": None,
+                    },
                 )
 
                 # Verify messages were created
@@ -215,7 +215,6 @@ class TestProcessMboxFileTask:
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": "Processing message 1 of 3",
                         "total_messages": 3,
@@ -232,7 +231,6 @@ class TestProcessMboxFileTask:
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": "Processing message 2 of 3",
                         "total_messages": 3,
@@ -249,7 +247,6 @@ class TestProcessMboxFileTask:
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": "Processing message 3 of 3",
                         "total_messages": 3,
@@ -265,7 +262,10 @@ class TestProcessMboxFileTask:
             # Verify success update
             mock_task.update_state.assert_called_with(
                 state="SUCCESS",
-                meta=task_result,
+                meta={
+                    "result": task_result["result"],
+                    "error": None,
+                },
             )
 
             # Verify messages were created
@@ -309,7 +309,10 @@ class TestProcessMboxFileTask:
             assert mock_task.update_state.call_count == 1
             mock_task.update_state.assert_called_once_with(
                 state="FAILURE",
-                meta=task_result,
+                meta={
+                    "result": task_result["result"],
+                    "error": task_result["error"],
+                },
             )
 
             # Verify no messages were created
@@ -353,7 +356,6 @@ class TestProcessMboxFileTask:
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": "Processing message 1 of 3",
                         "total_messages": 3,
@@ -370,7 +372,6 @@ class TestProcessMboxFileTask:
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": "Processing message 2 of 3",
                         "total_messages": 3,
@@ -387,7 +388,6 @@ class TestProcessMboxFileTask:
             mock_task.update_state.assert_any_call(
                 state="PROGRESS",
                 meta={
-                    "status": "PROGRESS",
                     "result": {
                         "message_status": "Processing message 3 of 3",
                         "total_messages": 3,
@@ -403,7 +403,10 @@ class TestProcessMboxFileTask:
             # Verify final success update
             mock_task.update_state.assert_called_with(
                 state="SUCCESS",
-                meta=task_result,
+                meta={
+                    "result": task_result["result"],
+                    "error": None,
+                },
             )
 
             # Verify no messages were created
@@ -439,7 +442,10 @@ class TestProcessMboxFileTask:
             assert mock_task.update_state.call_count == 1
             mock_task.update_state.assert_called_once_with(
                 state="SUCCESS",
-                meta=task_result,
+                meta={
+                    "result": task_result["result"],
+                    "error": None,
+                },
             )
 
             # Verify no messages were created


### PR DESCRIPTION
Ensure consistent state reporting across import task updates

