### PR TITLE
🐛(labels) implement cascading label rename with hierarchical tree fix

### DIFF
--- a/src/backend/core/api/viewsets/label.py
+++ b/src/backend/core/api/viewsets/label.py
@@ -137,10 +137,16 @@ class LabelViewSet(
                 # This is a child label
                 parent_name = "/".join(parts[:-1])
                 # Find parent label
+                parent_found = False
                 for potential_parent in labels:
                     if potential_parent.name == parent_name:
                         label_dict[potential_parent.id]["children"].append(label_data)
+                        parent_found = True
                         break
+
+                # If parent not found, treat as root label (orphaned child)
+                if not parent_found:
+                    root_labels.append(label_data)
 
         # Sort children alphabetically by name
         for label_data in label_dict.values():


### PR DESCRIPTION
- Add cascading rename functionality to Label model save method
- Update all child labels when parent label is renamed
- Clean up orphaned parent labels that are no longer referenced
- Fix hierarchical tree construction in LabelViewSet list method
- Handle orphaned child labels by treating them as root labels
- Add comprehensive test for parent label rename scenarios

This ensures that when a parent label is renamed, all its children are automatically updated to maintain the hierarchy, and the API correctly displays all labels even when some parents are missing. Fix #278

## Purpose

Description...


## Proposal

Description...

- [] item 1...
- [] item 2...
