### PR TITLE
🚸(frontend) display percentage as import progress

### DIFF
--- a/src/frontend/src/features/controlled-modals/message-importer/_index.scss
+++ b/src/frontend/src/features/controlled-modals/message-importer/_index.scss
@@ -94,6 +94,10 @@
     }
 }
 
+.task-loader__progress_resume {
+    font-variant-numeric: tabular-nums;
+}
+
 .importer-completed {
     display: flex;
     flex-direction: column;

--- a/src/frontend/src/features/controlled-modals/message-importer/step-loader.tsx
+++ b/src/frontend/src/features/controlled-modals/message-importer/step-loader.tsx
@@ -56,13 +56,7 @@ export const StepLoader = ({ taskId, onComplete, onError }: StepLoaderProps) => 
             <p className="task-loader__progress_resume">
                 <strong>
                     {   progress
-                        ? t(
-                            '{{count}} messages imported on {{total}}',
-                            {
-                                count: taskMetadata!.current_message,
-                                total: taskMetadata!.total_messages,
-                                defaultValue_one: '{{count}} message imported on {{total}}'
-                            })
+                        ? t('{{progress}}% imported', { progress: Math.ceil(progress) })
                         : t('Importing...')
                     }
                 </strong>

--- a/src/frontend/src/features/ui/components/contact-chip/index.tsx
+++ b/src/frontend/src/features/ui/components/contact-chip/index.tsx
@@ -48,7 +48,7 @@ export const ContactChip = ({ contact, showWarning = false }: ContactChipProps) 
 
     if (showWarning) {
         return (
-            <Tooltip content={t('This contact cannot be trusted. Be careful when interacting with this contact.')}>
+            <Tooltip content={t('This contact cannot be trusted. Be careful when interacting with it.')}>
                 {chipContent}
             </Tooltip>
         );


### PR DESCRIPTION
## Purpose

Currently we are displaying the number of message imports over the total to import. According to the import source, the total count cannot be exact as some message can be count twice, etc. So in order to reduce confusion about the final import state we now display progress as percentage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Message import progress now displays as a percentage (e.g., “42% imported”) for clearer at-a-glance status.

- Style
  - Applied tabular numeric styling to progress values for steadier number alignment during updates.
  - Updated warning tooltip copy on contact chips to “interacting with it” for clearer, more concise messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->