### PR TITLE
🐛(front) decrease intersection threshold to mark messages as read

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/index.tsx
@@ -94,7 +94,7 @@ export const ThreadView = () => {
                 }
             });
             debouncedMarkAsRead();
-        }, { threshold: 0.95, root: rootRef.current, rootMargin: "0px 40px 0px 0px" });
+        }, { threshold: 0.3, root: rootRef.current, rootMargin: "0px 40px 0px 0px" });
 
         unreadMessageIds.forEach(id => {
             const el = unreadRefs.current[id];


### PR DESCRIPTION
## Purpose

The intersection threshold to mark a message as read was 0.95. That means that 95% of the message must be displayed on the screen to trigger the observer so with long messages or on small viewport, in some cases the message could be not mark as read.