### PR TITLE
🚸(frontend) inform user when its session expired

### DIFF
--- a/src/frontend/src/features/api/fetch-api.ts
+++ b/src/frontend/src/features/api/fetch-api.ts
@@ -1,6 +1,7 @@
 // Inspired by https://github.com/orval-labs/orval/blob/master/samples/next-app-with-fetch/custom-fetch.ts
 
 import { logout } from "../auth";
+import { SESSION_EXPIRED_KEY } from "../config/constants";
 import { APIError } from "./api-error";
 import { getHeaders, getRequestUrl, isJson } from "./utils";
 
@@ -22,6 +23,7 @@ export const fetchAPI= async <T>(
   });
 
   if ((logoutOn401 ?? true) && response.status === 401) {
+    sessionStorage.setItem(SESSION_EXPIRED_KEY, 'true');
     logout();
   }
 

--- a/src/frontend/src/features/config/constants.ts
+++ b/src/frontend/src/features/config/constants.ts
@@ -8,3 +8,7 @@ export enum PORTALS {
 
 // Default page size for the API
 export const DEFAULT_PAGE_SIZE = 20;
+
+// Session storage keys
+const STORAGE_PREFIX = "messages_";
+export const SESSION_EXPIRED_KEY = STORAGE_PREFIX + "session_expired";

--- a/src/frontend/src/features/i18n/translations.json
+++ b/src/frontend/src/features/i18n/translations.json
@@ -8,6 +8,7 @@
       "no_mailbox": "No mailbox.",
       "no_threads": "No threads.",
       "mailbox": "Mailbox",
+      "session_expired": "Your session has expired. Please log in again.",
       "new_message_form": {
         "title": "New message"
       },
@@ -585,6 +586,7 @@
       "no_mailbox": "Aucune boîte aux lettres.",
       "no_threads": "Aucune conversation.",
       "mailbox": "Boîte aux lettres",
+      "session_expired": "Votre session a expiré. Veuillez vous reconnecter.",
       "new_message_form": {
         "title": "Nouveau message"
       },


### PR DESCRIPTION
## Purpose

When a request failed with a 401, the user is redirected to the home page. Currently no message is displayed to explain why it has been redirected that is weird. So now, a toast is displayed to explain that.


https://github.com/user-attachments/assets/f2e36755-b721-42b7-b271-cd698616dddf




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatically logs users out on unauthorized responses and marks the session as expired.
  * Displays a one-time informational toast on app load when a previous session expired.
* Chores
  * Added translation strings for the session-expired message in English and French.
  * Adjusted authentication data fetch to avoid triggering global error handling for that request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->