### PR TITLE
🔧(backend) prevent SSL redirect for internal MTA URLs

### DIFF
--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -740,6 +740,7 @@ class Production(Base):
     SECURE_REDIRECT_EXEMPT = [
         "^__lbheartbeat__",
         "^__heartbeat__",
+        "^api/v1\\.0/mta/"
     ]
 
     # Modern browsers require to have the `secure` attribute on cookies with `Samesite=none`


### PR DESCRIPTION
  ## Summary
  - Added SECURE_REDIRECT_EXEMPT pattern for api/v1.0/mta/ endpoints
  - Prevents Django from forcing HTTPS redirects on internal cluster communication
  - Fixes internal deployment issues where MTA endpoints need HTTP access

  ## Test plan
  - [x] Verify the configuration change is syntactically correct
  - [x] Test that internal MTA calls can use HTTP without redirect