### PR TITLE
💄(front) improve thread item layout with labels

### DIFF
--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-labels/components/label-form-modal/_index.scss
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-labels/components/label-form-modal/_index.scss
@@ -36,6 +36,7 @@
     inset: -10px;
     height: calc(100% + 20px);
     width: calc(100% + 20px);
+    border-radius: 0;
 }
 
 .label-form__color-field__icon {

--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-labels/components/label-item/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-labels/components/label-item/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { Badge } from "@/features/ui/components/badge";
 import { LabelModal } from "../label-form-modal";
+import { useLayoutContext } from "@/features/layouts/components/main";
 
 type LabelItemProps = TreeLabel & {
     level?: number;
@@ -34,6 +35,7 @@ export  const LabelItem = ({ level = 0, ...label }: LabelItemProps) => {
     });
     const unreadCount = (stats?.data as ThreadsStatsRetrieve200)?.all_unread ?? 0;
     const [isExpanded, setIsExpanded] = useState(false);
+    const { closeLeftPanel } = useLayoutContext();
     const searchParams = useSearchParams();
     const { t } = useTranslation();
     const isActive = searchParams.get('label_slug') === label.slug;
@@ -50,6 +52,7 @@ export  const LabelItem = ({ level = 0, ...label }: LabelItemProps) => {
       <>
         <Link
           href={`/mailbox/${selectedMailbox?.id}?${queryParams}`}
+          onClick={closeLeftPanel}
           className={clsx("label-item", isActive && "label-item--active")}
           style={{ paddingLeft: `${level * 1}rem` }}
           data-focus-within={isDropdownOpen}

--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/_index.scss
@@ -74,6 +74,15 @@
     max-width: 100%;
 }
 
+.thread-item__content {
+    display: flex;
+    flex-direction: row;
+    gap: var(--c--theme--spacings--base);
+    align-items: center;
+    margin-top: var(--c--theme--spacings--2xs);
+    min-width: 0;
+}
+
 .thread-item__senders,
 .thread-item__subject {
     margin: 0;
@@ -82,6 +91,7 @@
     text-overflow: ellipsis;
     max-width: 100%;
     display: inline-block;
+    flex-shrink: 0;
 }
 
 .thread-item__senders-container {
@@ -126,7 +136,7 @@
     color: var(--c--theme--colors--greyscale-400);
 }
 
-.thread-item[data-unread="true"]:not(:has(.thread-item__senders)) .thread-item__subject {
+.thread-item[data-unread="true"] .thread-item__subject {
     font-weight: 600;
 }
 
@@ -138,7 +148,18 @@
 .thread-item__labels {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    flex-shrink: 1;
     gap: var(--c--theme--spacings--2xs);
-    margin-top: var(--c--theme--spacings--2xs);
+    min-width: 0;
+    overflow: hidden;
+}
+
+.thread-item__labels .badge {
+    flex-shrink: 1;
+    min-width: 20px;
+    max-width: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
@@ -34,6 +34,11 @@ export const ThreadItem = ({ thread }: ThreadItemProps) => {
                             />
                         )}
                     <div className="thread-item__metadata">
+                        {thread.has_draft && (
+                            <Badge>
+                                {t('thread_message.draft')}
+                            </Badge>
+                        )}
                         {/* {thread.has_attachments ? (
                                 <span className="thread-item__metadata-attachments">
                                     <Tooltip placement="bottom" content={t('tooltips.has_attachments')}>
@@ -44,21 +49,14 @@ export const ThreadItem = ({ thread }: ThreadItemProps) => {
                     </div>
                 </div>
                 <div className="thread-item__content">
-                    <div className="thread-item__labels">
-                        {thread.has_draft && (
-                            <Badge>
-                                {t('thread_message.draft')}
-                            </Badge>
-                        )}
-                        {thread.labels && thread.labels.length > 0 && (
-                            <div className="thread-item__labels">
-                                {thread.labels.map((label) => (
-                                    <LabelBadge key={label.id} label={label} />
-                                ))}
-                            </div>
-                        )}
-                    </div>
                     <p className="thread-item__subject">{thread.subject}</p>
+                    {thread.labels.length > 0 && (
+                        <div className="thread-item__labels">
+                            {thread.labels.map((label) => (
+                                <LabelBadge key={label.id} label={label} />
+                            ))}
+                        </div>
+                    )}
                 </div>
             </div>
             </div>

--- a/src/frontend/src/features/ui/components/label-badge/index.tsx
+++ b/src/frontend/src/features/ui/components/label-badge/index.tsx
@@ -10,8 +10,8 @@ export const LabelBadge = ({ label }: LabelBadgeProps) => {
     const badgeColor = ColorHelper.getContrastColor(label.color!);
 
     return (
-        <Badge style={{ backgroundColor: label.color, color: badgeColor}}>
-            {label.display_name}
+        <Badge title={label.name} style={{ backgroundColor: label.color, color: badgeColor}}>
+            {label.name}
         </Badge>
     )
 }


### PR DESCRIPTION
## Purpose

Display full name of labels and put them in a row next to subject. Then make them shrinkable gracefully to always see a little part of all labels on small viewport.