### PR TITLE
🐛(frontend) invalidate properly mailbox query on mailbox creation

### DIFF
--- a/src/frontend/src/features/config/constants.ts
+++ b/src/frontend/src/features/config/constants.ts
@@ -5,3 +5,6 @@
 export enum PORTALS {
     DRAG_PREVIEW = 'portal-drag-preview',
 }
+
+// Default page size for the API
+export const DEFAULT_PAGE_SIZE = 20;

--- a/src/frontend/src/features/layouts/components/admin/modal-create-address/index.tsx
+++ b/src/frontend/src/features/layouts/components/admin/modal-create-address/index.tsx
@@ -52,7 +52,7 @@ export const ModalCreateAddress = ({ isOpen, onClose, onCreate }: ModalCreateAdd
   const [firstFieldRef, setFirstFieldRef] = useState<HTMLInputElement | null>(null);
 
   // Get existing mailboxes and domain info
-  const { data: mailboxesData, refetch: refetchMailboxes } = useMaildomainsMailboxesList(domainId);
+  const { data: mailboxesData } = useMaildomainsMailboxesList(domainId);
   const mailboxes = mailboxesData?.data.results || [];
   const { selectedMailDomain } = useAdminMailDomain();
   const domainName = selectedMailDomain?.name || "";
@@ -208,7 +208,6 @@ export const ModalCreateAddress = ({ isOpen, onClose, onCreate }: ModalCreateAdd
       }
 
       const response = await createMailbox({ maildomainPk: domainId, data: payload }, );
-      refetchMailboxes();
       setCreatedMailbox(response.data);
       onCreate();
     } catch (error: unknown) {

--- a/src/frontend/src/features/providers/admin-maildomain.tsx
+++ b/src/frontend/src/features/providers/admin-maildomain.tsx
@@ -3,6 +3,7 @@ import { MailDomainAdmin } from "../api/gen/models/mail_domain_admin";
 import { useMaildomainsList, useMaildomainsRetrieve } from "../api/gen";
 import { useRouter } from "next/router";
 import { usePagination } from "@openfun/cunningham-react";
+import { DEFAULT_PAGE_SIZE } from "../config/constants";
 
 type AdminMailDomainContextType = {
     selectedMailDomain: MailDomainAdmin | null;
@@ -20,7 +21,7 @@ const AdminMailDomainContext = createContext<AdminMailDomainContextType | undefi
  */
 export const AdminMailDomainProvider = ({ children }: PropsWithChildren) => {
     const router = useRouter();
-    const pagination = usePagination({ pageSize: 20 });
+    const pagination = usePagination({ pageSize: DEFAULT_PAGE_SIZE });
     const { data: maildomainsData, isLoading: isLoadingList, error: listError } = useMaildomainsList({ page: pagination.page });
     const { data: selectedMaildomainData, isLoading: isLoadingItem, error: itemError } = useMaildomainsRetrieve(
         router.query.maildomainId as string, { query: { enabled: !!router.query.maildomainId } });
@@ -30,7 +31,7 @@ export const AdminMailDomainProvider = ({ children }: PropsWithChildren) => {
         isLoading: isLoadingList || isLoadingItem,
         error: listError || itemError,
         pagination
-    }), [selectedMaildomainData, maildomainsData, isLoadingList, isLoadingItem, listError, itemError, pagination.page]);
+    }), [selectedMaildomainData, maildomainsData, isLoadingList, isLoadingItem, listError, itemError, pagination]);
 
     useEffect(() => {
         if (maildomainsData?.data.count) {

--- a/src/frontend/src/pages/domain/[maildomainId]/index.tsx
+++ b/src/frontend/src/pages/domain/[maildomainId]/index.tsx
@@ -1,17 +1,31 @@
+import { DEFAULT_PAGE_SIZE } from "@/features/config/constants";
 import { AdminLayout } from "@/features/layouts/components/admin/admin-layout";
 import { CreateMailboxAction } from "@/features/layouts/components/admin/mailboxes-view/create-mailbox-action";
 import { AdminDomainPageContent } from "@/features/layouts/components/admin/mailboxes-view/page-content";
 import { usePagination } from "@openfun/cunningham-react";
+import { useQueryClient } from "@tanstack/react-query";
 
 /**
  * Admin page which list all mailboxes for a given domain and allow to manage them.
  */
 export default function AdminDomainMailboxesPage() {
-  const pagination = usePagination({ pageSize: 20 });
+  const pagination = usePagination({ pageSize: DEFAULT_PAGE_SIZE });
+  const queryClient = useQueryClient();
 
-  const handleCreateMailbox = () => {
-    pagination.setPage(1);
-    pagination.setPagesCount(undefined)
+  const handleCreateMailbox = async () => {
+    if (pagination.page === 1) {
+      // Invalidate the mailboxes list query for the current domain of page 1
+      await queryClient.invalidateQueries({
+        predicate: (query) => {
+          const isMailboxesMailDomainQuery = typeof query.queryKey[0] === 'string' && /maildomains\/[a-f0-9-]*\/mailboxes\/?/.test(query.queryKey[0]);
+          const isFirstPageQuery = !!query.queryKey[1] && typeof query.queryKey[1] === 'object' && 'page' in query.queryKey[1] && query.queryKey[1].page === 1;
+          return isMailboxesMailDomainQuery && isFirstPageQuery;
+        }
+      });
+    } else {
+      pagination.setPage(1);
+    }
+    pagination.setPagesCount(undefined);
   }
 
   return (


### PR DESCRIPTION
## Purpose

When an admin creates a new mailbox and there was on the first page of the mailboxes, the data was not refreshed.