### PR TITLE
✨(smtp) implement smtp_tls_security_level, follow RFC more closely

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ swaks --to=user1@example.local --server localhost:8917
 # Send a test message to the MTA-out, which will then relay it to mailcatcher on http://localhost:8904/
 swaks -tls --to=test@example.external --server localhost:8911 --auth-user user --auth-password=pass
 
+# You can also send emails using Messages itself instead of the frontend
+make back-shell
+MTA_OUT_MODE=relay MTA_OUT_RELAY_HOST=localhost:8917 python manage.py send_mail --to=user1@example.local --subject="Test" --body="Hello World"
+
 ```
 
 > ⚠️ Most residential ISPs block the outgoing port 25, so you might not be able to send emails to outside

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ swaks -tls --to=test@example.external --server localhost:8911 --auth-user user -
 
 # You can also send emails using Messages itself instead of the frontend
 make back-shell
-MTA_OUT_MODE=relay MTA_OUT_RELAY_HOST=localhost:8917 python manage.py send_mail --to=user1@example.local --subject="Test" --body="Hello World"
+MTA_OUT_MODE=relay MTA_OUT_RELAY_HOST=mailcatcher:1025 python manage.py send_mail --to=user1@example.local --subject="Test" --body="Hello World"
 
 ```
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -80,11 +80,12 @@ The application uses a new environment file structure with `.defaults` and `.loc
 | Variable | Default | Description | Required |
 |----------|---------|-------------|----------|
 | `MTA_OUT_MODE` | `direct` | Outbound MTA mode ('direct' or 'relay') | Required |
-| `MTA_OUT_SMTP_HOST` | `mta-out:587` | Outbound SMTP server host for relay mode | Required |
-| `MTA_OUT_SMTP_USERNAME` | `user` | Outbound SMTP username for relay mode | Optional |
-| `MTA_OUT_SMTP_PASSWORD` | `pass` | Outbound SMTP password for relay mode | Optional |
-| `MTA_OUT_PROXIES` | `[]` | List of SOCKS proxy URLs (randomly chosen when non-empty; used in direct mode) | Optional |
+| `MTA_OUT_RELAY_HOST` | `mta-out:587` | Outbound SMTP server host for relay mode | Required |
+| `MTA_OUT_RELAY_USERNAME` | `user` | Outbound SMTP username for relay mode | Optional |
+| `MTA_OUT_RELAY_PASSWORD` | `pass` | Outbound SMTP password for relay mode | Optional |
+| `MTA_OUT_DIRECT_PROXIES` | `[]` | List of SOCKS proxy URLs (randomly chosen when non-empty; used in direct mode) | Optional |
 | `MTA_OUT_DIRECT_PORT` | `25` | TCP port for direct mode on remote MX servers | Optional |
+| `MTA_OUT_SMTP_TLS_SECURITY_LEVEL` | `may` | SMTP TLS security level ("none", "may") | Optional |
 | `MDA_API_SECRET` | `my-shared-secret-mda` | Shared secret for MDA API | Required |
 | `MDA_API_BASE_URL` | `http://backend-dev:8000/api/v1.0/mta/` | Base URL for MDA API | Dev |
 

--- a/env.d/development/backend.defaults
+++ b/env.d/development/backend.defaults
@@ -75,7 +75,7 @@ FRONTEND_THEME=dsfr
 MESSAGES_TESTDOMAIN=example.local
 MESSAGES_TESTDOMAIN_MAPPING_BASEDOMAIN=example.com
 MTA_OUT_MODE=relay
-MTA_OUT_SMTP_HOST=mailcatcher:1025
+MTA_OUT_RELAY_HOST=mailcatcher:1025
 MDA_API_SECRET=my-shared-secret-mda
 SALT_KEY=ThisIsAnExampleSaltForDevPurposeOnly
 

--- a/src/backend/core/management/commands/send_mail.py
+++ b/src/backend/core/management/commands/send_mail.py
@@ -194,5 +194,5 @@ class Command(BaseCommand):
                 )
                 if status.get("retry", False):
                     self.stdout.write(
-                        f"✗ Temporary failure - would be retried. Error : {error_msg}"
+                        f"✗ Temporary failure - would be retried. Error: {error_msg}"
                     )

--- a/src/backend/core/management/commands/send_mail.py
+++ b/src/backend/core/management/commands/send_mail.py
@@ -1,0 +1,198 @@
+"""
+Django management command to send emails using send_outbound_email.
+This command does not write to the database and works even without any mailboxes configured.
+
+Usage examples:
+    # Send a simple email (works without any mailboxes)
+    python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World"
+    
+    # Send with custom sender and log level
+    python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World" \
+        --from sender@mydomain.com --log-level DEBUG
+    
+    # Dry run to see what would be sent
+    python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World" --dry-run
+"""
+
+import base64
+import logging
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand, CommandError
+from django.core.validators import validate_email
+from django.utils import timezone
+
+from core import models
+from core.mda.outbound import send_outbound_email
+from core.mda.rfc5322 import compose_email
+from core.mda.signing import sign_message_dkim
+
+
+class Command(BaseCommand):
+    help = "Send an email using send_outbound_email (works without mailboxes, no DB writes)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--to",
+            type=str,
+            required=True,
+            help="Recipient email address",
+        )
+        parser.add_argument(
+            "--subject",
+            type=str,
+            required=True,
+            help="Email subject",
+        )
+        parser.add_argument(
+            "--body",
+            type=str,
+            required=True,
+            help="Email body (plain text)",
+        )
+        parser.add_argument(
+            "--from",
+            type=str,
+            help="Sender email address (defaults to noreply@localhost if not specified)",
+            dest="from_email",
+        )
+        parser.add_argument(
+            "--log-level",
+            type=str,
+            choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+            default="INFO",
+            help="Logging level (default: INFO)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be sent without actually sending the email",
+        )
+
+    def handle(self, *args, **options):
+        # Configure logging
+        log_level = getattr(logging, options["log_level"].upper())
+        logging.basicConfig(level=log_level)
+        logger = logging.getLogger(__name__)
+
+        to_email = options["to"]
+        subject = options["subject"]
+        body = options["body"]
+        from_email = options.get("from_email")
+        dry_run = options.get("dry_run", False)
+
+        # Validate email addresses
+        try:
+            validate_email(to_email)
+        except ValidationError as e:
+            raise CommandError(f"Invalid recipient email address: {to_email}") from e
+
+        if from_email:
+            try:
+                validate_email(from_email)
+            except ValidationError as e:
+                raise CommandError(f"Invalid sender email address: {from_email}") from e
+
+        # Get sender mailbox or use minimal setup
+        sender_mailbox = None
+        custom_attributes = {}
+
+        if from_email:
+            try:
+                sender_mailbox = models.Mailbox.objects.get(
+                    local_part=from_email.split("@")[0],
+                    domain__name=from_email.split("@")[1],
+                )
+                custom_attributes = sender_mailbox.domain.custom_attributes or {}
+            except models.Mailbox.DoesNotExist:
+                # Use minimal setup without mailbox
+                logger.warning(
+                    f"Mailbox with email '{from_email}' not found, sending without DKIM"
+                )
+        else:
+            # Use minimal setup without mailbox
+            logger.warning("No mailbox specified, sending without DKIM")
+            from_email = "noreply@localhost"  # Default fallback
+
+        from_name = (
+            sender_mailbox.contact.name if sender_mailbox else None
+        ) or from_email.split("@")[0]
+
+        logger.info(f"Sending email from {from_email} to {to_email}")
+        logger.info(f"Subject: {subject}")
+
+        # Generate MIME ID
+        mime_id = (
+            base64.urlsafe_b64encode(uuid.uuid4().bytes).rstrip(b"=").decode("ascii")
+        )
+        mime_id = f"{mime_id}@_lst.{from_email.split('@')[1]}"
+
+        # Generate MIME content
+        mime_data = {
+            "from": [{"name": from_name, "email": from_email}],
+            "date": timezone.now().strftime("%a, %d %b %Y %H:%M:%S %z"),
+            "to": [{"name": to_email.split("@")[0], "email": to_email}],
+            "cc": [],
+            "subject": subject,
+            "textBody": [{"content": body}],
+            "htmlBody": [],
+            "message_id": mime_id,
+        }
+
+        # Compose the email
+        raw_mime = compose_email(mime_data)
+
+        # Sign the message with DKIM (only if mailbox exists)
+        dkim_signature_header = None
+        if sender_mailbox:
+            dkim_signature_header = sign_message_dkim(
+                raw_mime_message=raw_mime, maildomain=sender_mailbox.domain
+            )
+
+        if dkim_signature_header:
+            raw_mime_signed = dkim_signature_header + b"\r\n" + raw_mime
+        else:
+            raw_mime_signed = raw_mime
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    "DRY RUN MODE - Email would be sent with the following details:"
+                )
+            )
+            self.stdout.write(f"  From: {from_name} <{from_email}>")
+            self.stdout.write(f"  To: {to_email}")
+            self.stdout.write(f"  Subject: {subject}")
+            self.stdout.write(f"  Body: {body[:100]}{'...' if len(body) > 100 else ''}")
+            self.stdout.write(f"  MIME ID: {mime_id}")
+            self.stdout.write(
+                f"  DKIM: {'Signed' if dkim_signature_header else 'Not signed (no mailbox/DKIM configured)'}"
+            )
+            return
+
+        # Send the message using send_outbound_email
+        recipient_emails = {to_email}
+        statuses = send_outbound_email(
+            recipient_emails, from_email, raw_mime_signed, custom_attributes
+        )
+
+        # Display results
+        for recipient_email, status in statuses.items():
+            if status["delivered"]:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"✓ Email sent successfully to {recipient_email}"
+                    )
+                )
+            else:
+                error_msg = status.get("error", "Unknown error")
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"✗ Failed to send email to {recipient_email}: {error_msg}"
+                    )
+                )
+                if status.get("retry", False):
+                    self.stdout.write(
+                        f"✗ Temporary failure - would be retried. Error : {error_msg}"
+                    )

--- a/src/backend/core/management/commands/send_mail.py
+++ b/src/backend/core/management/commands/send_mail.py
@@ -6,9 +6,9 @@ Usage examples:
     # Send a simple email (works without any mailboxes)
     python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World"
     
-    # Send with custom sender and log level
+    # Send with custom sender
     python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World" \
-        --from sender@mydomain.com --log-level DEBUG
+        --from sender@mydomain.com
     
     # Dry run to see what would be sent
     python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World" --dry-run
@@ -21,12 +21,13 @@ import uuid
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand, CommandError
 from django.core.validators import validate_email
-from django.utils import timezone
 
 from core import models
 from core.mda.outbound import send_outbound_email
 from core.mda.rfc5322 import compose_email
 from core.mda.signing import sign_message_dkim
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -58,24 +59,12 @@ class Command(BaseCommand):
             dest="from_email",
         )
         parser.add_argument(
-            "--log-level",
-            type=str,
-            choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-            default="INFO",
-            help="Logging level (default: INFO)",
-        )
-        parser.add_argument(
             "--dry-run",
             action="store_true",
             help="Show what would be sent without actually sending the email",
         )
 
     def handle(self, *args, **options):
-        # Configure logging
-        log_level = getattr(logging, options["log_level"].upper())
-        logging.basicConfig(level=log_level)
-        logger = logging.getLogger(__name__)
-
         to_email = options["to"]
         subject = options["subject"]
         body = options["body"]
@@ -131,7 +120,6 @@ class Command(BaseCommand):
         # Generate MIME content
         mime_data = {
             "from": [{"name": from_name, "email": from_email}],
-            "date": timezone.now().strftime("%a, %d %b %Y %H:%M:%S %z"),
             "to": [{"name": to_email.split("@")[0], "email": to_email}],
             "cc": [],
             "subject": subject,

--- a/src/backend/core/mda/outbound_direct.py
+++ b/src/backend/core/mda/outbound_direct.py
@@ -89,8 +89,8 @@ def select_smtp_proxy() -> Dict[str, Any]:
     """
     Select an SMTP proxy to use for sending messages.
     """
-    if len(settings.MTA_OUT_PROXIES) > 0:
-        proxy = random.choice(settings.MTA_OUT_PROXIES)  # noqa: S311
+    if len(settings.MTA_OUT_DIRECT_PROXIES) > 0:
+        proxy = random.choice(settings.MTA_OUT_DIRECT_PROXIES)  # noqa: S311
         parsed = urlparse(proxy)
         return {
             "proxy_host": parsed.hostname,
@@ -102,7 +102,7 @@ def select_smtp_proxy() -> Dict[str, Any]:
     return {}
 
 
-def send_message_via_mx(envelope_from, envelope_to, mime_data) -> Dict[str, Any]:
+def send_message_via_mx(envelope_from, recipient_emails, mime_data) -> Dict[str, Any]:
     """
     Send a message to external recipients by resolving MX and delivering via SMTP.
     Implements MX fallback logic: tries each MX in priority order, retrying failed
@@ -111,7 +111,7 @@ def send_message_via_mx(envelope_from, envelope_to, mime_data) -> Dict[str, Any]
     """
 
     final_statuses = {}
-    domain_groups = group_recipients_by_mx(list(envelope_to.keys()))
+    domain_groups = group_recipients_by_mx(recipient_emails)
 
     for domain, domain_info in domain_groups.items():
         mx_records = domain_info["mx_records"]

--- a/src/backend/core/mda/rfc5322/composer.py
+++ b/src/backend/core/mda/rfc5322/composer.py
@@ -658,7 +658,7 @@ def _embed_original_message(
             else:
                 # For replies, quote each line
                 quoted_text = "\r\n".join(
-                    [f"> {line}" for line in orig_text.split("\r\n")]
+                    [f"> {line}" for line in orig_text.splitlines()]
                 )
                 text_body += quoted_text
 

--- a/src/backend/core/mda/rfc5322/composer.py
+++ b/src/backend/core/mda/rfc5322/composer.py
@@ -527,7 +527,7 @@ def compose_email(
         message_str = msg_part.to_string()
 
         # Flanker doesn't enforce line length limits or CRLF conversion
-        # so we have to re-encode the message here to say RFC compliant
+        # so we have to re-encode the message here to stay RFC compliant
         msg = message_from_string(message_str)
         out = BytesIO()
         gen = BytesGenerator(out, policy=email_policy_smtp.clone(max_line_length=76))

--- a/src/backend/core/mda/rfc5322/composer.py
+++ b/src/backend/core/mda/rfc5322/composer.py
@@ -12,7 +12,11 @@ import binascii
 import datetime
 import html
 import logging
+from email import message_from_string
+from email.generator import BytesGenerator
+from email.policy import SMTP as email_policy_smtp
 from email.utils import format_datetime, parsedate_to_datetime
+from io import BytesIO
 from typing import Any, Dict, List, Optional
 
 from django.utils import timezone
@@ -522,10 +526,16 @@ def compose_email(
         # Convert the top-level part to string
         message_str = msg_part.to_string()
 
-        # Convert string to bytes using UTF-8
-        message_bytes = message_str.encode("utf-8")
+        # Flanker doesn't enforce line length limits or CRLF conversion
+        # so we have to re-encode the message here to say RFC compliant
+        msg = message_from_string(message_str)
+        out = BytesIO()
+        gen = BytesGenerator(out, policy=email_policy_smtp.clone(max_line_length=76))
+        gen.flatten(msg)
+        message_bytes = out.getvalue()
 
         return message_bytes
+
     except mime_errors.MimeError as e:
         # Catch flanker specific errors during composition/string conversion
         logger.error(
@@ -606,24 +616,24 @@ def _embed_original_message(
         to_display = format_address_list(orig_to)
         cc_display = format_address_list(orig_cc) if orig_cc else ""
 
-        header_text = "\n\n---------- Forwarded message ----------\n"
+        header_text = "\r\n\r\n---------- Forwarded message ----------\r\n"
         if from_display:
-            header_text += f"From: {from_display}\n"
+            header_text += f"From: {from_display}\r\n"
         if to_display:
-            header_text += f"To: {to_display}\n"
+            header_text += f"To: {to_display}\r\n"
         if cc_display:
-            header_text += f"Cc: {cc_display}\n"
-        header_text += f"Subject: {orig_subject}\n"
-        header_text += f"Date: {date_str}\n\n"
+            header_text += f"Cc: {cc_display}\r\n"
+        header_text += f"Subject: {orig_subject}\r\n"
+        header_text += f"Date: {date_str}\r\n\r\n"
     else:
         # Reply format
         from_display = format_address(
             orig_from.get("name", ""), orig_from.get("email", "")
         )
         if from_display:
-            header_text = f"\n\nOn {date_str}, {from_display} wrote:\n"
+            header_text = f"\r\n\r\nOn {date_str}, {from_display} wrote:\r\n"
         else:
-            header_text = f"\n\nOn {date_str}, someone wrote:\n"
+            header_text = f"\r\n\r\nOn {date_str}, someone wrote:\r\n"
 
     # Create the text body with original message
     text_body = f"{new_text}{header_text}"
@@ -647,7 +657,9 @@ def _embed_original_message(
                 text_body += orig_text
             else:
                 # For replies, quote each line
-                quoted_text = "\n".join([f"> {line}" for line in orig_text.split("\n")])
+                quoted_text = "\r\n".join(
+                    [f"> {line}" for line in orig_text.split("\r\n")]
+                )
                 text_body += quoted_text
 
     # Create HTML content

--- a/src/backend/core/tests/mda/test_outbound.py
+++ b/src/backend/core/tests/mda/test_outbound.py
@@ -71,10 +71,10 @@ class TestSendOutboundMessage:
     @patch("core.mda.outbound.send_smtp_mail")  # Mock SMTP client
     @override_settings(
         MTA_OUT_MODE="relay",
-        MTA_OUT_SMTP_HOST="smtp.test:1025",
+        MTA_OUT_RELAY_HOST="smtp.test:1025",
         # Ensure other auth settings are None for this test
-        MTA_OUT_SMTP_USERNAME="smtp_user",
-        MTA_OUT_SMTP_PASSWORD="smtp_pass",
+        MTA_OUT_RELAY_USERNAME="smtp_user",
+        MTA_OUT_RELAY_PASSWORD="smtp_pass",
         OPENSEARCH_INDEX_THREADS=False,
     )
     def test_outbound_send_relay(self, mock_smtp_send, draft_message):
@@ -149,7 +149,7 @@ class TestSendOutboundMessage:
     @patch("core.mda.outbound_direct.send_smtp_mail")
     @override_settings(
         MTA_OUT_MODE="direct",
-        MTA_OUT_PROXIES=["socks5://proxyuser:proxyuser@smtp.proxy:1080"],
+        MTA_OUT_DIRECT_PROXIES=["socks5://proxyuser:proxyuser@smtp.proxy:1080"],
         OPENSEARCH_INDEX_THREADS=False,
     )
     def test_outbound_send_direct(self, mock_smtp_send, mock_resolve, draft_message):

--- a/src/backend/core/tests/mda/test_outbound_e2e.py
+++ b/src/backend/core/tests/mda/test_outbound_e2e.py
@@ -101,7 +101,7 @@ class TestE2EMessageOutboundFlow:
 
     @override_settings(
         MTA_OUT_MODE="relay",
-        MTA_OUT_SMTP_HOST="mailcatcher:1025",
+        MTA_OUT_RELAY_HOST="mailcatcher:1025",
     )
     def test_draft_send_receive_verify_relay(
         self, mailbox, sender_contact, authenticated_user

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
+import logging
 import os
 import tomllib
 from socket import gethostbyname, gethostname
@@ -22,6 +23,8 @@ from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from core.utils import JSONValue
+
+logger = logging.getLogger(__name__)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -163,23 +166,30 @@ class Base(Configuration):
     MTA_OUT_MODE = values.Value(
         "direct", environ_name="MTA_OUT_MODE", environ_prefix=None
     )
-    # List of proxies for the direct outbound MTA
-    MTA_OUT_PROXIES = values.ListValue(
-        [], environ_name="MTA_OUT_PROXIES", environ_prefix=None
+
+    # SMTP settings for the direct outbound MTA
+    MTA_OUT_DIRECT_PROXIES = values.ListValue(
+        [], environ_name="MTA_OUT_DIRECT_PROXIES", environ_prefix=None
     )
     MTA_OUT_DIRECT_PORT = values.PositiveIntegerValue(
         25, environ_name="MTA_OUT_DIRECT_PORT", environ_prefix=None
     )
 
     # SMTP settings for external SMTP servers, if MTA_OUT_MODE="relay"
-    MTA_OUT_SMTP_HOST = values.Value(
-        None, environ_name="MTA_OUT_SMTP_HOST", environ_prefix=None
+    MTA_OUT_RELAY_HOST = values.Value(
+        None, environ_name="MTA_OUT_RELAY_HOST", environ_prefix=None
     )
-    MTA_OUT_SMTP_USERNAME = values.Value(
-        None, environ_name="MTA_OUT_SMTP_USERNAME", environ_prefix=None
+    MTA_OUT_RELAY_USERNAME = values.Value(
+        None, environ_name="MTA_OUT_RELAY_USERNAME", environ_prefix=None
     )
-    MTA_OUT_SMTP_PASSWORD = values.Value(
-        None, environ_name="MTA_OUT_SMTP_PASSWORD", environ_prefix=None
+    MTA_OUT_RELAY_PASSWORD = values.Value(
+        None, environ_name="MTA_OUT_RELAY_PASSWORD", environ_prefix=None
+    )
+
+    # SMTP settings for both modes
+    # We support a subset of https://www.postfix.org/postconf.5.html#smtp_tls_security_level
+    MTA_OUT_SMTP_TLS_SECURITY_LEVEL = values.Value(
+        "may", environ_name="MTA_OUT_SMTP_TLS_SECURITY_LEVEL", environ_prefix=None
     )
 
     # Test domain settings
@@ -697,6 +707,19 @@ class Base(Configuration):
                 *self.MIDDLEWARE,
                 "django_prometheus.middleware.PrometheusAfterMiddleware",
             ]
+        if os.environ.get("MTA_OUT_SMTP_HOST") and not self.MTA_OUT_RELAY_HOST:
+            logger.warning(
+                "MTA_OUT_SMTP_HOST is deprecated, use MTA_OUT_RELAY_HOST instead"
+            )
+            self.MTA_OUT_RELAY_HOST = values.Value(
+                None, environ_name="MTA_OUT_SMTP_HOST", environ_prefix=None
+            )
+            self.MTA_OUT_RELAY_USERNAME = values.Value(
+                None, environ_name="MTA_OUT_SMTP_USERNAME", environ_prefix=None
+            )
+            self.MTA_OUT_RELAY_PASSWORD = values.Value(
+                None, environ_name="MTA_OUT_SMTP_PASSWORD", environ_prefix=None
+            )
 
     # pylint: disable=invalid-name
     @property

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -711,16 +711,9 @@ class Base(Configuration):
             logger.warning(
                 "MTA_OUT_SMTP_HOST is deprecated, use MTA_OUT_RELAY_HOST instead"
             )
-            self.MTA_OUT_RELAY_HOST = values.Value(
-                None, environ_name="MTA_OUT_SMTP_HOST", environ_prefix=None
-            )
-            self.MTA_OUT_RELAY_USERNAME = values.Value(
-                None, environ_name="MTA_OUT_SMTP_USERNAME", environ_prefix=None
-            )
-            self.MTA_OUT_RELAY_PASSWORD = values.Value(
-                None, environ_name="MTA_OUT_SMTP_PASSWORD", environ_prefix=None
-            )
-
+            self.MTA_OUT_RELAY_HOST = os.environ.get("MTA_OUT_SMTP_HOST")
+            self.MTA_OUT_RELAY_USERNAME = os.environ.get("MTA_OUT_SMTP_USERNAME")
+            self.MTA_OUT_RELAY_PASSWORD = os.environ.get("MTA_OUT_SMTP_PASSWORD")
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -707,6 +707,7 @@ class Base(Configuration):
                 *self.MIDDLEWARE,
                 "django_prometheus.middleware.PrometheusAfterMiddleware",
             ]
+
         if os.environ.get("MTA_OUT_SMTP_HOST") and not self.MTA_OUT_RELAY_HOST:
             logger.warning(
                 "MTA_OUT_SMTP_HOST is deprecated, use MTA_OUT_RELAY_HOST instead"
@@ -714,6 +715,12 @@ class Base(Configuration):
             self.MTA_OUT_RELAY_HOST = os.environ.get("MTA_OUT_SMTP_HOST")
             self.MTA_OUT_RELAY_USERNAME = os.environ.get("MTA_OUT_SMTP_USERNAME")
             self.MTA_OUT_RELAY_PASSWORD = os.environ.get("MTA_OUT_SMTP_PASSWORD")
+
+        if self.MTA_OUT_SMTP_TLS_SECURITY_LEVEL not in {"none", "may", "encrypt"}:
+            raise ValueError(
+                f"Invalid MTA_OUT_SMTP_TLS_SECURITY_LEVEL: {self.MTA_OUT_SMTP_TLS_SECURITY_LEVEL}"
+            )
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):


### PR DESCRIPTION
This fixes delivery errors seen in the wild where:
 * Some servers advertise STARTTLS but have broken certificates. Because of this, we follow Postfix's recommendation to use opportunistic TLS by default.
 * As we are sending emails straight to other SMTPs in direct mode, we need to have stricter RFC compliance for our raw mime DATA, namely CRLF endings and maximum line length. This was transparently done by Postfix in relay mode. Some env vars have also been renamed for clarity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New backend email send command with dry-run and optional DKIM.
  - SMTP TLS security level option (“may”/“none”) with graceful fallback.
  - RFC-compliant email composition with CRLF line endings and improved line wrapping.

- Documentation
  - Added example for sending via backend relay.
  - Updated environment configuration guidance and TLS setting details.

- Chores
  - Renamed env vars: MTA_OUT_SMTP_* → MTA_OUT_RELAY_*, MTA_OUT_PROXIES → MTA_OUT_DIRECT_PROXIES.
  - Updated defaults and added backward-compatible deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->