### PR TITLE
🌐(frontend) change import modal title

### DIFF
--- a/src/frontend/public/locales/common/en-US.json
+++ b/src/frontend/public/locales/common/en-US.json
@@ -155,7 +155,7 @@
   "Import": "Import",
   "Import failed": "Import failed",
   "Import messages": "Import messages",
-  "Import your old messages": "Import your old messages",
+  "Import your old messages in {{mailbox}}": "Import your old messages in {{mailbox}}",
   "Imported messages": "Imported messages",
   "Importing messages...": "Importing messages...",
   "Importing...": "Importing...",

--- a/src/frontend/public/locales/common/fr-FR.json
+++ b/src/frontend/public/locales/common/fr-FR.json
@@ -155,7 +155,7 @@
   "Import": "Importer",
   "Import failed": "Importation échouée",
   "Import messages": "Importer des messages",
-  "Import your old messages": "Importer vos anciens messages",
+  "Import your old messages in {{mailbox}}": "Importer vos anciens messages dans {{mailbox}}",
   "Imported messages": "Messages importés",
   "Importing messages...": "Importation des messages...",
   "Importing...": "Importation en cours...",

--- a/src/frontend/src/features/controlled-modals/message-importer/index.tsx
+++ b/src/frontend/src/features/controlled-modals/message-importer/index.tsx
@@ -87,9 +87,12 @@ export const ModalMessageImporter = () => {
         return () => window.removeEventListener("beforeunload", unloadCallback);
     }, [step]);
 
+
+    if (!selectedMailbox) return null;
+
     return (
         <ControlledModal
-            title={t('Import your old messages')}
+            title={t('Import your old messages in {{mailbox}}', { mailbox: selectedMailbox.email })}
             modalId={MODAL_MESSAGE_IMPORTER_ID}
             size={ModalSize.LARGE}
             confirmFn={step !== 'uploading' ? undefined : handleConfirmCloseModal}

--- a/src/frontend/src/features/providers/modal-store/global-store.ts
+++ b/src/frontend/src/features/providers/modal-store/global-store.ts
@@ -1,16 +1,16 @@
-import { ReactElement } from "react";
+import { ReactNode } from "react";
 
 /**
  * A global store to register all the modals controlled by the ModalStoreProvider.
  * To register a modal, use the `registerModal` function.
  */
-export const modalStore = new Map<string, () => ReactElement>();
+export const modalStore = new Map<string, () => ReactNode>();
 
 /**
  * Register a modal controlled by the ModalStoreProvider.
  * Provide a modal id and the associated Modal component to be rendered.
  */
-export const registerModal = (modalId: string, Modal: () => ReactElement) => {
+export const registerModal = (modalId: string, Modal: () => ReactNode) => {
     if (modalStore.has(modalId)) {
         throw new Error(`Modal with id ${modalId} already registered.`);
     }


### PR DESCRIPTION
## Purpose

Bind the selected mailbox email into the import modal title. As we can now import emails for each mailbox at the same time, it can be useful to display the related mailbox for which import is ongoing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Import messages dialog now shows which mailbox messages are being imported into for clarity.
  * English and French translations updated to include mailbox context in the import dialog.

* **Bug Fixes**
  * Import modal no longer appears without a selected mailbox, preventing an empty/ambiguous dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->