### PR TITLE
✨(api) add multi-word search on contact name and email

### DIFF
--- a/src/backend/core/api/viewsets/contacts.py
+++ b/src/backend/core/api/viewsets/contacts.py
@@ -1,0 +1,81 @@
+"""API ViewSet for Contact model."""
+
+from django.db.models import Q
+
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
+from rest_framework import mixins, viewsets
+from rest_framework.response import Response
+
+from core import models
+
+from .. import permissions, serializers
+
+
+class ContactViewSet(
+    viewsets.GenericViewSet, mixins.ListModelMixin, mixins.RetrieveModelMixin
+):
+    """ViewSet for Contact model."""
+
+    serializer_class = serializers.ContactSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    pagination_class = None
+
+    def get_queryset(self):
+        """Restrict results to contacts of mailboxes the current user has access to."""
+        user_mailbox_ids = self.request.user.mailbox_accesses.values_list(
+            "mailbox_id", flat=True
+        )
+        return models.Contact.objects.filter(mailbox_id__in=user_mailbox_ids).order_by(
+            "name", "email"
+        )
+
+    @extend_schema(
+        tags=["contacts"],
+        parameters=[
+            OpenApiParameter(
+                name="mailbox_id",
+                type=OpenApiTypes.UUID,
+                location=OpenApiParameter.QUERY,
+                description="Filter contacts by mailbox ID.",
+                required=False,
+            ),
+            OpenApiParameter(
+                name="q",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Search contacts by name or email (case insensitive).",
+                required=False,
+            ),
+        ],
+        responses=serializers.ContactSerializer(many=True),
+    )
+    def list(self, request, *args, **kwargs):
+        """
+        List contacts with optional filtering by mailbox and search query.
+
+        Query parameters:
+        - mailbox_id: Optional UUID to filter contacts by mailbox
+        - q: Optional search query for name or email (case insensitive)
+        """
+        queryset = self.get_queryset()
+
+        # Filter by mailbox if specified
+        mailbox_id = request.query_params.get("mailbox_id")
+        if mailbox_id:
+            queryset = queryset.filter(mailbox_id=mailbox_id)
+
+        # Advanced search on name and email (multi-word)
+        search_query = request.query_params.get("q", "")
+        if search_query:
+            search_words = search_query.strip().split()
+            if search_words:
+                search_filters = Q()
+                for word in search_words:
+                    word_filter = Q(name__unaccent__icontains=word) | Q(
+                        email__unaccent__icontains=word
+                    )
+                    search_filters &= word_filter
+                queryset = queryset.filter(search_filters)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -12,7 +12,12 @@ from django.utils import timezone
 from core import models
 from core.enums import MessageDeliveryStatusChoices
 from core.mda.inbound import check_local_recipient, deliver_inbound_message
-from core.mda.rfc5322 import compose_email, parse_email_message, create_reply_message, create_forward_message
+from core.mda.rfc5322 import (
+    compose_email,
+    create_forward_message,
+    create_reply_message,
+    parse_email_message,
+)
 from core.mda.signing import sign_message_dkim
 
 logger = logging.getLogger(__name__)
@@ -69,7 +74,7 @@ def prepare_outbound_message(
                 original_message=parent_parsed,
                 forward_text=text_body,
                 forward_html=html_body,
-                include_original=True
+                include_original=True,
             )
         else:
             # Handle reply message embedding
@@ -79,7 +84,7 @@ def prepare_outbound_message(
                 original_message=parent_parsed,
                 reply_text=text_body,
                 reply_html=html_body,
-                include_quote=True
+                include_quote=True,
             )
 
         # Update the bodies with properly formatted reply content

--- a/src/backend/core/mda/rfc5322/__init__.py
+++ b/src/backend/core/mda/rfc5322/__init__.py
@@ -8,8 +8,8 @@ content according to RFC5322 standards.
 from .composer import (
     EmailComposeError,
     compose_email,
-    create_reply_message,
     create_forward_message,
+    create_reply_message,
     format_address,
     format_address_list,
 )

--- a/src/backend/core/mda/rfc5322/composer.py
+++ b/src/backend/core/mda/rfc5322/composer.py
@@ -537,6 +537,7 @@ def compose_email(
         logger.exception("Unexpected error during email composition: %s", str(e))
         raise EmailComposeError(f"Failed to compose email: {str(e)}") from e
 
+
 def _embed_original_message(
     original_message: Dict[str, Any],
     new_text: str = "",
@@ -669,13 +670,13 @@ def _embed_original_message(
             header_html = "<p>---------- In reply to ----------<br/>"
 
         if from_display_html:
-            header_html += f'<strong>From:</strong> {from_display_html}<br/>'
+            header_html += f"<strong>From:</strong> {from_display_html}<br/>"
         if to_display_html:
-            header_html += f'<strong>To:</strong> {to_display_html}<br/>'
+            header_html += f"<strong>To:</strong> {to_display_html}<br/>"
         if cc_display_html:
-            header_html += f'<strong>Cc:</strong> {cc_display_html}<br/>'
-        header_html += f'<strong>Subject:</strong> {html.escape(orig_subject)}<br/>'
-        header_html += f'<strong>Date:</strong> {html.escape(date_str)}<br/>'
+            header_html += f"<strong>Cc:</strong> {cc_display_html}<br/>"
+        header_html += f"<strong>Subject:</strong> {html.escape(orig_subject)}<br/>"
+        header_html += f"<strong>Date:</strong> {html.escape(date_str)}<br/>"
         header_html += "</p>"
 
         # Get original HTML content
@@ -691,7 +692,6 @@ def _embed_original_message(
                 orig_html = first_html
             elif isinstance(first_html, dict):
                 orig_html = first_html.get("content", "")
-
 
         nested_html = f"""
         <hr data-type="quote-separator" />

--- a/src/backend/core/tests/api/test_contacts.py
+++ b/src/backend/core/tests/api/test_contacts.py
@@ -1,0 +1,352 @@
+"""Test the ContactViewSet."""
+
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import factories, models
+
+
+@pytest.mark.django_db
+class TestContactViewSet:
+    """Test the ContactViewSet."""
+
+    def test_list_contacts(self):
+        """Test listing all contacts for user's mailboxes."""
+        # Create authenticated user with access to 2 mailboxes
+        authenticated_user = factories.UserFactory()
+        user_mailbox1 = factories.MailboxFactory()
+        user_mailbox2 = factories.MailboxFactory()
+        other_mailbox = factories.MailboxFactory()
+
+        # Authenticated user has access to 2 mailboxes
+        factories.MailboxAccessFactory(
+            mailbox=user_mailbox1,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.VIEWER,
+        )
+        factories.MailboxAccessFactory(
+            mailbox=user_mailbox2,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+
+        # Create contacts for user's mailboxes
+        contact1 = factories.ContactFactory(
+            mailbox=user_mailbox1, name="John Doe", email="john@example.com"
+        )
+        contact2 = factories.ContactFactory(
+            mailbox=user_mailbox2, name="Jane Smith", email="jane@example.com"
+        )
+        contact3 = factories.ContactFactory(
+            mailbox=user_mailbox2, name="Bob Wilson", email="bob@example.com"
+        )
+
+        # Create contact for other mailbox (should not appear in results)
+        factories.ContactFactory(
+            mailbox=other_mailbox, name="Other User", email="other@example.com"
+        )
+
+        # Authenticate user
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+
+        # Get list of contacts
+        response = client.get(reverse("contacts-list"))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 3
+
+        # Check response data (ordered by name, then email)
+        expected_contacts = [
+            {
+                "id": str(contact3.id),
+                "name": "Bob Wilson",
+                "email": "bob@example.com",
+            },
+            {
+                "id": str(contact2.id),
+                "name": "Jane Smith",
+                "email": "jane@example.com",
+            },
+            {
+                "id": str(contact1.id),
+                "name": "John Doe",
+                "email": "john@example.com",
+            },
+        ]
+        assert response.data == expected_contacts
+
+    def test_list_contacts_unauthorized(self):
+        """Anonymous user cannot access the list of contacts."""
+        client = APIClient()
+        response = client.get(reverse("contacts-list"))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_list_contacts_filter_by_mailbox(self):
+        """Test filtering contacts by mailbox ID."""
+        # Create authenticated user with access to 2 mailboxes
+        authenticated_user = factories.UserFactory()
+        user_mailbox1 = factories.MailboxFactory()
+        user_mailbox2 = factories.MailboxFactory()
+
+        # Authenticated user has access to both mailboxes
+        factories.MailboxAccessFactory(
+            mailbox=user_mailbox1,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.VIEWER,
+        )
+        factories.MailboxAccessFactory(
+            mailbox=user_mailbox2,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+
+        # Create contacts for each mailbox
+        contact1 = factories.ContactFactory(
+            mailbox=user_mailbox1, name="John Doe", email="john@example.com"
+        )
+        contact2 = factories.ContactFactory(
+            mailbox=user_mailbox2, name="Jane Smith", email="jane@example.com"
+        )
+
+        # Authenticate user
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+
+        # Filter by first mailbox
+        response = client.get(
+            reverse("contacts-list"), {"mailbox_id": str(user_mailbox1.id)}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact1.id)
+
+        # Filter by second mailbox
+        response = client.get(
+            reverse("contacts-list"), {"mailbox_id": str(user_mailbox2.id)}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact2.id)
+
+    def test_list_contacts_search_by_name(self):
+        """Test searching contacts by name (multi-words)."""
+        authenticated_user = factories.UserFactory()
+        mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+        contact1 = factories.ContactFactory(
+            mailbox=mailbox, name="John Doe", email="john@example.com"
+        )
+        contact2 = factories.ContactFactory(
+            mailbox=mailbox, name="Jane Doe", email="jane@example.com"
+        )
+        factories.ContactFactory(
+            mailbox=mailbox, name="Bob Smith", email="bob@example.com"
+        )
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+        # One word : "Doe" => both Doe
+        response = client.get(reverse("contacts-list"), {"q": "Doe"})
+        assert response.status_code == 200
+        assert {c["id"] for c in response.data} == {str(contact1.id), str(contact2.id)}
+        # Two words : "Jane Doe" => only Jane Doe
+        response = client.get(reverse("contacts-list"), {"q": "Jane Doe"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact2.id)
+        # Two words : "Doe John" => only John Doe
+        response = client.get(reverse("contacts-list"), {"q": "Doe John"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact1.id)
+
+    def test_list_contacts_search_by_email(self):
+        """Test searching contacts by email (multi-words)."""
+        authenticated_user = factories.UserFactory()
+        mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+        contact1 = factories.ContactFactory(
+            mailbox=mailbox, name="John Doe", email="john.doe@example.com"
+        )
+        contact2 = factories.ContactFactory(
+            mailbox=mailbox, name="Jane Smith", email="jane.smith@example.com"
+        )
+        factories.ContactFactory(
+            mailbox=mailbox, name="Bob Wilson", email="bob.wilson@test.com"
+        )
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+        # One word : "example.com" => both Doe
+        response = client.get(reverse("contacts-list"), {"q": "example.com"})
+        assert response.status_code == 200
+        assert {c["id"] for c in response.data} == {str(contact1.id), str(contact2.id)}
+        # Two words : "jane example.com" => only Jane Smith
+        response = client.get(reverse("contacts-list"), {"q": "jane example.com"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact2.id)
+        # Two words : "john example.com" => only John Doe
+        response = client.get(reverse("contacts-list"), {"q": "john example.com"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact1.id)
+
+    def test_list_contacts_search_combined(self):
+        """Test searching contacts with both mailbox filter and multi-words search query."""
+        authenticated_user = factories.UserFactory()
+        mailbox1 = factories.MailboxFactory()
+        mailbox2 = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=mailbox1,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+        factories.MailboxAccessFactory(
+            mailbox=mailbox2,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+        contact1 = factories.ContactFactory(
+            mailbox=mailbox1, name="John Doe", email="john@example.com"
+        )
+        contact2 = factories.ContactFactory(
+            mailbox=mailbox2, name="John Smith", email="john@test.com"
+        )
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+        # One word : "John" in mailbox1 => John Doe
+        response = client.get(
+            reverse("contacts-list"), {"mailbox_id": str(mailbox1.id), "q": "John"}
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact1.id)
+        # Two words : "John Doe" in mailbox1 => John Doe
+        response = client.get(
+            reverse("contacts-list"), {"mailbox_id": str(mailbox1.id), "q": "John Doe"}
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact1.id)
+        # Two words : "John test.com" in mailbox2 => John Smith
+        response = client.get(
+            reverse("contacts-list"),
+            {"mailbox_id": str(mailbox2.id), "q": "John test.com"},
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact2.id)
+
+    def test_list_contacts_search_multiword(self):
+        """Test searching contacts with three words (first name, last name, email domain)."""
+        authenticated_user = factories.UserFactory()
+        mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+        contact1 = factories.ContactFactory(
+            mailbox=mailbox, name="John Doe", email="john.doe@example.com"
+        )
+        factories.ContactFactory(
+            mailbox=mailbox, name="Jane Doe", email="jane.doe@example.com"
+        )
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+        # Three words : "John Doe example.com" => only John Doe
+        response = client.get(reverse("contacts-list"), {"q": "John Doe example.com"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(contact1.id)
+
+    def test_list_contacts_no_results(self):
+        """Test when no contacts match the search criteria."""
+        # Create authenticated user with access to a mailbox
+        authenticated_user = factories.UserFactory()
+        mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+
+        # Create a contact
+        factories.ContactFactory(
+            mailbox=mailbox, name="John Doe", email="john@example.com"
+        )
+
+        # Authenticate user
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+
+        # Search for non-existent contact
+        response = client.get(reverse("contacts-list"), {"q": "nonexistent"})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 0
+
+    def test_retrieve_contact(self):
+        """Test retrieving a specific contact."""
+        # Create authenticated user with access to a mailbox
+        authenticated_user = factories.UserFactory()
+        mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=authenticated_user,
+            role=models.MailboxRoleChoices.EDITOR,
+        )
+
+        # Create a contact
+        contact = factories.ContactFactory(
+            mailbox=mailbox, name="John Doe", email="john@example.com"
+        )
+
+        # Authenticate user
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+
+        # Retrieve the contact
+        response = client.get(
+            reverse("contacts-detail", kwargs={"pk": str(contact.id)})
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "id": str(contact.id),
+            "name": "John Doe",
+            "email": "john@example.com",
+        }
+
+    def test_retrieve_contact_unauthorized(self):
+        """Anonymous user cannot retrieve a contact."""
+        contact = factories.ContactFactory()
+        client = APIClient()
+        response = client.get(
+            reverse("contacts-detail", kwargs={"pk": str(contact.id)})
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_retrieve_contact_no_access(self):
+        """User without access to the mailbox cannot retrieve the contact."""
+        # Create user without access to the mailbox
+        user = factories.UserFactory()
+        contact = factories.ContactFactory()
+
+        # Authenticate user
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        # Try to retrieve the contact
+        response = client.get(
+            reverse("contacts-detail", kwargs={"pk": str(contact.id)})
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/src/backend/core/tests/mda/test_rfc5322_composer.py
+++ b/src/backend/core/tests/mda/test_rfc5322_composer.py
@@ -16,10 +16,10 @@ from core.mda.rfc5322.composer import (
     EmailComposeError,
     compose_email,
     create_attachment_part,
+    create_forward_message,
     create_reply_message,
     format_address,
     format_address_list,
-    create_forward_message,
 )
 
 
@@ -822,7 +822,7 @@ class TestReplyGeneration:
             "This is the original <b>HTML</b> content"
             in reply["htmlBody"][0]["content"]
         )
-        assert "<hr data-type=\"quote-separator\" />" in reply["htmlBody"][0]["content"]
+        assert '<hr data-type="quote-separator" />' in reply["htmlBody"][0]["content"]
         assert "---------- In reply to ----------" in reply["htmlBody"][0]["content"]
 
     def test_reply_with_long_original(self):
@@ -1004,9 +1004,12 @@ class TestForwardGeneration:
         # Check HTML body
         html_content = forward["htmlBody"][0]["content"]
         assert "<p>Forward HTML content.</p>" in html_content
-        assert "<hr data-type=\"quote-separator\" />" in html_content
+        assert '<hr data-type="quote-separator" />' in html_content
         assert "---------- Forwarded message ----------" in html_content
-        assert "<strong>From:</strong> HTML Sender &lt;html@example.com&gt;<br/>" in html_content
+        assert (
+            "<strong>From:</strong> HTML Sender &lt;html@example.com&gt;<br/>"
+            in html_content
+        )
         assert "<p>Original <strong>HTML</strong> content.</p>" in html_content
 
     def test_forward_without_original(self):
@@ -1027,7 +1030,9 @@ class TestForwardGeneration:
 
         forward_text = "This is a forward message."
 
-        forward = create_forward_message(original_message, forward_text, include_original=False)
+        forward = create_forward_message(
+            original_message, forward_text, include_original=False
+        )
 
         # Check subject
         assert forward["subject"] == "Fwd: Original Subject"

--- a/src/backend/core/urls.py
+++ b/src/backend/core/urls.py
@@ -7,6 +7,7 @@ from rest_framework.routers import DefaultRouter
 
 from core.api.viewsets.blob import BlobViewSet
 from core.api.viewsets.config import ConfigView
+from core.api.viewsets.contacts import ContactViewSet
 from core.api.viewsets.draft import DraftMessageView
 from core.api.viewsets.flag import ChangeFlagViewSet
 from core.api.viewsets.import_message import ImportViewSet
@@ -31,6 +32,7 @@ router.register("mta", MTAViewSet, basename="mta")
 router.register("users", UserViewSet, basename="users")
 router.register("messages", MessageViewSet, basename="messages")
 router.register("blob", BlobViewSet, basename="blob")
+router.register("contacts", ContactViewSet, basename="contacts")
 router.register("threads", ThreadViewSet, basename="threads")
 router.register("labels", LabelViewSet, basename="labels")
 router.register("mailboxes", MailboxViewSet, basename="mailboxes")


### PR DESCRIPTION
- Add ability to search contacts by multiple keywords (AND logic) on name and email, in contacts endpoint.
- Adapt and enrich tests to cover multi-word search, case sensitivity, and name/email combination.

