### PR TITLE
💄(quoted-message) does not use hr element to detect quoted message

### DIFF
--- a/src/backend/core/mda/rfc5322/composer.py
+++ b/src/backend/core/mda/rfc5322/composer.py
@@ -694,8 +694,7 @@ def _embed_original_message(
                 orig_html = first_html.get("content", "")
 
         nested_html = f"""
-        <hr data-type="quote-separator" />
-        <blockquote>
+        <blockquote data-type="quote-separator">
             {header_html}
             {orig_html}
         </blockquote>

--- a/src/backend/core/tests/mda/test_rfc5322_composer.py
+++ b/src/backend/core/tests/mda/test_rfc5322_composer.py
@@ -822,7 +822,7 @@ class TestReplyGeneration:
             "This is the original <b>HTML</b> content"
             in reply["htmlBody"][0]["content"]
         )
-        assert '<hr data-type="quote-separator" />' in reply["htmlBody"][0]["content"]
+        assert '<blockquote data-type="quote-separator">' in reply["htmlBody"][0]["content"]
         assert "---------- In reply to ----------" in reply["htmlBody"][0]["content"]
 
     def test_reply_with_long_original(self):
@@ -1004,7 +1004,7 @@ class TestForwardGeneration:
         # Check HTML body
         html_content = forward["htmlBody"][0]["content"]
         assert "<p>Forward HTML content.</p>" in html_content
-        assert '<hr data-type="quote-separator" />' in html_content
+        assert '<blockquote data-type="quote-separator">' in html_content
         assert "---------- Forwarded message ----------" in html_content
         assert (
             "<strong>From:</strong> HTML Sender &lt;html@example.com&gt;<br/>"

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/message-body.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/message-body.tsx
@@ -138,21 +138,19 @@ const MessageBody = ({ rawHtmlBody, rawTextBody }: MessageBodyProps) => {
         if (iframeRef.current?.contentWindow?.document) {
             const doc = iframeRef.current.contentWindow.document;
 
-            // Replace all <hr /><blockquote>...</blockquote> by
+            // Replace all <blockquote data-type="quote-separator">...</blockquote> by
             // a details element to automatically fold embedded messages
             // TODO : Try to detect replies and forward messages coming form external sources
-            doc.querySelectorAll('hr').forEach(node => {
-                const blockquote = node.nextElementSibling as HTMLQuoteElement | null;
-                if(blockquote) {
-                    const details = doc.createElement('details');
-                    details.addEventListener('toggle', resizeIframe);
+            doc.querySelectorAll('blockquote[data-type="quote-separator"]').forEach(node => {
+                const parentElement = node.parentElement;
+                const details = doc.createElement('details');
+                details.addEventListener('toggle', resizeIframe);
 
-                    const summary = doc.createElement('summary');
-                    summary.textContent = t('message_body.show_embedded_message');
-                    details.appendChild(summary);
-                    details.appendChild(blockquote);
-                    node.replaceWith(details);
-                }
+                const summary = doc.createElement('summary');
+                summary.textContent = t('message_body.show_embedded_message');
+                details.appendChild(summary);
+                details.appendChild(node);
+                parentElement?.appendChild(details);
             });
         }
         resizeIframe();


### PR DESCRIPTION
## Purpose

Previously to detect quoted message we used a hr sibling to a blockquote. That was weird as the hr was displayed on external messaging application and adds visual noise. So instead we now use a blockquote we a specific data attribute.