### PR TITLE
🌐(frontend) pass current language to CunninghamProvider

### DIFF
--- a/src/frontend/src/features/i18n/conf.ts
+++ b/src/frontend/src/features/i18n/conf.ts
@@ -1,3 +1,3 @@
-export const LANGUAGES_ALLOWED = ['en', 'fr'];
+export const LANGUAGES_ALLOWED = ['en-US', 'fr-FR'];
 export const LANGUAGE_LOCAL_STORAGE = 'main-language';
-export const BASE_LANGUAGE = 'fr';
+export const BASE_LANGUAGE = 'fr-FR';

--- a/src/frontend/src/features/layouts/components/main/language-picker.tsx
+++ b/src/frontend/src/features/layouts/components/main/language-picker.tsx
@@ -12,8 +12,8 @@ export const LanguagePicker = () => {
     const { i18n } = useTranslation();
     const [selectedValues, setSelectedValues] = useState([i18n.language]);
     const languages = [
-        { label: "Français", value: "fr" },
-        { label: "English", value: "en" },
+        { label: "Français", value: "fr-FR" },
+        { label: "English", value: "en-US" },
     ];
 
     return (
@@ -48,4 +48,3 @@ export const LanguagePicker = () => {
       </DropdownMenu>
     );
 }
-  

--- a/src/frontend/src/pages/_app.tsx
+++ b/src/frontend/src/pages/_app.tsx
@@ -59,7 +59,7 @@ const queryClient = new QueryClient({
 
 export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   // Use the layout defined at the page level, if available
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const getLayout = Component.getLayout ?? ((page) => page);
 
   return (
@@ -84,7 +84,7 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
       </Head>
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools initialIsOpen={false} />
-        <CunninghamProvider>
+        <CunninghamProvider currentLocale={i18n.language}>
           <Auth>
             {getLayout(<Component {...pageProps} />)}
           </Auth>


### PR DESCRIPTION
## Purpose

Currently UI Kit components are not internationalized, we pass the active language to CunninghamProvider to fix that.