### PR TITLE
💄(front) fix layout when there is no mailbox

### DIFF
--- a/src/frontend/src/features/layouts/components/main/index.tsx
+++ b/src/frontend/src/features/layouts/components/main/index.tsx
@@ -46,6 +46,7 @@ const MainLayoutContent = ({ children }: PropsWithChildren<{ simple?: boolean }>
                 setIsLeftPanelOpen={setLeftPanelOpen}
                 leftPanelContent={<LeftPanel hasNoMailbox={hasNoMailbox} />}
                 icon={<img src="/images/app-logo.svg" alt="logo" height={32} />}
+                hideLeftPanelOnDesktop={hasNoMailbox}
             >
                 {hasNoMailbox ? (
                     <NoMailbox />

--- a/src/frontend/src/features/layouts/components/main/no-mailbox.tsx
+++ b/src/frontend/src/features/layouts/components/main/no-mailbox.tsx
@@ -9,7 +9,7 @@ export const NoMailbox = () => {
             <div>
                 <span className="material-icons">error</span>
                 <p>{t('no_mailbox')}</p>
-                <Button onClick={logout}>{t('logout')}</Button>
+                <Button onClick={logout}>{t('user_menu.logout')}</Button>
             </div>
         </div>
     )


### PR DESCRIPTION
## Purpose

There were some issues when the user has no mailbox. The left panel was displayed on desktop but there is nothing within. Furthermore, a translation key was wrong.