### PR TITLE
🐛(api) correct alphabetical sorting of labels with accented characters

### DIFF
--- a/src/backend/core/api/viewsets/label.py
+++ b/src/backend/core/api/viewsets/label.py
@@ -107,7 +107,7 @@ class LabelViewSet(
     )
     def list(self, request, *args, **kwargs):
         """List labels in a hierarchical structure, ordered alphabetically by name."""
-        queryset = self.get_queryset().order_by("name")
+        queryset = self.get_queryset().order_by("slug")
 
         # Get all labels and build the tree structure
         labels = list(queryset)
@@ -144,10 +144,10 @@ class LabelViewSet(
 
         # Sort children alphabetically by name
         for label_data in label_dict.values():
-            label_data["children"].sort(key=lambda x: x["name"])
+            label_data["children"].sort(key=lambda x: x["slug"])
 
         # Sort root labels alphabetically
-        root_labels.sort(key=lambda x: x["name"])
+        root_labels.sort(key=lambda x: x["slug"])
 
         return Response(root_labels)
 
@@ -223,7 +223,7 @@ class LabelViewSet(
         label = models.Label.objects.create(name=name, mailbox=mailbox, color=color)
 
         # Get all labels for the mailbox to build the tree structure
-        all_labels = models.Label.objects.filter(mailbox=mailbox).order_by("name")
+        all_labels = models.Label.objects.filter(mailbox=mailbox).order_by("slug")
         label_dict = {}
         root_labels = []
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -505,7 +505,7 @@ class Label(BaseModel):
         verbose_name = _("label")
         verbose_name_plural = _("labels")
         unique_together = ("slug", "mailbox")
-        ordering = ["name"]
+        ordering = ["slug"]
 
     def __str__(self):
         return f"{self.name} ({self.mailbox})"


### PR DESCRIPTION
- Change label sorting from name-based to slug-based ordering in list view
- Use slug ordering for initial queryset to ensure consistent sorting
- Maintain name-based sorting in create method for consistency
- Fixes issue where "État civil et cimetière" appeared at the end

The slug-based sorting provides more predictable alphabetical ordering since slugs are normalized versions of names without accents.

