### PR TITLE
✨(template) add permissions check to manage mailbox message template

### DIFF
--- a/src/backend/core/api/viewsets/message_template.py
+++ b/src/backend/core/api/viewsets/message_template.py
@@ -36,10 +36,16 @@ class MailboxMessageTemplateViewSet(
 ):
     """ViewSet for retrieving and rendering message templates for a mailbox."""
 
-    permission_classes = [permissions.HasAccessToMailbox]
+    permission_classes = [permissions.IsMailboxAdmin]
     serializer_class = MessageTemplateSerializer
     lookup_field = "pk"
     pagination_class = None
+
+    def get_permissions(self):
+        """Get permissions for the viewset."""
+        if self.action in ["render_template", "list", "retrieve"]:
+            return [permissions.HasAccessToMailbox()]
+        return super().get_permissions()
 
     @cached_property
     def mailbox(self):

--- a/src/backend/core/tests/tasks/test_task_importer.py
+++ b/src/backend/core/tests/tasks/test_task_importer.py
@@ -166,9 +166,7 @@ class TestProcessMboxFileTask:
                 assert messages[1].subject == "Test Message 2"
                 assert messages[2].subject == "Test Message 1"
 
-    def test_task_process_mbox_file_partial_success(
-        self, mailbox, sample_mbox_content
-    ):
+    def test_task_process_mbox_file_partial_success(self, mailbox, sample_mbox_content):
         """Test MBOX processing with some messages failing."""
 
         # Mock deliver_inbound_message to fail for the second message
@@ -323,9 +321,7 @@ class TestProcessMboxFileTask:
             # Verify no messages were created
             assert Message.objects.count() == 0
 
-    def test_task_process_mbox_file_parse_error(
-        self, mailbox, sample_mbox_content
-    ):
+    def test_task_process_mbox_file_parse_error(self, mailbox, sample_mbox_content):
         """Test MBOX processing with message parsing error."""
 
         # Mock parse_email_message to raise an exception for all messages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Tightened message template permissions: only mailbox admins may create, update, or delete; editors/senders/viewers can list, view, and render templates.

- Tests
  - Expanded role-based tests for list, retrieve, render and CRUD permission scenarios, covering forbidden/no-access and mailbox-context cases.
  - Minor test formatting cleanup in task importer tests (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->