### PR TITLE
✨(api) Allow superuser+staff to view all mail domains in admin API

### DIFF
--- a/src/backend/core/api/viewsets/maildomain.py
+++ b/src/backend/core/api/viewsets/maildomain.py
@@ -26,6 +26,9 @@ class MailDomainAdminViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         if not user or not user.is_authenticated:
             return models.MailDomain.objects.none()
 
+        if user.is_superuser and user.is_staff:
+            return models.MailDomain.objects.all().order_by("name")
+
         accessible_maildomain_ids = models.MailDomainAccess.objects.filter(
             user=user, role=models.MailDomainAccessRoleChoices.ADMIN
         ).values_list("maildomain_id", flat=True)


### PR DESCRIPTION
- Add condition in MailDomainAdminViewSet.get_queryset() to return all domains when user is both superuser and staff
- Add comprehensive tests covering all user permission combinations:
  * superuser + staff: can see all domains
  * superuser only: cannot see all domains (empty list)
  * staff only: cannot see all domains (empty list)
  * staff with domain access: can only see accessible domains
- Maintain existing behavior for regular users and domain admins

This change ensures that superusers with staff privileges have full administrative access to all mail domains through the admin API, while maintaining proper access control for other user types.
