### PR TITLE
✨(front) display a button to import a message when no thread

### DIFF
--- a/src/frontend/src/features/i18n/translations.json
+++ b/src/frontend/src/features/i18n/translations.json
@@ -50,7 +50,8 @@
         "delete_draft": "Delete draft",
         "download": "Download",
         "close": "Close",
-        "import": "Import"
+        "import": "Import",
+        "import_messages": "Import messages"
       },
       "tooltips": {
         "has_attachments": "This email has an attachment",
@@ -247,7 +248,8 @@
         "delete_draft": "Supprimer le brouillon",
         "download": "Télécharger",
         "close": "Fermer",
-        "import": "Importer"
+        "import": "Importer",
+        "import_messages": "Importer des messages"
       },
       "tooltips": {
         "has_attachments": "Cette email contient une pièce jointe",

--- a/src/frontend/src/features/layouts/components/thread-panel/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-panel/index.tsx
@@ -63,6 +63,7 @@ export const ThreadPanel = () => {
                 <div>
                     <span className="material-icons">mail</span>
                     <p>{t('no_threads')}</p>
+                    <Button href="#modal-message-importer">{t('actions.import_messages')}</Button>
                 </div>
             </div>
         );


### PR DESCRIPTION
## Purpose

When a mailbox has no threads, a button should be displayed to open the modal to import messages from an old mailbox.