### PR TITLE
Feat/admin mailbox delete

### DIFF
--- a/src/frontend/src/features/i18n/translations.json
+++ b/src/frontend/src/features/i18n/translations.json
@@ -530,7 +530,7 @@
       },
       "folders": {
         "inbox": "Boîte de réception",
-        "all_messages": "Toutes les messages",
+        "all_messages": "Tous les messages",
         "drafts": "Brouillons",
         "sent": "Envoyés",
         "trash": "Corbeille"

--- a/src/frontend/src/features/i18n/translations.json
+++ b/src/frontend/src/features/i18n/translations.json
@@ -461,7 +461,12 @@
           "reset_password": "Reset password",
           "more": "More"
         },
-        "loading": "Loading addresses..."
+        "loading": "Loading addresses...",
+        "delete_modal": {
+          "title": "Delete mailbox {{mailbox}}",
+          "message": "Are you sure you want to delete this mailbox? This action is irreversible!",
+          "success": "Mailbox {{mailbox}} has been deleted successfully."
+        }
       },
       "admin_maildomains_dns": {
         "explanation": "These DNS records must be configured on the domain <strong>{{domain}}</strong> for the mail system to work properly. If you don't know how to update them, please contact your technical service provider or system administrator.",
@@ -950,7 +955,12 @@
           "reset_password": "Réinitialiser le mot de passe",
           "more": "Plus"
         },
-        "loading": "Chargement des adresses..."
+        "loading": "Chargement des adresses...",
+        "delete_modal": {
+          "title": "Supprimer la boîte aux lettres {{mailbox}}",
+          "message": "Voulez-vous vraiment supprimer cette boîte aux lettres ? Cette action est irréversible!",
+          "success": "La boîte aux lettres {{mailbox}} a été supprimée avec succès."
+        }
       },
       "admin_maildomains_dns": {
         "explanation": "Ces enregistrements DNS doivent être configurés sur le domaine <strong>{{domain}}</strong> pour que le système de messagerie fonctionne correctement. Si vous ne savez pas comment les mettre à jour, contactez votre prestataire technique ou votre administrateur système.",

--- a/src/frontend/src/features/layouts/components/admin/modal-mailbox-reset-password/index.tsx
+++ b/src/frontend/src/features/layouts/components/admin/modal-mailbox-reset-password/index.tsx
@@ -60,7 +60,7 @@ const ModalMailboxResetPassword = ({ isOpen, onClose, mailbox, domainId }: Modal
                         }
                         <footer>
                             <Button
-                                color="tertiary"
+                                color="secondary"
                                 onClick={onClose}
                                 disabled={isPending}
                                 icon={isPending && <Spinner />}


### PR DESCRIPTION
## Purpose

Add row action to delete a mailbox in the maildomain admin.


https://github.com/user-attachments/assets/4c16a42b-dac5-4e13-a914-9eeea77b7a2c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Admins can delete mailboxes from the Mailboxes view; confirmation dialog and success toast added. Action menu now shows Manage Access, Reset Password (when available), and Delete.

- Bug Fixes
  - Corrected French translation for “All messages” to “Tous les messages.”
  - Added localized delete-confirmation texts (EN/FR) for mailbox deletion.

- Style
  - Cancel button color updated to secondary in the mailbox reset-password modal.

- Tests
  - Added tests covering mailbox deletion: success, unauthenticated, forbidden, and not-found cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->