### PR TITLE
🩹(text rendering) fix plain text line breaks

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/message-body.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/message-body.tsx
@@ -95,7 +95,7 @@ const MessageBody = ({ rawHtmlBody, rawTextBody = '', attachments = [], isHidden
                 ADD_ATTR: ['target', 'rel'],
             });
 
-            const unquoteMessage = new UnquoteMessage(sanitizedContent, sanitizedContent, {
+            const unquoteMessage = new UnquoteMessage(sanitizedContent, '', {
                 mode: 'wrap',
                 ignoreFirstForward: true,
                 depth: 0,


### PR DESCRIPTION
Improves over https://github.com/suitenumerique/messages/pull/426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plain-text messages now render with preserved whitespace and proper word wrapping.
  * HTML messages display inline images correctly by converting embedded references to viewable image sources.

* **New Features**
  * Viewer now reliably distinguishes and renders HTML vs. plain-text message bodies, applying appropriate escaping and styling for each.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->