### PR TITLE
🐛(frontend) do not display delivering status if message is still draft

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
@@ -65,7 +65,7 @@ export const ThreadMessage = forwardRef<HTMLElement, ThreadMessageProps>(
 
         const getRecipientDeliveryStatus = (recipient: MessageRecipient): ContactChipDeliveryStatus | undefined => {
             // If the message has just been sent, it has not delivery status but for the sender it is useful to show that the message is being delivered
-            if (message.is_sender && recipient.delivery_status === null) {
+            if (message.is_sender && recipient.delivery_status === null && !message.is_draft) {
                 return { 'status': 'delivering', 'timestamp': null, 'message': null };
             }
             switch (recipient.delivery_status) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display of message delivery status for draft messages, preventing them from incorrectly showing a "delivering" indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->