### PR TITLE
✨(template) CRUD for mailbox message templates

### DIFF
--- a/src/backend/core/api/openapi.json
+++ b/src/backend/core/api/openapi.json
@@ -2280,6 +2280,96 @@
                 }
             }
         },
+        "/api/v1.0/mailboxes/{mailbox_id}/message-templates/": {
+            "get": {
+                "operationId": "mailboxes_message_templates_list",
+                "description": "ViewSet for retrieving and rendering message templates for a mailbox.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "mailbox_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "mailboxes"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MessageTemplate"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "mailboxes_message_templates_create",
+                "description": "ViewSet for retrieving and rendering message templates for a mailbox.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "mailbox_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "mailboxes"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MessageTemplateRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MessageTemplateRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageTemplate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1.0/mailboxes/{mailbox_id}/message-templates/{id}/": {
             "get": {
                 "operationId": "mailboxes_message_templates_retrieve",
@@ -2316,11 +2406,162 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ReadOnlyMessageTemplate"
+                                    "$ref": "#/components/schemas/MessageTemplate"
                                 }
                             }
                         },
                         "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "mailboxes_message_templates_update",
+                "description": "ViewSet for retrieving and rendering message templates for a mailbox.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "mailbox_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "mailboxes"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MessageTemplateRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MessageTemplateRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageTemplate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "mailboxes_message_templates_partial_update",
+                "description": "ViewSet for retrieving and rendering message templates for a mailbox.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "mailbox_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "mailboxes"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMessageTemplateRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMessageTemplateRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageTemplate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "mailboxes_message_templates_destroy",
+                "description": "ViewSet for retrieving and rendering message templates for a mailbox.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "mailbox_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "mailboxes"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
                     }
                 }
             }

--- a/src/backend/core/tests/api/test_mailbox_message_template.py
+++ b/src/backend/core/tests/api/test_mailbox_message_template.py
@@ -1,0 +1,541 @@
+"""Test CRUD operations for MailboxMessageTemplateViewSet."""
+
+import json
+
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import enums, factories, models
+from core.tests.api.conftest import MESSAGE_TEMPLATE_RAW_DATA as RAW_DATA_STRUCT
+from core.tests.api.conftest import MESSAGE_TEMPLATE_RAW_DATA_JSON as RAW_DATA
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(name="user")
+def fixture_user():
+    """Create a test user."""
+    return factories.UserFactory(
+        full_name="John Doe", custom_attributes={"job_title": "Adjointe"}
+    )
+
+
+@pytest.fixture(name="mailbox")
+def fixture_mailbox():
+    """Create a test mailbox."""
+    return factories.MailboxFactory()
+
+
+@pytest.fixture(name="mailbox_template")
+def fixture_mailbox_template(mailbox):
+    """Create a test template for a mailbox."""
+    return factories.MessageTemplateFactory(
+        html_body="<p>Template Content</p>",
+        text_body="Template Content",
+        mailbox=mailbox,
+    )
+
+
+@pytest.fixture(name="list_url")
+def fixture_list_url(mailbox):
+    """Url to list message templates for a mailbox."""
+    return reverse(
+        "mailbox-message-templates-list",
+        kwargs={"mailbox_id": mailbox.id},
+    )
+
+
+@pytest.fixture(name="detail_url")
+def fixture_detail_url(mailbox):
+    """Url to get a message template for a mailbox."""
+    return lambda template_id: reverse(
+        "mailbox-message-templates-detail",
+        kwargs={"mailbox_id": mailbox.id, "pk": template_id},
+    )
+
+
+class TestMailboxMessageTemplateList:
+    """Test list operations for MailboxMessageTemplateViewSet."""
+
+    def test_unauthorized(self, list_url):
+        """Test that unauthenticated users cannot list templates."""
+        client = APIClient()
+        response = client.get(list_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_forbidden(self, user, list_url):
+        """Test that users without mailbox access cannot list templates."""
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get(list_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_list_templates(self, user, mailbox, list_url):
+        """Test listing all templates."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+
+        reply_template = factories.MessageTemplateFactory(
+            name="Reply Template",
+            html_body="<p>Reply content</p>",
+            text_body="Reply content",
+            type=enums.MessageTemplateTypeChoices.REPLY,
+            mailbox=mailbox,
+        )
+        new_message_template = factories.MessageTemplateFactory(
+            name="New Message Template",
+            html_body="<p>New message content</p>",
+            text_body="New message content",
+            type=enums.MessageTemplateTypeChoices.NEW_MESSAGE,
+            mailbox=mailbox,
+        )
+        signature_template = factories.MessageTemplateFactory(
+            name="Signature Template",
+            html_body="<p>Signature content</p>",
+            text_body="Signature content",
+            type=enums.MessageTemplateTypeChoices.SIGNATURE,
+            mailbox=mailbox,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(list_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 3
+        templates_by_type = {t["type"]: t for t in response.data}
+        assert templates_by_type["signature"]["id"] == str(signature_template.id)
+        assert templates_by_type["reply"]["id"] == str(reply_template.id)
+        assert templates_by_type["new_message"]["id"] == str(new_message_template.id)
+
+    def test_filter_by_type(self, user, mailbox, list_url):
+        """Test filtering list by template type."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+        reply_template = factories.MessageTemplateFactory(
+            name="Reply Template",
+            html_body="<p>Reply content</p>",
+            text_body="Reply content",
+            type=enums.MessageTemplateTypeChoices.REPLY,
+            mailbox=mailbox,
+        )
+        new_message_template = factories.MessageTemplateFactory(
+            name="New Message Template",
+            html_body="<p>New message content</p>",
+            text_body="New message content",
+            type=enums.MessageTemplateTypeChoices.NEW_MESSAGE,
+            mailbox=mailbox,
+        )
+        signature_template = factories.MessageTemplateFactory(
+            name="Signature Template",
+            html_body="<p>Signature content</p>",
+            text_body="Signature content",
+            type=enums.MessageTemplateTypeChoices.SIGNATURE,
+            mailbox=mailbox,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get(list_url, {"type": "reply"})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["type"] == "reply"
+        assert response.data[0]["id"] == str(reply_template.id)
+
+        response = client.get(list_url, {"type": ["new_message"]})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["type"] == "new_message"
+        assert response.data[0]["id"] == str(new_message_template.id)
+
+        response = client.get(list_url, {"type": ["signature"]})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["type"] == "signature"
+        assert response.data[0]["id"] == str(signature_template.id)
+
+        response = client.get(list_url, {"type": ["reply", "new_message", "signature"]})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 3
+        templates_by_type = {t["type"]: t for t in response.data}
+        assert templates_by_type["signature"]["id"] == str(signature_template.id)
+        assert templates_by_type["reply"]["id"] == str(reply_template.id)
+        assert templates_by_type["new_message"]["id"] == str(new_message_template.id)
+
+        # test with invalid type
+        response = client.get(list_url, {"type": ["reply", "invalid_type"]})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["type"] == "reply"
+        assert response.data[0]["id"] == str(reply_template.id)
+
+
+class TestMailboxMessageTemplateCreate:
+    """Test create operations for MailboxMessageTemplateViewSet."""
+
+    def test_unauthorized(self, list_url):
+        """Test that unauthorized users cannot create templates."""
+        client = APIClient()
+
+        data = {
+            "name": "Test Template",
+            "type": "reply",
+            "html_body": "<p>Hello {recipient_name}</p>",
+            "text_body": "Hello {recipient_name}",
+            "raw_body": RAW_DATA,
+            "is_active": True,
+        }
+        response = client.post(
+            list_url,
+            data,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_forbidden(self, user, list_url):
+        """Test that users without proper role cannot create templates."""
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        data = {
+            "name": "Test Template",
+            "html_body": "<p>Hello {recipient_name}</p>",
+            "text_body": "Hello {recipient_name}",
+            "raw_body": RAW_DATA,
+            "type": "reply",
+            "is_active": True,
+        }
+
+        response = client.post(
+            list_url,
+            data,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_success(self, user, mailbox, list_url):
+        """Test creating a new template."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        data = {
+            "name": "Test Template Signature",
+            "html_body": "<hr />\n<p>{name} - Mairie de Brigny</p>",
+            "is_active": True,
+            "raw_body": RAW_DATA,
+            "text_body": "----\n\n{name} - Mairie de Brigny\n",
+            "type": "signature",
+        }
+        response = client.post(
+            list_url,
+            data,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["name"] == "Test Template Signature"
+        assert response.data["type"] == "signature"
+        assert "- Mairie de Brigny" in response.data["raw_body"]
+
+        # check template and blob are created
+        assert models.MessageTemplate.objects.count() == 1
+        assert models.Blob.objects.count() == 1
+        template = models.MessageTemplate.objects.get()
+        assert template.mailbox == mailbox
+        content = json.loads(template.blob.get_content().decode("utf-8"))
+        assert content["raw"] == RAW_DATA_STRUCT
+
+    def test_create_with_mailbox_and_maildomain_in_payload(
+        self, user, mailbox, list_url
+    ):
+        """Test creating a template with mailbox and maildomain in payload but only mailbox is used from the context."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+        factories.MailDomainAccessFactory(
+            maildomain=mailbox.domain,
+            user=user,
+            role=enums.MailDomainAccessRoleChoices.ADMIN,
+        )
+        other_mailbox = factories.MailboxFactory()
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        data = {
+            "name": "Test Template",
+            "html_body": "<p>Content</p>",
+            "text_body": "Content",
+            "raw_body": RAW_DATA,
+            "type": "signature",
+            "mailbox": str(other_mailbox.id),
+            "maildomain": str(mailbox.domain.id),
+        }
+        response = client.post(list_url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        template = models.MessageTemplate.objects.get()
+        # mailbox is used from the context
+        assert template.mailbox == mailbox
+        assert not template.maildomain
+        assert template.name == "Test Template"
+
+
+class TestMailboxMessageTemplateUpdate:
+    """Test update operations for MailboxMessageTemplateViewSet."""
+
+    def test_unauthorized(self, mailbox_template, detail_url):
+        """Test that unauthorized users cannot update templates."""
+        client = APIClient()
+
+        data = {
+            "name": "Updated Template",
+        }
+
+        response = client.put(
+            detail_url(mailbox_template.id),
+            data,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+        # Verify template was not updated
+        mailbox_template.refresh_from_db()
+        assert mailbox_template.name != "Updated Template"
+
+    def test_forbidden(self, user, mailbox_template, detail_url):
+        """Test that users without proper role cannot update templates."""
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        data = {
+            "name": "Updated Template",
+        }
+
+        response = client.put(
+            detail_url(mailbox_template.id),
+            data,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        # Verify template was not updated
+        mailbox_template.refresh_from_db()
+        assert mailbox_template.name != "Updated Template"
+
+    def test_cannot_change_mailbox(self, user, mailbox, mailbox_template, detail_url):
+        """Test that we cannot change the mailbox of a template."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+
+        # Create another mailbox
+        other_mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=other_mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        data = {
+            "name": "Updated Template",
+            "html_body": "<p>Updated content</p>",
+            "text_body": "Updated content",
+            "raw_body": RAW_DATA,
+            "type": "reply",
+            "is_active": False,
+            "is_forced": False,
+            "mailbox": str(other_mailbox.id),
+        }
+
+        response = client.put(
+            detail_url(mailbox_template.id),
+            data,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # Verify template was not updated
+        mailbox_template.refresh_from_db()
+        assert mailbox_template.mailbox == mailbox
+        assert mailbox_template.name == "Updated Template"
+
+    def test_success(self, user, mailbox, mailbox_template, detail_url):
+        """Test updating a template."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        data = {
+            "name": "Updated Template",
+            "html_body": "<p>Updated content</p>",
+            "text_body": "Updated content",
+            "raw_body": RAW_DATA,
+            "type": "reply",
+            "is_active": False,
+            "is_forced": False,
+        }
+
+        response = client.put(
+            detail_url(mailbox_template.id),
+            data,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["name"] == "Updated Template"
+        assert response.data["type"] == "reply"
+        assert response.data["is_active"] is False
+
+        # check that the blob was updated
+        mailbox_template.refresh_from_db()
+        content = json.loads(mailbox_template.blob.get_content().decode("utf-8"))
+        assert content["raw"] == RAW_DATA_STRUCT
+
+
+class TestMailboxMessageTemplateDelete:
+    """Test delete operations for MailboxMessageTemplateViewSet."""
+
+    def test_unauthorized(self, mailbox_template, detail_url):
+        """Test that unauthorized users cannot delete templates."""
+        client = APIClient()
+
+        response = client.delete(
+            detail_url(mailbox_template.id),
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+        # Verify template still exists
+        assert models.MessageTemplate.objects.filter(id=mailbox_template.id).exists()
+
+    def test_forbidden(self, user, mailbox_template, detail_url):
+        """Test that users without proper role cannot delete templates."""
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete(
+            detail_url(mailbox_template.id),
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert models.MessageTemplate.objects.filter(id=mailbox_template.id).exists()
+
+    def test_success(self, user, mailbox, mailbox_template, detail_url):
+        """Test deleting a template."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete(
+            detail_url(mailbox_template.id),
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not models.MessageTemplate.objects.filter(
+            id=mailbox_template.id
+        ).exists()
+
+        # Verify template is deleted
+        response = client.get(
+            detail_url(mailbox_template.id),
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestMailboxMessageTemplateRetrieve:
+    """Test retrieve operations for MailboxMessageTemplateViewSet."""
+
+    def test_unauthorized(self, mailbox_template, detail_url):
+        """Test that unauthenticated users cannot retrieve templates."""
+        client = APIClient()
+        response = client.get(detail_url(mailbox_template.id))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_forbidden(self, user, mailbox_template, detail_url):
+        """Test that users without mailbox access cannot retrieve templates."""
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get(detail_url(mailbox_template.id))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_success(self, user, mailbox, mailbox_template, detail_url):
+        """Test retrieving a single template."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get(detail_url(mailbox_template.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["id"] == str(mailbox_template.id)
+        assert response.data["name"] == mailbox_template.name
+
+
+class TestMailboxMessageTemplatePartialUpdate:
+    """Test partial update (PATCH) operations for MailboxMessageTemplateViewSet."""
+
+    def test_unauthorized(self, mailbox_template, detail_url):
+        """Test that unauthorized users cannot partially update templates."""
+        client = APIClient()
+        response = client.patch(
+            detail_url(mailbox_template.id), {"name": "Patched Name"}, format="json"
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_forbidden(self, user, mailbox_template, detail_url):
+        """Test that users without proper role cannot partially update templates."""
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.patch(
+            detail_url(mailbox_template.id), {"name": "Patched Name"}, format="json"
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_success_patch_name_only(self, user, mailbox, mailbox_template, detail_url):
+        """Test partially updating only the name field."""
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.patch(
+            detail_url(mailbox_template.id),
+            {"name": "Patched Name"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["name"] == "Patched Name"
+
+        # Verify other fields unchanged
+        mailbox_template.refresh_from_db()
+        assert mailbox_template.name == "Patched Name"

--- a/src/backend/core/tests/api/test_message_template_render.py
+++ b/src/backend/core/tests/api/test_message_template_render.py
@@ -1,5 +1,6 @@
 """Test render action for MessageTemplateViewSet."""
 
+import uuid
 from unittest.mock import patch
 
 from django.urls import reverse
@@ -162,6 +163,22 @@ class TestMessageTemplateRender:
         assert response.status_code == status.HTTP_200_OK
         assert "Cordialement, John Doe - Adjointe" in response.data["html_body"]
         assert "Cordialement, John Doe - Adjointe" in response.data["text_body"]
+
+    def test_render_template_no_access_mailbox(self, user, mailbox):
+        """Test rendering a template from a mailbox that doesn't exist."""
+        client = APIClient()
+        client.force_authenticate(user=user)
+        mailbox_template = factories.MessageTemplateFactory(
+            name="Mailbox Test Template",
+            mailbox=mailbox,
+        )
+        response = client.get(
+            reverse(
+                "mailbox-message-templates-render-template",
+                kwargs={"mailbox_id": uuid.uuid4(), "pk": mailbox_template.id},
+            )
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_render_template_not_found(self, user, mailbox):
         """Test rendering a non-existent template."""

--- a/src/frontend/src/features/api/gen/mailboxes/mailboxes.ts
+++ b/src/frontend/src/features/api/gen/mailboxes/mailboxes.ts
@@ -5,15 +5,18 @@
  * This is the messages API schema.
  * OpenAPI spec version: 1.0.0 (v1.0)
  */
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type {
   DataTag,
   DefinedInitialDataOptions,
   DefinedUseQueryResult,
+  MutationFunction,
   QueryClient,
   QueryFunction,
   QueryKey,
   UndefinedInitialDataOptions,
+  UseMutationOptions,
+  UseMutationResult,
   UseQueryOptions,
   UseQueryResult,
 } from "@tanstack/react-query";
@@ -24,6 +27,9 @@ import type {
   MailboxesMessageTemplatesAvailableListParams,
   MailboxesMessageTemplatesRenderRetrieve200,
   MailboxesSearchListParams,
+  MessageTemplate,
+  MessageTemplateRequest,
+  PatchedMessageTemplateRequest,
   ReadOnlyMessageTemplate,
 } from ".././models";
 
@@ -179,8 +185,303 @@ export function useMailboxesList<
 /**
  * ViewSet for retrieving and rendering message templates for a mailbox.
  */
+export type mailboxesMessageTemplatesListResponse200 = {
+  data: MessageTemplate[];
+  status: 200;
+};
+
+export type mailboxesMessageTemplatesListResponseComposite =
+  mailboxesMessageTemplatesListResponse200;
+
+export type mailboxesMessageTemplatesListResponse =
+  mailboxesMessageTemplatesListResponseComposite & {
+    headers: Headers;
+  };
+
+export const getMailboxesMessageTemplatesListUrl = (mailboxId: string) => {
+  return `/api/v1.0/mailboxes/${mailboxId}/message-templates/`;
+};
+
+export const mailboxesMessageTemplatesList = async (
+  mailboxId: string,
+  options?: RequestInit,
+): Promise<mailboxesMessageTemplatesListResponse> => {
+  return fetchAPI<mailboxesMessageTemplatesListResponse>(
+    getMailboxesMessageTemplatesListUrl(mailboxId),
+    {
+      ...options,
+      method: "GET",
+    },
+  );
+};
+
+export const getMailboxesMessageTemplatesListQueryKey = (mailboxId: string) => {
+  return [`/api/v1.0/mailboxes/${mailboxId}/message-templates/`] as const;
+};
+
+export const getMailboxesMessageTemplatesListQueryOptions = <
+  TData = Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+  TError = unknown,
+>(
+  mailboxId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getMailboxesMessageTemplatesListQueryKey(mailboxId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>
+  > = ({ signal }) =>
+    mailboxesMessageTemplatesList(mailboxId, { signal, ...requestOptions });
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!mailboxId,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type MailboxesMessageTemplatesListQueryResult = NonNullable<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>
+>;
+export type MailboxesMessageTemplatesListQueryError = unknown;
+
+export function useMailboxesMessageTemplatesList<
+  TData = Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+  TError = unknown,
+>(
+  mailboxId: string,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+          TError,
+          Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useMailboxesMessageTemplatesList<
+  TData = Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+  TError = unknown,
+>(
+  mailboxId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+          TError,
+          Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useMailboxesMessageTemplatesList<
+  TData = Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+  TError = unknown,
+>(
+  mailboxId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+
+export function useMailboxesMessageTemplatesList<
+  TData = Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+  TError = unknown,
+>(
+  mailboxId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mailboxesMessageTemplatesList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getMailboxesMessageTemplatesListQueryOptions(
+    mailboxId,
+    options,
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * ViewSet for retrieving and rendering message templates for a mailbox.
+ */
+export type mailboxesMessageTemplatesCreateResponse201 = {
+  data: MessageTemplate;
+  status: 201;
+};
+
+export type mailboxesMessageTemplatesCreateResponseComposite =
+  mailboxesMessageTemplatesCreateResponse201;
+
+export type mailboxesMessageTemplatesCreateResponse =
+  mailboxesMessageTemplatesCreateResponseComposite & {
+    headers: Headers;
+  };
+
+export const getMailboxesMessageTemplatesCreateUrl = (mailboxId: string) => {
+  return `/api/v1.0/mailboxes/${mailboxId}/message-templates/`;
+};
+
+export const mailboxesMessageTemplatesCreate = async (
+  mailboxId: string,
+  messageTemplateRequest: MessageTemplateRequest,
+  options?: RequestInit,
+): Promise<mailboxesMessageTemplatesCreateResponse> => {
+  return fetchAPI<mailboxesMessageTemplatesCreateResponse>(
+    getMailboxesMessageTemplatesCreateUrl(mailboxId),
+    {
+      ...options,
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      body: JSON.stringify(messageTemplateRequest),
+    },
+  );
+};
+
+export const getMailboxesMessageTemplatesCreateMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesCreate>>,
+    TError,
+    { mailboxId: string; data: MessageTemplateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof fetchAPI>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesCreate>>,
+  TError,
+  { mailboxId: string; data: MessageTemplateRequest },
+  TContext
+> => {
+  const mutationKey = ["mailboxesMessageTemplatesCreate"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesCreate>>,
+    { mailboxId: string; data: MessageTemplateRequest }
+  > = (props) => {
+    const { mailboxId, data } = props ?? {};
+
+    return mailboxesMessageTemplatesCreate(mailboxId, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type MailboxesMessageTemplatesCreateMutationResult = NonNullable<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesCreate>>
+>;
+export type MailboxesMessageTemplatesCreateMutationBody =
+  MessageTemplateRequest;
+export type MailboxesMessageTemplatesCreateMutationError = unknown;
+
+export const useMailboxesMessageTemplatesCreate = <
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof mailboxesMessageTemplatesCreate>>,
+      TError,
+      { mailboxId: string; data: MessageTemplateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesCreate>>,
+  TError,
+  { mailboxId: string; data: MessageTemplateRequest },
+  TContext
+> => {
+  const mutationOptions =
+    getMailboxesMessageTemplatesCreateMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+/**
+ * ViewSet for retrieving and rendering message templates for a mailbox.
+ */
 export type mailboxesMessageTemplatesRetrieveResponse200 = {
-  data: ReadOnlyMessageTemplate;
+  data: MessageTemplate;
   status: 200;
 };
 
@@ -381,6 +682,337 @@ export function useMailboxesMessageTemplatesRetrieve<
   return query;
 }
 
+/**
+ * ViewSet for retrieving and rendering message templates for a mailbox.
+ */
+export type mailboxesMessageTemplatesUpdateResponse200 = {
+  data: MessageTemplate;
+  status: 200;
+};
+
+export type mailboxesMessageTemplatesUpdateResponseComposite =
+  mailboxesMessageTemplatesUpdateResponse200;
+
+export type mailboxesMessageTemplatesUpdateResponse =
+  mailboxesMessageTemplatesUpdateResponseComposite & {
+    headers: Headers;
+  };
+
+export const getMailboxesMessageTemplatesUpdateUrl = (
+  mailboxId: string,
+  id: string,
+) => {
+  return `/api/v1.0/mailboxes/${mailboxId}/message-templates/${id}/`;
+};
+
+export const mailboxesMessageTemplatesUpdate = async (
+  mailboxId: string,
+  id: string,
+  messageTemplateRequest: MessageTemplateRequest,
+  options?: RequestInit,
+): Promise<mailboxesMessageTemplatesUpdateResponse> => {
+  return fetchAPI<mailboxesMessageTemplatesUpdateResponse>(
+    getMailboxesMessageTemplatesUpdateUrl(mailboxId, id),
+    {
+      ...options,
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      body: JSON.stringify(messageTemplateRequest),
+    },
+  );
+};
+
+export const getMailboxesMessageTemplatesUpdateMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesUpdate>>,
+    TError,
+    { mailboxId: string; id: string; data: MessageTemplateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof fetchAPI>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesUpdate>>,
+  TError,
+  { mailboxId: string; id: string; data: MessageTemplateRequest },
+  TContext
+> => {
+  const mutationKey = ["mailboxesMessageTemplatesUpdate"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesUpdate>>,
+    { mailboxId: string; id: string; data: MessageTemplateRequest }
+  > = (props) => {
+    const { mailboxId, id, data } = props ?? {};
+
+    return mailboxesMessageTemplatesUpdate(mailboxId, id, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type MailboxesMessageTemplatesUpdateMutationResult = NonNullable<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesUpdate>>
+>;
+export type MailboxesMessageTemplatesUpdateMutationBody =
+  MessageTemplateRequest;
+export type MailboxesMessageTemplatesUpdateMutationError = unknown;
+
+export const useMailboxesMessageTemplatesUpdate = <
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof mailboxesMessageTemplatesUpdate>>,
+      TError,
+      { mailboxId: string; id: string; data: MessageTemplateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesUpdate>>,
+  TError,
+  { mailboxId: string; id: string; data: MessageTemplateRequest },
+  TContext
+> => {
+  const mutationOptions =
+    getMailboxesMessageTemplatesUpdateMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+/**
+ * ViewSet for retrieving and rendering message templates for a mailbox.
+ */
+export type mailboxesMessageTemplatesPartialUpdateResponse200 = {
+  data: MessageTemplate;
+  status: 200;
+};
+
+export type mailboxesMessageTemplatesPartialUpdateResponseComposite =
+  mailboxesMessageTemplatesPartialUpdateResponse200;
+
+export type mailboxesMessageTemplatesPartialUpdateResponse =
+  mailboxesMessageTemplatesPartialUpdateResponseComposite & {
+    headers: Headers;
+  };
+
+export const getMailboxesMessageTemplatesPartialUpdateUrl = (
+  mailboxId: string,
+  id: string,
+) => {
+  return `/api/v1.0/mailboxes/${mailboxId}/message-templates/${id}/`;
+};
+
+export const mailboxesMessageTemplatesPartialUpdate = async (
+  mailboxId: string,
+  id: string,
+  patchedMessageTemplateRequest: PatchedMessageTemplateRequest,
+  options?: RequestInit,
+): Promise<mailboxesMessageTemplatesPartialUpdateResponse> => {
+  return fetchAPI<mailboxesMessageTemplatesPartialUpdateResponse>(
+    getMailboxesMessageTemplatesPartialUpdateUrl(mailboxId, id),
+    {
+      ...options,
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      body: JSON.stringify(patchedMessageTemplateRequest),
+    },
+  );
+};
+
+export const getMailboxesMessageTemplatesPartialUpdateMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesPartialUpdate>>,
+    TError,
+    { mailboxId: string; id: string; data: PatchedMessageTemplateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof fetchAPI>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesPartialUpdate>>,
+  TError,
+  { mailboxId: string; id: string; data: PatchedMessageTemplateRequest },
+  TContext
+> => {
+  const mutationKey = ["mailboxesMessageTemplatesPartialUpdate"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesPartialUpdate>>,
+    { mailboxId: string; id: string; data: PatchedMessageTemplateRequest }
+  > = (props) => {
+    const { mailboxId, id, data } = props ?? {};
+
+    return mailboxesMessageTemplatesPartialUpdate(
+      mailboxId,
+      id,
+      data,
+      requestOptions,
+    );
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type MailboxesMessageTemplatesPartialUpdateMutationResult = NonNullable<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesPartialUpdate>>
+>;
+export type MailboxesMessageTemplatesPartialUpdateMutationBody =
+  PatchedMessageTemplateRequest;
+export type MailboxesMessageTemplatesPartialUpdateMutationError = unknown;
+
+export const useMailboxesMessageTemplatesPartialUpdate = <
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof mailboxesMessageTemplatesPartialUpdate>>,
+      TError,
+      { mailboxId: string; id: string; data: PatchedMessageTemplateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesPartialUpdate>>,
+  TError,
+  { mailboxId: string; id: string; data: PatchedMessageTemplateRequest },
+  TContext
+> => {
+  const mutationOptions =
+    getMailboxesMessageTemplatesPartialUpdateMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+/**
+ * ViewSet for retrieving and rendering message templates for a mailbox.
+ */
+export type mailboxesMessageTemplatesDestroyResponse204 = {
+  data: void;
+  status: 204;
+};
+
+export type mailboxesMessageTemplatesDestroyResponseComposite =
+  mailboxesMessageTemplatesDestroyResponse204;
+
+export type mailboxesMessageTemplatesDestroyResponse =
+  mailboxesMessageTemplatesDestroyResponseComposite & {
+    headers: Headers;
+  };
+
+export const getMailboxesMessageTemplatesDestroyUrl = (
+  mailboxId: string,
+  id: string,
+) => {
+  return `/api/v1.0/mailboxes/${mailboxId}/message-templates/${id}/`;
+};
+
+export const mailboxesMessageTemplatesDestroy = async (
+  mailboxId: string,
+  id: string,
+  options?: RequestInit,
+): Promise<mailboxesMessageTemplatesDestroyResponse> => {
+  return fetchAPI<mailboxesMessageTemplatesDestroyResponse>(
+    getMailboxesMessageTemplatesDestroyUrl(mailboxId, id),
+    {
+      ...options,
+      method: "DELETE",
+    },
+  );
+};
+
+export const getMailboxesMessageTemplatesDestroyMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesDestroy>>,
+    TError,
+    { mailboxId: string; id: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof fetchAPI>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesDestroy>>,
+  TError,
+  { mailboxId: string; id: string },
+  TContext
+> => {
+  const mutationKey = ["mailboxesMessageTemplatesDestroy"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof mailboxesMessageTemplatesDestroy>>,
+    { mailboxId: string; id: string }
+  > = (props) => {
+    const { mailboxId, id } = props ?? {};
+
+    return mailboxesMessageTemplatesDestroy(mailboxId, id, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type MailboxesMessageTemplatesDestroyMutationResult = NonNullable<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesDestroy>>
+>;
+
+export type MailboxesMessageTemplatesDestroyMutationError = unknown;
+
+export const useMailboxesMessageTemplatesDestroy = <
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof mailboxesMessageTemplatesDestroy>>,
+      TError,
+      { mailboxId: string; id: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof fetchAPI>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof mailboxesMessageTemplatesDestroy>>,
+  TError,
+  { mailboxId: string; id: string },
+  TContext
+> => {
+  const mutationOptions =
+    getMailboxesMessageTemplatesDestroyMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
 /**
  * Render a template with the provided context variables.
  */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full CRUD and listing for mailbox-scoped message templates via the API; render/list support by mailbox or mailbox-domain.

* **Bug Fixes**
  * Mailbox context consistently preserved during create/update so template content stays associated with the correct mailbox.
  * Validation relaxed: domain no longer required in serializer context.
  * Maildomain immutability enforced on updates (payload maildomain ignored).

* **Documentation**
  * API schema updated with mailbox-scoped message-template endpoints and request/response shapes.

* **Tests**
  * Comprehensive tests added for auth, CRUD, listing, filtering, rendering (including forbidden mailbox render), and content integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->