### PR TITLE
🐛(permissions) resolve MultipleObjectsReturned when user has access t…

### DIFF
--- a/src/backend/core/api/permissions.py
+++ b/src/backend/core/api/permissions.py
@@ -148,31 +148,20 @@ class IsAllowedToAccess(IsAuthenticated):
 
             # Only EDITOR, SENDER or ADMIN role can destroy. SENDER or ADMIN can send.
             if view.action in ["destroy", "send"]:
-                mailbox = thread.accesses.get(mailbox__accesses__user=user).mailbox
-                if (
-                    models.ThreadAccess.objects.filter(
-                        thread=thread,
-                        mailbox=mailbox,
-                        role=enums.ThreadAccessRoleChoices.EDITOR,
-                    ).exists()
-                    and models.MailboxAccess.objects.filter(
-                        mailbox=mailbox,
-                        user=user,
-                        role__in=[
-                            enums.MailboxRoleChoices.ADMIN,
-                            enums.MailboxRoleChoices.SENDER,
-                        ]
-                        + (
-                            [enums.MailboxRoleChoices.EDITOR]
-                            if view.action == "destroy"
-                            else []
-                        ),
-                    ).exists()
-                ):
-                    return True
+                # filter only mailboxes with editor role on thread
+                # and check if user has enough role on those mailboxes to destroy or send the message
+                minimal_user_role = (
+                    enums.MailboxRoleChoices.EDITOR
+                    if view.action == "destroy"
+                    else enums.MailboxRoleChoices.SENDER
+                )
+                return thread.accesses.filter(
+                    role=enums.ThreadAccessRoleChoices.EDITOR,
+                    mailbox__accesses__user=user,
+                    mailbox__accesses__role__gte=minimal_user_role,
+                ).exists()
             # for retrieve action has_access is already checked above
-            else:
-                return True
+            return True
 
         # Deny access for other object types or if type is unknown
         return False

--- a/src/backend/core/tests/api/test_messages_create.py
+++ b/src/backend/core/tests/api/test_messages_create.py
@@ -1458,3 +1458,96 @@ class TestApiDraftAndSendReply:
         # Final check: Still only one thread per mailbox
         assert models.Thread.objects.filter(accesses__mailbox=mailbox1).count() == 1
         assert models.Thread.objects.filter(accesses__mailbox=mailbox2).count() == 1
+
+    def test_send_message_with_user_having_role_on_two_mailboxes_on_same_thread(
+        self, mailbox, mailbox2, authenticated_user, send_url
+    ):
+        """
+        Test that sending a message succeeds when a user has access to two mailboxes
+        that both have access to the same thread.
+        """
+        # Create a mailbox access on this mailbox for the authenticated user
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=authenticated_user,
+            role=enums.MailboxRoleChoices.SENDER,
+        )
+        # Give the user access to mailbox2 with ADMIN role
+        factories.MailboxAccessFactory(
+            mailbox=mailbox2,
+            user=authenticated_user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+        # Create a thread with a message
+        thread_access = factories.ThreadAccessFactory(
+            mailbox=mailbox,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+        _thread_access_2 = factories.ThreadAccessFactory(
+            mailbox=mailbox2,
+            thread=thread_access.thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+        message = factories.MessageFactory(thread=thread_access.thread, read_at=None)
+        factories.MessageRecipientFactory(
+            message=message,
+            type=enums.MessageRecipientTypeChoices.TO,
+        )
+
+        # Create a client and authenticate the user
+        client = APIClient()
+        client.force_authenticate(user=authenticated_user)
+
+        # Step 1: Create a draft reply
+        draft_response = client.post(
+            reverse("draft-message"),
+            {
+                "parentId": message.id,  # ID of the message we're replying to
+                "senderId": mailbox.id,
+                "subject": "test reply",
+                "draftBody": "<p>test reply</p> or test reply",
+                "to": ["pierre@example.com"],
+            },
+            format="json",
+        )
+
+        # Assert the draft response is successful
+        assert draft_response.status_code == status.HTTP_201_CREATED
+
+        # Assert the draft message is created
+        draft_message = models.Message.objects.get(id=draft_response.data["id"])
+        assert draft_message.is_draft is True
+        assert draft_message.parent == message
+
+        draft_api_message = client.get(
+            reverse("messages-detail", kwargs={"id": draft_message.id})
+        ).data
+        assert draft_api_message["is_draft"] is True
+        assert draft_api_message["parent_id"] == str(message.id)
+
+        # Step 2: Send the draft reply
+        send_response = client.post(
+            send_url,
+            {
+                "messageId": draft_message.id,
+                "senderId": mailbox.id,
+                "textBody": "test",
+            },
+            format="json",
+        )
+
+        # Assert the send response is successful
+        assert send_response.status_code == status.HTTP_200_OK
+
+        # Assert the message is now sent
+        sent_message = models.Message.objects.get(id=draft_message.id)
+        assert sent_message.is_draft is False
+        assert sent_message.sent_at is not None
+
+        # Assert the message and thread are created correctly
+        assert models.Message.objects.count() == 2
+        assert models.Thread.objects.count() == 1
+
+        # Assert the message is correct
+        assert sent_message.subject == "test reply"
+        assert sent_message.thread == thread_access.thread


### PR DESCRIPTION
…o multiple mailboxes on same thread

The has_object_permission method was failing with MultipleObjectsReturned exception when a user had access to multiple mailboxes that both have access to the same thread.

Changes:
- Filter thread accesses by EDITOR role and check user mailbox permissions
- Use filter().exists() instead of get() to avoid MultipleObjectsReturned
- Add test case to verify users can send messages when they have access to multiple mailboxes on the same thread


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined permission evaluation for message and thread actions to a per-mailbox, per-action check, improving role-based authorization and reducing incorrect denials for send/destroy operations.

* **Tests**
  * Added end-to-end coverage for sending messages when a user holds different roles across multiple mailboxes in the same thread, ensuring correct send behavior and thread/message state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->