### PR TITLE
fix(backend): exempt inbound MTA endpoints from SSL redirect

### DIFF
--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -983,7 +983,7 @@ class Production(Base):
     SECURE_HSTS_PRELOAD = True
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_SSL_REDIRECT = True
-    SECURE_REDIRECT_EXEMPT = ["^__lbheartbeat__", "^__heartbeat__", "^api/v1\\.0/mta/"]
+    SECURE_REDIRECT_EXEMPT = ["^__lbheartbeat__", "^__heartbeat__", "^api/v1\\.0/mta/", "^api/v1\\.0/inbound/mta/"]
 
     # Modern browsers require to have the `secure` attribute on cookies with `Samesite=none`
     CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
The SECURE_REDIRECT_EXEMPT setting was missing the inbound MTA router endpoints, causing internal HTTP calls from the MTA-in service to be redirected to HTTPS with a 301 response.

This caused the milter to timeout when checking recipients and delivering mail, resulting in "451 4.7.1 Service unavailable" errors.

The MTA-in service calls:
- /api/v1.0/inbound/mta/check/ (for recipient validation)
- /api/v1.0/inbound/mta/deliver/ (for mail delivery)

These internal endpoints must accept HTTP requests and should not be redirected to HTTPS.

Changed:
- Added "^api/v1\.0/inbound/mta/" to SECURE_REDIRECT_EXEMPT

This follows the existing pattern for the alias endpoints at /api/v1.0/mta/* which were already exempted.

Fixes: MTA milter timeout and mail delivery failures



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security configuration to enable proper handling of inbound API requests in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->