### PR TITLE
✨(import) add new mailbox ability to import messages

### DIFF
--- a/src/backend/core/api/openapi.json
+++ b/src/backend/core/api/openapi.json
@@ -5505,6 +5505,10 @@
                             "manage_message_templates": {
                                 "type": "boolean",
                                 "description": "Can manage mailbox message templates"
+                            },
+                            "import_messages": {
+                                "type": "boolean",
+                                "description": "Can import messages"
                             }
                         },
                         "required": [
@@ -5517,7 +5521,8 @@
                             "view_messages",
                             "send_messages",
                             "manage_labels",
-                            "manage_message_templates"
+                            "manage_message_templates",
+                            "import_messages"
                         ],
                         "readOnly": true
                     }

--- a/src/backend/core/enums.py
+++ b/src/backend/core/enums.py
@@ -111,6 +111,7 @@ class MailboxAbilities(models.TextChoices):
         "manage_message_templates",
         "Can manage mailbox message templates",
     )
+    CAN_IMPORT_MESSAGES = "import_messages", "Can import messages"
 
 
 class MessageTemplateTypeChoices(models.IntegerChoices):

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -612,6 +612,7 @@ class Mailbox(BaseModel):
                 "send_messages": False,
                 "manage_labels": False,
                 "manage_message_templates": False,
+                "import_messages": False,
             }
 
         is_admin = role == MailboxRoleChoices.ADMIN
@@ -631,6 +632,7 @@ class Mailbox(BaseModel):
             MailboxAbilities.CAN_SEND_MESSAGES: can_send,
             MailboxAbilities.CAN_MANAGE_LABELS: can_modify,
             MailboxAbilities.CAN_MANAGE_MESSAGE_TEMPLATES: is_admin,
+            MailboxAbilities.CAN_IMPORT_MESSAGES: is_admin,
         }
 
     def get_validated_signature(self, signature_id: str):

--- a/src/backend/core/tests/api/test_mailboxes.py
+++ b/src/backend/core/tests/api/test_mailboxes.py
@@ -389,6 +389,7 @@ class TestMailboxAbilitiesAPI:
         assert abilities["send_messages"] is True
         assert abilities["manage_labels"] is True
         assert abilities["manage_message_templates"] is True
+        assert abilities["import_messages"] is True
 
     def test_mailbox_list_with_abilities(self, api_client, user, mailbox):
         """Test that mailbox list includes abilities for each mailbox."""
@@ -418,6 +419,7 @@ class TestMailboxAbilitiesAPI:
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is True
         assert abilities["manage_message_templates"] is False
+        assert abilities["import_messages"] is False
 
     def test_mailbox_detail_no_access_abilities(self, api_client, user, mailbox):
         """Test that abilities are correctly set when user has no access to detail."""
@@ -464,6 +466,7 @@ class TestMailboxAbilitiesAPI:
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is False
         assert abilities["manage_message_templates"] is False
+        assert abilities["import_messages"] is False
 
     def test_mailbox_user_role_annotation(self, api_client, user, mailbox):
         """Test that the user_role annotation works correctly."""

--- a/src/backend/core/tests/models/test_mailbox.py
+++ b/src/backend/core/tests/models/test_mailbox.py
@@ -117,6 +117,7 @@ class TestMailboxModelAbilities:
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is False
         assert abilities["manage_message_templates"] is False
+        assert abilities["import_messages"] is False
 
     def test_mailbox_get_abilities_viewer(self, user, mailbox):
         """Test Mailbox.get_abilities when user has viewer access."""
@@ -138,6 +139,7 @@ class TestMailboxModelAbilities:
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is False
         assert abilities["manage_message_templates"] is False
+        assert abilities["import_messages"] is False
 
     def test_mailbox_get_abilities_editor(self, user, mailbox):
         """Test Mailbox.get_abilities when user has editor access."""
@@ -159,6 +161,7 @@ class TestMailboxModelAbilities:
         assert abilities["send_messages"] is False
         assert abilities["manage_labels"] is True
         assert abilities["manage_message_templates"] is False
+        assert abilities["import_messages"] is False
 
     def test_mailbox_get_abilities_admin(self, user, mailbox):
         """Test Mailbox.get_abilities when user has admin access."""
@@ -180,6 +183,7 @@ class TestMailboxModelAbilities:
         assert abilities["send_messages"] is True
         assert abilities["manage_labels"] is True
         assert abilities["manage_message_templates"] is True
+        assert abilities["import_messages"] is True
 
     def test_mailbox_get_abilities_sender(self, user, mailbox):
         """Test Mailbox.get_abilities when user has sender access."""
@@ -201,3 +205,4 @@ class TestMailboxModelAbilities:
         assert abilities["send_messages"] is True
         assert abilities["manage_labels"] is True
         assert abilities["manage_message_templates"] is False
+        assert abilities["import_messages"] is False

--- a/src/frontend/src/features/api/gen/models/mailbox_abilities.ts
+++ b/src/frontend/src/features/api/gen/models/mailbox_abilities.ts
@@ -30,4 +30,6 @@ export type MailboxAbilities = {
   readonly manage_labels: boolean;
   /** Can manage mailbox message templates */
   readonly manage_message_templates: boolean;
+  /** Can import messages */
+  readonly import_messages: boolean;
 };

--- a/src/frontend/src/features/layouts/components/main/header/authenticated.tsx
+++ b/src/frontend/src/features/layouts/components/main/header/authenticated.tsx
@@ -8,6 +8,7 @@ import useAbility, { Abilities } from "@/hooks/use-ability";
 import { useAuth, logout } from "@/features/auth";
 import { LanguagePicker } from "@/features/layouts/components/main/language-picker";
 import { LagaufreButton } from "@/features/ui/components/lagaufre";
+import { useMailboxContext } from "@/features/providers/mailbox";
 
 
 type AuthenticatedHeaderProps = HeaderProps & {
@@ -58,6 +59,8 @@ export const HeaderRight = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const canAccessDomainAdmin = useAbility(Abilities.CAN_VIEW_DOMAIN_ADMIN);
+  const { selectedMailbox } = useMailboxContext();
+  const canImportMessages = useAbility(Abilities.CAN_IMPORT_MESSAGES, selectedMailbox);
 
   return (
     <>
@@ -70,13 +73,13 @@ export const HeaderRight = () => {
                 icon: <Icon name="domain" />,
                 callback: () => router.push("/domain"),
               }] : []),
-              {
+              ...(canImportMessages ? [{
                   label: t("Import messages"),
                   icon: <Icon name="archive" type={IconType.OUTLINED} />,
                   callback: () => {
                       window.location.hash = `#modal-message-importer`;
                   }
-              },
+              }] : []),
           ]}
       >
       <Button

--- a/src/frontend/src/hooks/use-ability.ts
+++ b/src/frontend/src/hooks/use-ability.ts
@@ -10,6 +10,7 @@ enum MailboxAbilities {
   CAN_SEND_MESSAGES = "send_messages",
   CAN_WRITE_MESSAGES = "patch",
   CAN_MANAGE_MAILBOX_LABELS = "manage_labels",
+  CAN_IMPORT_MESSAGES = "import_messages",
 }
 
 enum UserAbilities {
@@ -73,6 +74,7 @@ function useAbility(
     case Abilities.CAN_VIEW_DOMAIN_ADMIN:
     case Abilities.CAN_CREATE_MAILDOMAINS:
     case Abilities.CAN_MANAGE_MAILBOX_LABELS:
+    case Abilities.CAN_IMPORT_MESSAGES:
     case Abilities.CAN_MANAGE_MAILDOMAIN_MAILBOXES:
     case Abilities.CAN_MANAGE_MAILDOMAIN_ACCESSES:
     case Abilities.CAN_MANAGE_SOME_MAILDOMAIN_ACCESSES:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new mailbox permission for importing messages. The “Import messages” option now appears only for users with the appropriate access.
  * Updated mailbox abilities to include an “import messages” capability, ensuring visibility and access align with user roles across lists and detail views.
  * Improved header dropdown behavior: “Import messages” is conditionally shown based on your permissions, while other options remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->