### PR TITLE
✨(api) add dynamic abilities field to MailDomain API

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -500,8 +500,8 @@ class MailboxAccessWriteSerializer(serializers.ModelSerializer):
         return attrs
 
 
-class MailDomainAdminSerializer(serializers.ModelSerializer):
-    """Serialize MailDomain basic information for admin listing."""
+class MailDomainAdminSerializer(AbilitiesModelSerializer):
+    """Serialize mail domains for admin view."""
 
     class Meta:
         model = models.MailDomain

--- a/src/backend/core/tests/models/test_maildomain.py
+++ b/src/backend/core/tests/models/test_maildomain.py
@@ -1,0 +1,55 @@
+"""Tests for the MailDomain permissions system based on get_abilities."""
+# pylint: disable=redefined-outer-name,unused-argument
+
+import pytest
+
+from core import models
+from core.factories import MailDomainFactory, UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user():
+    """Create a test user."""
+    return UserFactory()
+
+
+@pytest.fixture
+def maildomain():
+    """Create a test mail domain."""
+    return MailDomainFactory()
+
+
+class TestMailDomainModelAbilities:
+    """Test the get_abilities methods on MailDomain models."""
+
+    def test_maildomain_get_abilities_no_access(self, user, maildomain):
+        """Test MailDomain.get_abilities when user has no access."""
+        abilities = maildomain.get_abilities(user)
+
+        assert abilities["get"] is False
+        assert abilities["patch"] is False
+        assert abilities["put"] is False
+        assert abilities["post"] is False
+        assert abilities["delete"] is False
+        assert abilities["manage_accesses"] is False
+        assert abilities["manage_mailboxes"] is False
+
+    def test_maildomain_get_abilities_admin(self, user, maildomain):
+        """Test MailDomain.get_abilities when user has admin access."""
+        models.MailDomainAccess.objects.create(
+            maildomain=maildomain,
+            user=user,
+            role=models.MailDomainAccessRoleChoices.ADMIN,
+        )
+
+        abilities = maildomain.get_abilities(user)
+
+        assert abilities["get"] is True
+        assert abilities["patch"] is True
+        assert abilities["put"] is True
+        assert abilities["post"] is True
+        assert abilities["delete"] is True
+        assert abilities["manage_accesses"] is True
+        assert abilities["manage_mailboxes"] is True


### PR DESCRIPTION
- Add get_abilities() method to MailDomain model for permission-based abilities
- Update MailDomainAdminSerializer to inherit from AbilitiesModelSerializer
- Add RetrieveModelMixin to MailDomainAdminViewSet for detail endpoints
- Optimize queries with JOIN and annotation for regular users
- Add prefetch_related for superusers to avoid N+1 queries
- Add comprehensive tests for abilities functionality and query optimization
- Add new test file for MailDomain model abilities

The abilities field dynamically controls user permissions based on their role in the mail domain, with optimized database queries to maintain performance.


<img width="452" height="894" alt="Capture d’écran 2025-07-11 à 01 00 15" src="https://github.com/user-attachments/assets/faea09ba-cbb7-401d-a8ce-bb91b2c2ce7e" />


