### PR TITLE
💚(api): ensure consistent thread ordering in list endpoint

### DIFF
--- a/src/backend/core/api/viewsets/thread.py
+++ b/src/backend/core/api/viewsets/thread.py
@@ -89,7 +89,7 @@ class ThreadViewSet(
                     # Allow filtering for threads with zero count
                     queryset = queryset.filter(**{filter_lookup.replace("__gt", ""): 0})
 
-        queryset = queryset.order_by("-messaged_at")
+        queryset = queryset.order_by("-messaged_at", "-created_at")
         return queryset
 
     @extend_schema(

--- a/src/backend/core/tests/api/test_threads_list.py
+++ b/src/backend/core/tests/api/test_threads_list.py
@@ -659,7 +659,7 @@ class TestThreadListAPI:
         )
         # check that the accesses are returned
         assert len(response.data["results"][0]["accesses"]) == 1
-        access = response.data["results"][0]["accesses"][0]
+        access = response.data["results"][1]["accesses"][0]
         assert access["id"] == str(access2.id)
         assert access["mailbox"]["id"] == str(access2.mailbox.id)
         assert access["mailbox"]["email"] == str(access2.mailbox)


### PR DESCRIPTION
- Add secondary ordering by created_at to prevent flaky test results
- When threads have the same messaged_at value, order by newest created_at first
- Ensures deterministic API responses for better test reliability
