### PR TITLE
✨(template) add new mailbox ability to manage message templates

### DIFF
--- a/src/backend/core/api/openapi.json
+++ b/src/backend/core/api/openapi.json
@@ -5501,6 +5501,10 @@
                             "manage_labels": {
                                 "type": "boolean",
                                 "description": "Can manage mailbox labels"
+                            },
+                            "manage_message_templates": {
+                                "type": "boolean",
+                                "description": "Can manage mailbox message templates"
                             }
                         },
                         "required": [
@@ -5512,7 +5516,8 @@
                             "manage_accesses",
                             "view_messages",
                             "send_messages",
-                            "manage_labels"
+                            "manage_labels",
+                            "manage_message_templates"
                         ],
                         "readOnly": true
                     }

--- a/src/backend/core/enums.py
+++ b/src/backend/core/enums.py
@@ -107,6 +107,10 @@ class MailboxAbilities(models.TextChoices):
     CAN_VIEW_MESSAGES = "view_messages", "Can view mailbox messages"
     CAN_SEND_MESSAGES = "send_messages", "Can send messages from mailbox"
     CAN_MANAGE_LABELS = "manage_labels", "Can manage mailbox labels"
+    CAN_MANAGE_MESSAGE_TEMPLATES = (
+        "manage_message_templates",
+        "Can manage mailbox message templates",
+    )
 
 
 class MessageTemplateTypeChoices(models.IntegerChoices):

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -611,6 +611,7 @@ class Mailbox(BaseModel):
                 "view_messages": False,
                 "send_messages": False,
                 "manage_labels": False,
+                "manage_message_templates": False,
             }
 
         is_admin = role == MailboxRoleChoices.ADMIN
@@ -629,6 +630,7 @@ class Mailbox(BaseModel):
             MailboxAbilities.CAN_VIEW_MESSAGES: has_access,
             MailboxAbilities.CAN_SEND_MESSAGES: can_send,
             MailboxAbilities.CAN_MANAGE_LABELS: can_modify,
+            MailboxAbilities.CAN_MANAGE_MESSAGE_TEMPLATES: is_admin,
         }
 
     def get_validated_signature(self, signature_id: str):

--- a/src/backend/core/tests/api/test_mailboxes.py
+++ b/src/backend/core/tests/api/test_mailboxes.py
@@ -388,6 +388,7 @@ class TestMailboxAbilitiesAPI:
         assert abilities["view_messages"] is True
         assert abilities["send_messages"] is True
         assert abilities["manage_labels"] is True
+        assert abilities["manage_message_templates"] is True
 
     def test_mailbox_list_with_abilities(self, api_client, user, mailbox):
         """Test that mailbox list includes abilities for each mailbox."""
@@ -416,6 +417,7 @@ class TestMailboxAbilitiesAPI:
         assert abilities["view_messages"] is True
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is True
+        assert abilities["manage_message_templates"] is False
 
     def test_mailbox_detail_no_access_abilities(self, api_client, user, mailbox):
         """Test that abilities are correctly set when user has no access to detail."""
@@ -461,6 +463,7 @@ class TestMailboxAbilitiesAPI:
         assert abilities["view_messages"] is True
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is False
+        assert abilities["manage_message_templates"] is False
 
     def test_mailbox_user_role_annotation(self, api_client, user, mailbox):
         """Test that the user_role annotation works correctly."""

--- a/src/backend/core/tests/models/test_mailbox.py
+++ b/src/backend/core/tests/models/test_mailbox.py
@@ -116,6 +116,7 @@ class TestMailboxModelAbilities:
         assert abilities["view_messages"] is False
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is False
+        assert abilities["manage_message_templates"] is False
 
     def test_mailbox_get_abilities_viewer(self, user, mailbox):
         """Test Mailbox.get_abilities when user has viewer access."""
@@ -136,6 +137,7 @@ class TestMailboxModelAbilities:
         assert abilities["view_messages"] is True
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is False
+        assert abilities["manage_message_templates"] is False
 
     def test_mailbox_get_abilities_editor(self, user, mailbox):
         """Test Mailbox.get_abilities when user has editor access."""
@@ -156,6 +158,7 @@ class TestMailboxModelAbilities:
         assert abilities["view_messages"] is True
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is True
+        assert abilities["manage_message_templates"] is False
 
     def test_mailbox_get_abilities_admin(self, user, mailbox):
         """Test Mailbox.get_abilities when user has admin access."""
@@ -176,6 +179,7 @@ class TestMailboxModelAbilities:
         assert abilities["view_messages"] is True
         assert abilities["send_messages"] is True
         assert abilities["manage_labels"] is True
+        assert abilities["manage_message_templates"] is True
 
     def test_mailbox_get_abilities_sender(self, user, mailbox):
         """Test Mailbox.get_abilities when user has sender access."""
@@ -196,3 +200,4 @@ class TestMailboxModelAbilities:
         assert abilities["view_messages"] is True
         assert abilities["send_messages"] is True
         assert abilities["manage_labels"] is True
+        assert abilities["manage_message_templates"] is False

--- a/src/frontend/src/features/api/gen/models/mailbox_abilities.ts
+++ b/src/frontend/src/features/api/gen/models/mailbox_abilities.ts
@@ -28,4 +28,6 @@ export type MailboxAbilities = {
   readonly send_messages: boolean;
   /** Can manage mailbox labels */
   readonly manage_labels: boolean;
+  /** Can manage mailbox message templates */
+  readonly manage_message_templates: boolean;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Manage message templates” mailbox permission. Enabled for admins, disabled for other roles.
  - Mailbox responses now include a manage_message_templates flag indicating this permission.

- **Tests**
  - Updated and expanded tests to validate manage_message_templates behavior across roles.

- **Documentation**
  - API schema updated to expose the new manage_message_templates field in mailbox abilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->