### PR TITLE
🧱(backups) fix restic retention conflict with scalingo one-offs

### DIFF
--- a/bin/scalingo_pgdump.sh
+++ b/bin/scalingo_pgdump.sh
@@ -34,4 +34,4 @@ export RESTIC_REPOSITORY=s3:${BACKUP_PGSQL_S3_REPOSITORY}/${APP}
 
 ./restic backup ${FILENAME}
 # Scalingo one-offs use a different hostname every time group only by paths and not by hosts,paths.
-./restic forget --keep-daily 30 --keep-last 30 --group-by 'paths'  --prune
+./restic forget --keep-daily 30 --group-by 'paths' --prune


### PR DESCRIPTION
Scalingo one-offs use a different hostname every time group only by paths and not by hosts,paths
Also, add the `--prune` option to actually delete data and not just indices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved snapshot management with enhanced grouping and pruning, maintaining 30-day retention policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->