### PR TITLE
✨(front) add mailbox settings dropdown menu

### DIFF
--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/index.tsx
@@ -1,11 +1,14 @@
-import { Button } from "@openfun/cunningham-react";
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLayoutContext } from "../../../main";
+import { Button, Tooltip } from "@openfun/cunningham-react";
+import { DropdownMenu, Icon, IconType } from "@gouvfr-lasuite/ui-kit";
 import { useMailboxContext } from "@/features/providers/mailbox";
+import { useLayoutContext } from "../../../main";
 
 export const MailboxPanelActions = () => {
     const { t } = useTranslation();
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
     const router = useRouter();
     const { selectedMailbox } = useMailboxContext();
     const { closeLeftPanel } = useLayoutContext();
@@ -27,6 +30,30 @@ export const MailboxPanelActions = () => {
             >
                 {t("actions.new_message")}
             </Button>
+            <div className="mailbox-panel-actions__extra">
+                <DropdownMenu
+                    isOpen={isDropdownOpen}
+                    onOpenChange={setIsDropdownOpen}
+                    options={[
+                        {
+                            label: t("actions.import_messages"),
+                            icon: <Icon name="archive" type={IconType.OUTLINED} />,
+                            callback: () => {
+                                window.location.hash = `#modal-message-importer`;
+                            }
+                        },
+                    ]}
+                >
+                    <Tooltip content={t("tooltips.more_options")} placement="left">
+                        <Button
+                            onClick={() => setIsDropdownOpen(true)}
+                            icon={<Icon name="settings" type={IconType.OUTLINED} />}
+                            aria-label={t("mailbox-panel.actions.more_options")}
+                            color="tertiary-text"
+                        />
+                    </Tooltip>
+                </DropdownMenu>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Purpose

In the mailbox actions, add a mailbox settings dropdown menu with an option to import messages.

<img width="406" height="562" alt="image" src="https://github.com/user-attachments/assets/87b682ef-42e4-4e03-85de-ade4da886dc6" />
