### PR TITLE
♻️(labels) move parent labels creation logic

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -566,6 +566,16 @@ class LabelSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "slug", "color", "mailbox", "threads"]
         read_only_fields = ["id", "slug"]
 
+    def validate(self, attrs):
+        """Validate that the label name is unique within the mailbox."""
+        if models.Label.objects.filter(
+            name=attrs.get("name"), mailbox=attrs.get("mailbox")
+        ).exists():
+            raise serializers.ValidationError(
+                {"name": "A label with this name already exists in this mailbox."}
+            )
+        return attrs
+
     def validate_mailbox(self, value):
         """Validate that user has access to the mailbox."""
         user = self.context["request"].user

--- a/src/backend/core/api/viewsets/label.py
+++ b/src/backend/core/api/viewsets/label.py
@@ -306,37 +306,8 @@ class LabelViewSet(
             models.Label._meta.get_field("color").default,  # noqa: SLF001
         )
 
-        # Split the name into parts to handle hierarchy
-        parts = name.split("/")
-
-        # Create parent labels if they don't exist
-        current_path = []
-        created_labels = []  # Track all labels created (including parents)
-        for part in parts[:-1]:  # Exclude the last part (the actual label)
-            current_path.append(part)
-            parent_name = "/".join(current_path)
-
-            # Check if parent label exists
-            parent_label = models.Label.objects.filter(
-                name=parent_name, mailbox=mailbox
-            ).first()
-
-            if not parent_label:
-                # Create parent label with color if provided, otherwise use model default
-                parent_label = models.Label.objects.create(
-                    name=parent_name,
-                    mailbox=mailbox,
-                    color=color,
-                )
-                created_labels.append(parent_label)
-
         # Create the actual label with color if provided, otherwise use model default
-        label = models.Label.objects.create(
-            name=name,
-            mailbox=mailbox,
-            color=color,
-        )
-        created_labels.append(label)
+        label = models.Label.objects.create(name=name, mailbox=mailbox, color=color)
 
         # Get all labels for the mailbox to build the tree structure
         all_labels = models.Label.objects.filter(mailbox=mailbox).order_by("name")

--- a/src/backend/core/tests/api/test_labels.py
+++ b/src/backend/core/tests/api/test_labels.py
@@ -181,8 +181,8 @@ class TestLabelSerializer:
 
         response = api_client.post(url, data, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Label with this Slug and Mailbox already exists." in str(
-            response.data["__all__"]
+        assert "A label with this name already exists in this mailbox." in str(
+            response.data["name"]
         )
 
     def test_create_label_with_parents(self, api_client, mailbox):
@@ -252,7 +252,9 @@ class TestLabelSerializer:
 
         response = api_client.post(url, data, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Label with this Slug and Mailbox already exists" in str(response.data)
+        assert "A label with this name already exists in this mailbox." in str(
+            response.data["name"]
+        )
 
     def test_create_label_with_special_characters(self, api_client, mailbox):
         """Test creating labels with special characters in the hierarchy."""
@@ -703,8 +705,8 @@ class TestLabelViewSet:
 
     def test_label_unique_constraint(self, api_client, mailbox):
         """Test that labels must have unique names within a mailbox."""
-        models.Label.objects.all().delete()
         LabelFactory(name="Work", mailbox=mailbox)
+        assert models.Label.objects.count() == 1
         url = reverse("labels-list")
         data = {
             "name": "Work",
@@ -713,9 +715,10 @@ class TestLabelViewSet:
         }
         response = api_client.post(url, data, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Label with this Slug and Mailbox already exists." in str(
-            response.data["__all__"]
+        assert "A label with this name already exists in this mailbox." in str(
+            response.data["name"]
         )
+        assert models.Label.objects.count() == 1
 
     def test_list_labels_hierarchical_structure(self, api_client, mailbox, user):
         """Test that labels are returned in a proper hierarchical structure."""


### PR DESCRIPTION
Put the logic into Label model's save() method to guarantee the invariant always holds, even when using the admin interfacee uses, the shell, bulk operations, or any code path.
