### PR TITLE
🐛(frontend) use i18n.resolvedLanguage to get locale

### DIFF
--- a/src/frontend/src/features/blocknote/quoted-message-block/index.tsx
+++ b/src/frontend/src/features/blocknote/quoted-message-block/index.tsx
@@ -28,7 +28,7 @@ export const QuotedMessageBlock = createReactBlockSpec(
                         <p>{props.mode === "reply" ? t('quoted_message_block.replied-message') : t('quoted_message_block.forwarded-message')}</p>
                         <p><strong>{t('quoted_message_block.from')}:</strong> {props.sender}</p>
                         <p><strong>{t('quoted_message_block.subject')}:</strong> {props.subject}</p>
-                        <p><strong>{t('quoted_message_block.date')}:</strong> {DateHelper.formatDate(props.received_at, i18n.language)}</p>
+                        <p><strong>{t('quoted_message_block.date')}:</strong> {DateHelper.formatDate(props.received_at, i18n.resolvedLanguage)}</p>
                         <p><strong>{t('quoted_message_block.to')}:</strong> {props.recipients}</p>
                     </blockquote>
                 </div>

--- a/src/frontend/src/features/forms/components/message-editor/index.tsx
+++ b/src/frontend/src/features/forms/components/message-editor/index.tsx
@@ -69,9 +69,9 @@ const MessageEditor = ({ blockNoteOptions, defaultValue, quotedMessage, ...props
         trailingBlock: false,
         initialContent: getInitialContent(),
         dictionary: {
-            ...locales[i18n.language as keyof typeof locales],
+            ...(locales[(i18n.resolvedLanguage) as keyof typeof locales] || locales.en),
             placeholders: {
-                ...locales[i18n.language as keyof typeof locales].placeholders,
+                ...(locales[(i18n.resolvedLanguage) as keyof typeof locales] || locales.en).placeholders,
                 emptyDocument: t('message_editor.start_typing'),
                 default: t('message_editor.start_typing'),
             }

--- a/src/frontend/src/features/forms/components/message-form/attachment-uploader.tsx
+++ b/src/frontend/src/features/forms/components/message-form/attachment-uploader.tsx
@@ -89,7 +89,7 @@ export const AttachmentUploader = ({
         if (!hasClickInBucketList) {
             getRootProps().onClick?.(event);
         }
-        
+
     }
 
     /**
@@ -126,7 +126,7 @@ export const AttachmentUploader = ({
                 <div className="attachment-uploader__bucket">
                     <p className="attachment-bucket__counter">
                         <strong>{t("attachments.counter", { count: attachments.length })}</strong>{' '}
-                        ({AttachmentHelper.getFormattedTotalSize(attachments, i18n.language)})
+                        ({AttachmentHelper.getFormattedTotalSize(attachments, i18n.resolvedLanguage)})
                     </p>
                     <div className="attachment-bucket__list">
                         {failedQueue.map((entry) => (
@@ -151,4 +151,4 @@ export const AttachmentUploader = ({
             )}
         </section>
     );
-}; 
+};

--- a/src/frontend/src/features/forms/components/search-filters-form/index.tsx
+++ b/src/frontend/src/features/forms/components/search-filters-form/index.tsx
@@ -15,7 +15,7 @@ export const SearchFiltersForm = ({ query, onChange }: SearchFiltersFormProps) =
 
     const updateQuery = (submit: boolean) => {
         const formData = new FormData(formRef.current as HTMLFormElement);
-        const query = SearchHelper.serializeSearchFormData(formData, i18n.language);
+        const query = SearchHelper.serializeSearchFormData(formData, i18n.resolvedLanguage);
         onChange(query, submit);
         formRef.current?.reset();
     }

--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
@@ -104,7 +104,7 @@ export const ThreadItem = ({ thread }: ThreadItemProps) => {
                 </div> */}
                     {thread.messaged_at && (
                         <span className="thread-item__date">
-                            {DateHelper.formatDate(thread.messaged_at, i18n.language)}
+                            {DateHelper.formatDate(thread.messaged_at, i18n.resolvedLanguage)}
                         </span>
                     )}
                 </div>

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-attachment-list/attachment-item.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-attachment-list/attachment-item.tsx
@@ -32,7 +32,7 @@ export const AttachmentItem = ({ attachment, isLoading = false, canDownload = tr
                 :
                     <img className="attachment-item-icon" src={icon} alt="" />
                 }
-                <p className="attachment-item-size">{AttachmentHelper.getFormattedSize(attachment.size, i18n.language)}</p>
+                <p className="attachment-item-size">{AttachmentHelper.getFormattedSize(attachment.size, i18n.resolvedLanguage)}</p>
             </div>
             <div className="attachment-item-content">
                 <p className="attachment-item-name">{attachment.name}</p>

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-attachment-list/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-attachment-list/index.tsx
@@ -8,14 +8,14 @@ type AttachmentListProps = {
 
 export const AttachmentList = ({ attachments }: AttachmentListProps) => {
     const { t, i18n } = useTranslation();
-    
+
     return (
         <section className="thread-attachment-list">
             <header className="thread-attachment-list__header">
                 <p>
                     <strong>{t("attachments.counter", { count: attachments.length })}</strong>
                     {' '}
-                    ({AttachmentHelper.getFormattedTotalSize(attachments, i18n.language)})
+                    ({AttachmentHelper.getFormattedTotalSize(attachments, i18n.resolvedLanguage)})
                 </p>
             </header>
             <div className="thread-attachment-list__body">

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
@@ -84,7 +84,7 @@ export const ThreadMessage = forwardRef<HTMLElement, ThreadMessageProps>(
                             <div className="thread-message__metadata">
                                 {message.sent_at && (
                                     <p className="thread-message__date">{
-                                        new Date(message.sent_at).toLocaleString(i18n.language, {
+                                        new Date(message.sent_at).toLocaleString(i18n.resolvedLanguage, {
                                             minute: '2-digit',
                                             hour: '2-digit',
                                             day: '2-digit',

--- a/src/frontend/src/features/utils/attachment-helper/index.ts
+++ b/src/frontend/src/features/utils/attachment-helper/index.ts
@@ -45,7 +45,7 @@ export class AttachmentHelper {
         const category = AttachmentHelper.getMimeCategory(attachment);
         return mini ? MIME_TO_ICON_MINI[category] : MIME_TO_ICON[category];
     }
-      
+
     /**
      * Get the format translation key of an attachment
      */

--- a/src/frontend/src/features/utils/date-helper.ts
+++ b/src/frontend/src/features/utils/date-helper.ts
@@ -9,12 +9,12 @@ export class DateHelper {
    * - Today: displays time (HH:mm)
    * - Less than 1 month: displays short date (e.g., "3 mars")
    * - Otherwise: displays full date (DD/MM/YYYY)
-   * 
+   *
    * @param dateString - The date string to format
    * @param locale - The locale code (e.g., 'fr', 'en')
    * @returns Formatted date string
    */
-  public static formatDate(dateString: string, locale: string): string {
+  public static formatDate(dateString: string, locale: string = 'en'): string {
     const date = new Date(dateString);
     const daysDifference = differenceInDays(new Date(), date);
     const dateLocale = locales[locale as keyof typeof locales];

--- a/src/frontend/src/features/utils/search-helper/index.ts
+++ b/src/frontend/src/features/utils/search-helper/index.ts
@@ -16,7 +16,7 @@ const KEYS_PAIR = Object.fromEntries(Object.entries(KEYS_FLATTEN).filter(([key])
 export class SearchHelper {
     static parseSearchQuery = (query: string): Record<string, string | boolean> => {
         const result: Record<string, string | boolean> = {};
-        // A group is a string of the form from:"value" or to:"value" or text:"value" 
+        // A group is a string of the form from:"value" or to:"value" or text:"value"
         const regex_keys_single = new RegExp(Object.values(KEYS_SINGLE).flat().join('|'), 'g');
         const regex_keys_pair = new RegExp(`(${Object.values(KEYS_PAIR).flat().join('|')}):"[^"]*"`, 'g');
         const single_matches = query.match(regex_keys_single);
@@ -27,7 +27,7 @@ export class SearchHelper {
             .replace(regex_keys_single, '')
             .replace(regex_keys_pair, '')
             .trim();
-        
+
         // Process key-value pairs (e.g "from:value")
         pair_matches?.forEach(match => {
             const [localizedKey, value] = match.split(':');
@@ -35,7 +35,7 @@ export class SearchHelper {
             if (key) result[key] = value?.replace(/"/g, '');
             else rawText = `${rawText} ${match}`;
         });
-    
+
 
         // Process single value (e.g "is_unread", "in_trash")
         single_matches?.forEach(match => {
@@ -44,19 +44,19 @@ export class SearchHelper {
             else if(key.startsWith('in_')) result['in'] = key.split('_')[1];
             else result[key] = true;
         });
-    
+
         if (rawText) {
             result.text = rawText;
         }
-    
+
         return result;
     }
 
-    
-    static serializeSearchFormData = (data: FormData, language: string): string => {
+
+    static serializeSearchFormData = (data: FormData, language: string = 'en'): string => {
         const i18nFiltersMap = SearchFiltersMap[language as keyof typeof SearchFiltersMap] ?? SearchFiltersMap['en'];
         const isFiltersMapKey = (key: string): key is keyof typeof i18nFiltersMap => i18nFiltersMap.hasOwnProperty(key);
-        
+
         return Array.from(data.entries()).reduce((acc, [key, value]) => {
             if (key === 'text') return acc;
             if (key.startsWith('is_')) {


### PR DESCRIPTION
## Purpose

For Blocknote and Intl methods, we must provide a locale without region. So we use `i18n.resolvedLanguage` instead of `i18n.language` to fix that.
