### PR TITLE
🚸(front) put new message route under [mailboxId]

### DIFF
--- a/src/frontend/src/features/forms/components/message-form/index.tsx
+++ b/src/frontend/src/features/forms/components/message-form/index.tsx
@@ -151,10 +151,10 @@ export const MessageForm = ({
                 toast.dismiss(DRAFT_TOAST_ID);
             },
             onSuccess: async (response) => {
-                const taskId = (response as sendCreateResponse200).data.task_id;
+                const data = (response as sendCreateResponse200).data
+                const taskId = data.task_id;
                 addQueuedMessage(taskId);
                 onSuccess?.();
-                onClose?.();
             }
         }
     });
@@ -195,7 +195,6 @@ export const MessageForm = ({
                     unselectThread();
                     addToast(
                         <ToasterItem type="info">
-                            
                             <span>{t("message_form.success.draft_deleted")}</span>
                         </ToasterItem>
                     );
@@ -239,7 +238,7 @@ export const MessageForm = ({
     const saveDraft = async (data: MessageFormFields) => {
         if (Object.keys(form.formState.dirtyFields).length === 0) return draft;
 
-        const subject = parentMessage 
+        const subject = parentMessage
             ? MailHelper.prefixSubjectIfNeeded(parentMessage.subject)
             : data.subject;
 
@@ -254,7 +253,7 @@ export const MessageForm = ({
             attachments: form.getValues('attachments'),
         }
         let response;
-        
+
         if (!draft) {
             response = await draftCreateMutation.mutateAsync({
                 data: payload,
@@ -268,7 +267,7 @@ export const MessageForm = ({
                 data: payload,
             });
         }
-        
+
         const newDraft = response.data as Message;
         setDraft(newDraft);
         return newDraft;
@@ -291,7 +290,7 @@ export const MessageForm = ({
 
         const draft = await saveDraft(data);
 
-        if (!draft) { 
+        if (!draft) {
             setPendingSubmit(false);
             return;
         }
@@ -361,9 +360,9 @@ export const MessageForm = ({
                     />
                 </div>
                 <div className="form-field-row">
-                    <RhfInput 
+                    <RhfInput
                         name="to"
-                        label={t("thread_message.to")} 
+                        label={t("thread_message.to")}
                         icon={<span className="material-icons">group</span>}
                         fullWidth
                         text={form.formState.errors.to && !Array.isArray(form.formState.errors.to) ? t(form.formState.errors.to.message as string) : t("message_form.helper_text.recipients")}
@@ -375,9 +374,9 @@ export const MessageForm = ({
 
                 {showCCField && (
                     <div className="form-field-row">
-                        <RhfInput 
+                        <RhfInput
                             name="cc"
-                            label={t("thread_message.cc")} 
+                            label={t("thread_message.cc")}
                             icon={<span className="material-icons">group</span>}
                             text={form.formState.errors.cc && !Array.isArray(form.formState.errors.cc) ? t(form.formState.errors.cc.message as string) : t("message_form.helper_text.recipients")}
                             textItems={Array.isArray(form.formState.errors.cc) ? form.formState.errors.cc?.map((error, index) => t(error!.message as string, { email: form.getValues('cc')?.split(',')[index] })) : []}
@@ -390,11 +389,11 @@ export const MessageForm = ({
                     <div className="form-field-row">
                         <RhfInput
                             name="bcc"
-                            label={t("thread_message.bcc")} 
+                            label={t("thread_message.bcc")}
                             icon={<span className="material-icons">visibility_off</span>}
                             text={form.formState.errors.bcc && !Array.isArray(form.formState.errors.bcc) ? t(form.formState.errors.bcc.message as string) : t("message_form.helper_text.recipients")}
                             textItems={Array.isArray(form.formState.errors.bcc) ? form.formState.errors.bcc?.map((error, index) => t(error!.message as string, { email: form.getValues('bcc')?.split(',')[index] })) : []}
-                            fullWidth 
+                            fullWidth
                         />
                     </div>
                 )}
@@ -429,9 +428,9 @@ export const MessageForm = ({
                         {t("actions.send")}
                     </Button>
                     {!draft && onClose && (
-                        <Button 
-                            type="button" 
-                            color="secondary" 
+                        <Button
+                            type="button"
+                            color="secondary"
                             onClick={onClose}
                     >
                             {t("actions.cancel")}
@@ -439,9 +438,9 @@ export const MessageForm = ({
                     )}
                     {
                         draft && (
-                            <Button 
-                                type="button" 
-                                color="secondary" 
+                            <Button
+                                type="button"
+                                color="secondary"
                                 onClick={() => handleDeleteMessage(draft.id)}
                             >
                                 {t("actions.delete_draft")}
@@ -452,4 +451,4 @@ export const MessageForm = ({
             </form>
         </FormProvider>
     );
-}; 
+};

--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/index.tsx
@@ -2,23 +2,27 @@ import { Button } from "@openfun/cunningham-react";
 import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
 import { useLayoutContext } from "../../../main";
+import { useMailboxContext } from "@/features/providers/mailbox";
 
 export const MailboxPanelActions = () => {
     const { t } = useTranslation();
     const router = useRouter();
+    const { selectedMailbox } = useMailboxContext();
     const { closeLeftPanel } = useLayoutContext();
 
     const goToNewMessageForm = (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
         event.preventDefault();
         closeLeftPanel();
-        router.push(`/mailbox/new`);
+        router.push(`/mailbox/${selectedMailbox!.id}/new`);
     }
+
+    if (!selectedMailbox) return null;
 
     return (
         <div className="mailbox-panel-actions">
             <Button
                 onClick={goToNewMessageForm}
-                href="/mailbox/new"
+                href={`/mailbox/${selectedMailbox.id}/new`}
                 icon={<span className="material-icons">edit_note</span>}
             >
                 {t("actions.new_message")}

--- a/src/frontend/src/features/layouts/components/thread-view/components/message-reply-form/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/message-reply-form/index.tsx
@@ -1,7 +1,5 @@
 import { Message } from "@/features/api/gen";
 import { MessageForm } from "@/features/forms/components/message-form";
-import { MAILBOX_FOLDERS } from "../../../mailbox-panel/components/mailbox-list";
-import { usePathname, useRouter } from "next/navigation";
 
 type MessageReplyFormProps = {
     handleClose: () => void;
@@ -10,20 +8,13 @@ type MessageReplyFormProps = {
 };
 
 const MessageReplyForm = ({ handleClose, message, replyAll }: MessageReplyFormProps) => {
-    const router = useRouter()
-    const pathname = usePathname();
-    const goToDefaultFolder = () => {
-        const defaultFolder = MAILBOX_FOLDERS[0];
-        router.push(pathname + `?${new URLSearchParams(defaultFolder.filter).toString()}`);
-    }
-
     return (
         <div className="message-reply-form-container">
             <MessageForm
                 draftMessage={message.is_draft ? message : undefined}
                 parentMessage={message.is_draft ? undefined : message}
                 replyAll={replyAll}
-                onSuccess={goToDefaultFolder}
+                onSuccess={handleClose}
                 onClose={message.is_draft ? undefined : handleClose}
             />
         </div>

--- a/src/frontend/src/pages/mailbox/[mailboxId]/new/_index.scss
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/new/_index.scss
@@ -1,4 +1,4 @@
-@use "../../../styles/utils" as *;
+@use "../../../../styles/utils" as *;
 
 .new-message-form-container {
     margin-block: auto;

--- a/src/frontend/src/pages/mailbox/[mailboxId]/new/index.tsx
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/new/index.tsx
@@ -4,21 +4,25 @@ import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
 import { useMailboxContext } from "@/features/providers/mailbox";
 import { Spinner } from "@gouvfr-lasuite/ui-kit";
+import { MAILBOX_FOLDERS } from "@/features/layouts/components/mailbox-panel/components/mailbox-list";
 
 const NewMessageFormPage = () => {
     const { t } = useTranslation();
     const router = useRouter();
-    const { queryStates } = useMailboxContext();
+    const { queryStates, selectedMailbox } = useMailboxContext();
 
     /**
      * Go back to the previous page or to
      * the mailbox list if there is no previous page in the history
-     */ 
+     */
     const handleClose = () => {
         if (window.history.length > 1) {
             router.back();
-        } else {
+        } else if (!selectedMailbox) {
             router.push('/');
+        } else {
+            const defaultFolder = MAILBOX_FOLDERS[0];
+            router.push(`/mailbox/${selectedMailbox.id}` + `?${new URLSearchParams(defaultFolder.filter).toString()}`);
         }
     }
 
@@ -35,7 +39,7 @@ const NewMessageFormPage = () => {
             <h1>{t("new_message_form.title")}</h1>
             <MessageForm
                 showSubject={true}
-                onSuccess={() => router.push('/')}
+                onSuccess={handleClose}
                 onClose={handleClose}
             />
         </div>

--- a/src/frontend/src/styles/main.scss
+++ b/src/frontend/src/styles/main.scss
@@ -43,4 +43,4 @@
 // Application views
 @use "./../pages";
 @use "./../pages/mailbox";
-@use "./../pages/mailbox/new";
+@use "./../pages/mailbox/[mailboxId]/new";


### PR DESCRIPTION
## Purpose

Previously the new message view was not a child of the `[mailboxId]` route. So as the selectedMailbox is computed from the url param `mailboxId` selectedMailbox was empty on this view so the first mailbox was selected. This was weird for users with several mailboxes as if this one wants to write a message on a secondary mailbox, the left panel was updated to display the default mailbox. So by nesting new message view under `[mailboxId]` we ensure that the context is retain when the user wants to write a new message.