### PR TITLE
🩹(Signature) remove unnecessary wrap signature in paragraph

### DIFF
--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -84,7 +84,7 @@ def prepare_outbound_message(
                     else signatures["text_body"]
                 )
                 html_body = (
-                    html_body + "<p>" + signatures["html_body"] + "</p>"
+                    html_body + signatures["html_body"]
                     if html_body
                     else signatures["html_body"]
                 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email signatures now render without an extra paragraph wrapper, eliminating unintended extra spacing.
  * Signatures integrate seamlessly with the message body, preserving original formatting and alignment.
  * Improves visual consistency across email clients, replies, and forwards.
  * Results in a cleaner appearance with reduced chances of double spacing or layout glitches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->