### PR TITLE
💚(crowdin) fix crowdin upload job

### DIFF
--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -10,7 +10,8 @@ jobs:
 
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
-
+    env:
+      DJANGO_CONFIGURATION: Build
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Purpose

The `synchronize-with-crowdin` was not working since we add the msg-import s3 storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for the synchronization job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->