### PR TITLE
🩹(text rendering) fix plain text line breaks

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/message-body.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/message-body.tsx
@@ -88,19 +88,40 @@ const MessageBody = ({ rawHtmlBody, rawTextBody = '', attachments = [], isHidden
     }, [cidToBlobUrlMap]);
 
     const sanitizedHtmlBody = useMemo(() => {
-        const sanitizedContent = domPurify.sanitize(rawHtmlBody || rawTextBody, {
-            FORBID_TAGS: ['script', 'object', 'iframe', 'embed', 'audio', 'video'],
-            ADD_ATTR: ['target', 'rel'],
-        });
+        if (rawHtmlBody) {
+            // For HTML content, sanitize as HTML
+            const sanitizedContent = domPurify.sanitize(rawHtmlBody, {
+                FORBID_TAGS: ['script', 'object', 'iframe', 'embed', 'audio', 'video'],
+                ADD_ATTR: ['target', 'rel'],
+            });
 
-        const unquoteMessage = new UnquoteMessage(sanitizedContent, sanitizedContent, {
-            mode: 'wrap',
-            ignoreFirstForward: true,
-            depth: 0,
-        });
+            const unquoteMessage = new UnquoteMessage(sanitizedContent, sanitizedContent, {
+                mode: 'wrap',
+                ignoreFirstForward: true,
+                depth: 0,
+            });
 
-        if (rawHtmlBody) return unquoteMessage.getHtml().content;
-        return unquoteMessage.getText().content;
+            return unquoteMessage.getHtml().content;
+        } else {
+            // For plain text, process with UnquoteMessage first (preserving newlines)
+            const unquoteMessage = new UnquoteMessage('', rawTextBody, {
+                mode: 'wrap',
+                ignoreFirstForward: true,
+                depth: 0,
+            });
+
+            const unquotedText = unquoteMessage.getText().content;
+
+            // Wrap in a div with class for CSS styling, and escape HTML entities
+            const textAsHtml = `<div class="text-plain-content">${unquotedText
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;')}</div>`;
+
+            return textAsHtml;
+        }
     }, [rawHtmlBody, rawTextBody, domPurify]);
 
     const wrappedHtml = useMemo(() => {
@@ -118,6 +139,10 @@ const MessageBody = ({ rawHtmlBody, rawTextBody = '', attachments = [], isHidden
                     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
                     font-size: 14px;
                     color: #24292e;
+                }
+                .text-plain-content {
+                    white-space: pre-wrap;
+                    word-wrap: break-word;
                 }
                 body > *:first-child {
                     padding-top: 0 !important;


### PR DESCRIPTION
Before:

<img width="776" height="182" alt="image" src="https://github.com/user-attachments/assets/694f30ba-6a7e-442f-b08d-8e7b56d1fb75" />

After:

<img width="822" height="390" alt="image" src="https://github.com/user-attachments/assets/9b5b0fdd-f433-4630-ac60-5a508250bdf6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message display formatting to properly preserve line breaks and text wrapping in plain text content.
  * Improved HTML content handling and rendering in message bodies for better consistency and display quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->