### PR TITLE
✨(frontend) store import task id per mailbox

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -8,7 +8,7 @@
     "npm": ">=10.0.0"
   },
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/frontend/public/locales/common/en-US.json
+++ b/src/frontend/public/locales/common/en-US.json
@@ -331,6 +331,7 @@
   "Update a Label": "Update a Label",
   "Updated at": "Updated at",
   "Upload an archive": "Upload an archive",
+  "Uploading your archive": "Uploading your archive",
   "Uploading... {{progress}}%": "Uploading... {{progress}}%",
   "Use \"Send and archive\" by default": "Use \"Send and archive\" by default",
   "Use SSL": "Use SSL",

--- a/src/frontend/public/locales/common/fr-FR.json
+++ b/src/frontend/public/locales/common/fr-FR.json
@@ -331,6 +331,7 @@
   "Update a Label": "Modifier un libellé",
   "Updated at": "Modifié le",
   "Upload an archive": "Téléversez une archive",
+  "Uploading your archive": "Téléversement de votre archive",
   "Uploading... {{progress}}%": "Téléversement en cours... {{progress}}%",
   "Use \"Send and archive\" by default": "Utiliser \"Envoyer et archiver\" par défaut",
   "Use SSL": "Utiliser SSL",

--- a/src/frontend/src/features/controlled-modals/message-importer/index.tsx
+++ b/src/frontend/src/features/controlled-modals/message-importer/index.tsx
@@ -6,13 +6,13 @@ import { StepForm } from "./step-form";
 import { StepLoader } from "./step-loader";
 import { StepCompleted } from "./step-completed";
 import clsx from "clsx";
-import { MESSAGE_IMPORT_TASK_KEY } from "@/features/config/constants";
 import { useEffect, useState } from "react";
+import { TaskImportCacheHelper } from "@/features/utils/task-import-cache";
 
 
 export const MODAL_MESSAGE_IMPORTER_ID = "modal-message-importer";
 
-type IMPORT_STEP = 'idle' | 'importing' | 'uploading' | 'completed';
+export type IMPORT_STEP = 'idle' | 'uploading' | 'importing' | 'completed';
 
 /**
  * A controlled modal to import messages from an archive file or an IMAP server.
@@ -23,31 +23,21 @@ type IMPORT_STEP = 'idle' | 'importing' | 'uploading' | 'completed';
  * - completed : Importing completed once the task is SUCCESS
  */
 export const ModalMessageImporter = () => {
-    const { invalidateThreadMessages, invalidateThreadsStats, invalidateLabels } = useMailboxContext();
+    const { invalidateThreadMessages, invalidateThreadsStats, invalidateLabels, selectedMailbox } = useMailboxContext();
     const { t } = useTranslation();
     const modals = useModals();
-    const [taskId, setTaskId] = useState<string | null>(() => {
-        if (typeof localStorage === 'undefined') return null;
-        return localStorage.getItem(MESSAGE_IMPORT_TASK_KEY) || null;
-    });
+    const taskImportCacheHelper = new TaskImportCacheHelper(selectedMailbox?.id);
+    const [taskId, setTaskId] = useState<string | null>(taskImportCacheHelper.get());
     const [step, setStep] = useState<IMPORT_STEP>(taskId ? 'importing' : 'idle');
     const [error, setError] = useState<string | null>(null);
     const { closeModal } = useModalStore();
-    const onClose = () => {
-        if (!taskId) {
-            setStep('idle');
-            setTaskId('');
-            setError(null);
-        }
-    }
     const handleCompletedStepClose = () => {
         closeModal(MODAL_MESSAGE_IMPORTER_ID);
-        onClose();
     }
 
     const handleImportingStepComplete = async () => {
-        localStorage.removeItem(MESSAGE_IMPORT_TASK_KEY);
-        setTaskId('');
+        taskImportCacheHelper.remove();
+        setTaskId(null);
         setStep('completed');
         await Promise.all([
             invalidateThreadMessages(),
@@ -59,21 +49,21 @@ export const ModalMessageImporter = () => {
 
     const handleArchiveUploading = () => {
         setStep('uploading');
-        setTaskId('');
+        setTaskId(null);
         setError(null);
-        localStorage.removeItem(MESSAGE_IMPORT_TASK_KEY);
+        taskImportCacheHelper.remove();
     }
 
     const handleFormSuccess = (taskId: string) => {
         setTaskId(taskId);
         setStep('importing');
-        localStorage.setItem(MESSAGE_IMPORT_TASK_KEY, taskId);
+        taskImportCacheHelper.set(taskId);
     }
 
     const handleError = (error: string | null) => {
         setStep('idle');
-        setTaskId('');
-        localStorage.removeItem(MESSAGE_IMPORT_TASK_KEY);
+        setTaskId(null);
+        taskImportCacheHelper.remove();
         setError(error);
     }
 
@@ -95,18 +85,17 @@ export const ModalMessageImporter = () => {
 
         window.addEventListener("beforeunload", unloadCallback);
         return () => window.removeEventListener("beforeunload", unloadCallback);
-      }, [step]);
+    }, [step]);
 
     return (
         <ControlledModal
             title={t('Import your old messages')}
             modalId={MODAL_MESSAGE_IMPORTER_ID}
             size={ModalSize.LARGE}
-            onClose={onClose}
             confirmFn={step !== 'uploading' ? undefined : handleConfirmCloseModal}
         >
             <div className="modal-importer">
-                {(step === 'idle'  || step === 'uploading' || step === 'importing') && (
+                {(step === 'idle' || step === 'uploading' || step === 'importing') && (
                     <div
                         className={clsx("flex-column flex-align-center", { "c__offscreen": step === 'importing' })}
                         style={{ gap: 'var(--c--theme--spacings--xl)' }}
@@ -115,6 +104,7 @@ export const ModalMessageImporter = () => {
                             onUploading={handleArchiveUploading}
                             onSuccess={handleFormSuccess}
                             onError={handleError}
+                            step={step}
                             error={error}
                         />
                     </div>

--- a/src/frontend/src/features/controlled-modals/message-importer/step-form.tsx
+++ b/src/frontend/src/features/controlled-modals/message-importer/step-form.tsx
@@ -15,6 +15,7 @@ import { Banner } from "@/features/ui/components/banner";
 import i18n from "@/features/i18n/initI18n";
 import { BucketUploadState, useBucketUpload } from "./use-bucket-upload";
 import ProgressBar from "@/features/ui/components/progress-bar";
+import { IMPORT_STEP } from ".";
 
 const usernameSchema = z.email({ error: i18n.t('The email address is invalid.') });
 
@@ -46,9 +47,9 @@ type StepFormProps = {
     onSuccess: (taskId: string) => void;
     onError: (error: string | null) => void;
     error: string | null;
-
+    step: IMPORT_STEP;
 }
-export const StepForm = ({ onUploading, onSuccess, onError, error}: StepFormProps) => {
+export const StepForm = ({ onUploading, onSuccess, onError, error, step }: StepFormProps) => {
     const { t } = useTranslation();
     const router = useRouter();
     const [showAdvancedImapFields, setShowAdvancedImapFields] = useState(false);
@@ -187,7 +188,10 @@ export const StepForm = ({ onUploading, onSuccess, onError, error}: StepFormProp
                 onSubmit={form.handleSubmit(handleSubmit)}
                 noValidate
             >
-                <h2>{t('First, we need some information about your old mailbox')}</h2>
+                {step === 'uploading'
+                    ? <h2>{t('Uploading your archive')}</h2>
+                    : <h2>{t('First, we need some information about your old mailbox')}</h2>
+                }
                 {showImapForm === true && (
                     <>
                         <div className="form-field-row flex-justify-center">
@@ -264,9 +268,11 @@ export const StepForm = ({ onUploading, onSuccess, onError, error}: StepFormProp
                         </div>
                     </>
                 )}
+                {step !== 'uploading' && (
                 <div className="form-field-row flex-justify-center">
                     <p>{t('Upload an archive')}</p>
                 </div>
+                )}
                 <div className="form-field-row archive_file_field">
                     <RhfFileUploader
                         name="archive_file"
@@ -284,7 +290,7 @@ export const StepForm = ({ onUploading, onSuccess, onError, error}: StepFormProp
                         </div>
                     )}
                 </div>
-                {error && ( <Banner type="error"><p>{t(error)}</p></Banner> )}
+                {error && (<Banner type="error"><p>{t(error)}</p></Banner>)}
                 <div className="form-field-row">
                     {[BucketUploadState.IMPORTING].includes(bucketUploadManager.state) ? (
                         <Button
@@ -293,7 +299,7 @@ export const StepForm = ({ onUploading, onSuccess, onError, error}: StepFormProp
                             color="tertiary"
                             fullWidth
                         >
-                                {t('Abort upload')}
+                            {t('Abort upload')}
                         </Button>
 
                     ) : (

--- a/src/frontend/src/features/layouts/components/main/header/authenticated.tsx
+++ b/src/frontend/src/features/layouts/components/main/header/authenticated.tsx
@@ -9,10 +9,10 @@ import { useAuth, logout } from "@/features/auth";
 import { LanguagePicker } from "@/features/layouts/components/main/language-picker";
 import { LagaufreButton } from "@/features/ui/components/lagaufre";
 import { useMailboxContext } from "@/features/providers/mailbox";
-import { MESSAGE_IMPORT_TASK_KEY } from "@/features/config/constants";
 import { useImportTaskStatus } from "@/hooks/use-import-task";
 import { StatusEnum } from "@/features/api/gen";
 import { CircularProgress } from "@/features/ui/components/circular-progress";
+import { TaskImportCacheHelper } from "@/features/utils/task-import-cache";
 
 
 type AuthenticatedHeaderProps = HeaderProps & {
@@ -88,9 +88,9 @@ const ApplicationMenu = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const taskId = useMemo(() => {
-    if (typeof window === undefined) return null;
-    return localStorage.getItem(MESSAGE_IMPORT_TASK_KEY);
-  }, [isDropdownOpen]);
+    const taskImportCacheHelper = new TaskImportCacheHelper(selectedMailbox?.id);
+    return taskImportCacheHelper.get();
+  }, [isDropdownOpen, selectedMailbox?.id]);
 
   const taskStatus = useImportTaskStatus(taskId, { enabled: canImportMessages && isDropdownOpen });
   const importMessageOption = useMemo(() => {

--- a/src/frontend/src/features/providers/modal-store/index.tsx
+++ b/src/frontend/src/features/providers/modal-store/index.tsx
@@ -75,7 +75,7 @@ export const ModalStoreProvider = ({ children }: PropsWithChildren) => {
         <ModalStoreContext.Provider value={contextValue}>
             {children}
             {Array.from(modalStore.entries()).map(([modalId, Modal]) => (
-                <Modal key={modalId} />
+                openModals.has(modalId) && <Modal key={modalId} />
             ))}
         </ModalStoreContext.Provider>
     )

--- a/src/frontend/src/features/utils/task-import-cache/index.test.ts
+++ b/src/frontend/src/features/utils/task-import-cache/index.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TaskImportCacheHelper } from ".";
+
+describe("TaskImportCacheHelper", () => {
+  const mailboxId = "test-mailbox-123";
+  const storageKey = `messages_message-import-task_${mailboxId}`;
+  const taskId = "test-task-456";
+
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear();
+    // Reset Date.now() mock
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should set mailboxId", () => {
+      const helper = new TaskImportCacheHelper(mailboxId);
+      expect(helper.mailboxId).toBe(mailboxId);
+    });
+
+    it("should handle undefined mailboxId", () => {
+      const helper = new TaskImportCacheHelper(undefined);
+      expect(helper.mailboxId).toBeUndefined();
+    });
+  });
+
+  describe("set", () => {
+    it("should store taskId in localStorage with expiration", () => {
+      const now = 1000000000000;
+      vi.spyOn(Date, "now").mockReturnValue(now);
+
+      const helper = new TaskImportCacheHelper(mailboxId);
+      helper.set(taskId);
+
+      const storedValue = localStorage.getItem(storageKey);
+      expect(storedValue).not.toBeNull();
+
+      // Should store taskId:expiresAt format
+      const [storedTaskId, expiresAt] = storedValue!.split(":");
+      expect(storedTaskId).toBe(taskId);
+      // Should expire in 2 days (2 * 24 * 60 * 60 * 1000 ms)
+      expect(parseInt(expiresAt)).toBe(now + 2 * 24 * 60 * 60 * 1000);
+    });
+
+    it("should not store when mailboxId is undefined", () => {
+      const helper = new TaskImportCacheHelper(undefined);
+      helper.set(taskId);
+
+      expect(localStorage.length).toBe(0);
+    });
+  });
+
+  describe("get", () => {
+    it("should retrieve valid taskId from localStorage", () => {
+      const now = 1000000000000;
+      vi.spyOn(Date, "now").mockReturnValue(now);
+
+      const helper = new TaskImportCacheHelper(mailboxId);
+      helper.set(taskId);
+
+      const retrievedTaskId = helper.get();
+      expect(retrievedTaskId).toBe(taskId);
+    });
+
+    it("should return null when no value is stored", () => {
+      const helper = new TaskImportCacheHelper(mailboxId);
+      const result = helper.get();
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when mailboxId is undefined", () => {
+      const helper = new TaskImportCacheHelper(undefined);
+      const result = helper.get();
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null and remove expired taskId", () => {
+      const now = 1000000000000;
+      const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+
+      const helper = new TaskImportCacheHelper(mailboxId);
+      helper.set(taskId);
+      expect(localStorage.getItem(storageKey)).not.toBeNull();
+
+      // Fast forward time by 2 days + 1 ms
+      dateNowSpy.mockReturnValue(1 + now + (2 * 24 * 60 * 60 * 1000));
+      expect(helper.get()).toBeNull();
+
+      // Should have removed the expired entry
+      expect(localStorage.getItem(storageKey)).toBeNull();
+    });
+
+    it("should return taskId when not yet expired", () => {
+      const now = 1000000000000;
+      const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+
+      const helper = new TaskImportCacheHelper(mailboxId);
+      helper.set(taskId);
+
+      // Fast forward time by exactly 2 days (still valid, expires after 2 days)
+      dateNowSpy.mockReturnValue(now + 1 * 24 * 60 * 60 * 1000);
+
+      const result = helper.get();
+      expect(result).toBe(taskId);
+    });
+
+    it("should return taskId at exact expiration time", () => {
+      const now = 1000000000000;
+      const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+
+      const helper = new TaskImportCacheHelper(mailboxId);
+      helper.set(taskId);
+
+      // Fast forward to exact expiration time (2 days)
+      dateNowSpy.mockReturnValue(now + 2 * 24 * 60 * 60 * 1000);
+
+      const result = helper.get();
+      expect(result).toBe(taskId);
+    });
+  });
+
+  describe("remove", () => {
+    it("should remove taskId from localStorage", () => {
+      const helper = new TaskImportCacheHelper(mailboxId);
+      helper.set(taskId);
+
+      expect(localStorage.getItem(storageKey)).toBeTruthy();
+
+      helper.remove();
+
+      expect(localStorage.getItem(storageKey)).toBeNull();
+    });
+
+    it("should not remove when mailboxId is undefined", () => {
+      const helper = new TaskImportCacheHelper(undefined);
+
+      // Manually add something to localStorage
+      localStorage.setItem("messages_message-import-task_undefined", "test");
+
+      helper.remove();
+
+      // Should not remove (the method returns early)
+      expect(
+        localStorage.getItem("messages_message-import-task_undefined")
+      ).toBe("test");
+    });
+  });
+
+  describe("multiple instances", () => {
+    it("should handle different mailboxIds independently", () => {
+      const mailboxId1 = "mailbox-1";
+      const mailboxId2 = "mailbox-2";
+      const taskId1 = "task-1";
+      const taskId2 = "task-2";
+
+      const helper1 = new TaskImportCacheHelper(mailboxId1);
+      const helper2 = new TaskImportCacheHelper(mailboxId2);
+
+      helper1.set(taskId1);
+      helper2.set(taskId2);
+
+      expect(helper1.get()).toBe(taskId1);
+      expect(helper2.get()).toBe(taskId2);
+
+      helper1.remove();
+
+      expect(helper1.get()).toBeNull();
+      expect(helper2.get()).toBe(taskId2);
+    });
+  });
+});

--- a/src/frontend/src/features/utils/task-import-cache/index.ts
+++ b/src/frontend/src/features/utils/task-import-cache/index.ts
@@ -1,0 +1,46 @@
+import { MESSAGE_IMPORT_TASK_KEY } from "../../config/constants";
+
+/** An helper to read and write ongoing task import id from the local storage */
+export class TaskImportCacheHelper {
+    readonly mailboxId: string | undefined;
+    readonly #key: string;
+    readonly #staleTime = 2 * 24 * 60 * 60 * 1000; // 2 days in ms
+
+
+    constructor(mailboxId: string | undefined) {
+        this.mailboxId = mailboxId;
+        this.#key = `${MESSAGE_IMPORT_TASK_KEY}_${mailboxId}`;
+    }
+
+    #serialize(taskId: string) {
+        const expiresAt = Date.now() + this.#staleTime;
+        return `${taskId}:${expiresAt}`;
+    }
+
+    #deserialize(value: string) {
+        const [taskId, expiresAt] = value.split(":");
+        return { taskId, expiresAt: parseInt(expiresAt) || 0 };
+    }
+
+    get() {
+        if (typeof window === "undefined" || !this.mailboxId) return null;
+        const value = localStorage.getItem(this.#key);
+        if (!value) return null
+
+        const { taskId, expiresAt } = this.#deserialize(value);
+        if (Date.now() <= expiresAt) return taskId;
+
+        this.remove();
+        return null;
+    }
+
+    set(taskId: string) {
+        if (typeof window === "undefined" || !this.mailboxId) return;
+        localStorage.setItem(this.#key, this.#serialize(taskId));
+    }
+
+    remove() {
+        if (typeof window === "undefined" || !this.mailboxId) return;
+        localStorage.removeItem(this.#key);
+    }
+}


### PR DESCRIPTION
## Purpose

Currently when we store a task import id globally. So once the user has launched one import he is not able to start a new import from another mailbox. Furthermore, currently the storage never expires that is weird. Now after 48hours, if the task is still pending we consider it as stale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Uploading your archive" status message during message import uploads in English and French locales.
  * Enhanced message importer workflow with dedicated uploading state indication.

* **Chores**
  * Updated build configuration to use Turbopack for improved development performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->