### PR TITLE
🩹(mime) parsing fixes

### DIFF
--- a/src/backend/core/tests/mda/test_rfc5322_parser.py
+++ b/src/backend/core/tests/mda/test_rfc5322_parser.py
@@ -577,7 +577,7 @@ aW1hZ2UgZGF0YSBoZXJl
         assert not content["textBody"]
         assert len(content["attachments"]) == 1
         attachment = content["attachments"][0]
-        assert attachment["name"] == "image.png" or attachment["name"] == "unnamed"
+        assert attachment["name"] in ("image.png", "unnamed.png")
         assert attachment["type"] == "image/png"
         assert attachment["cid"] == "image1"
 
@@ -627,7 +627,7 @@ PDF data
         assert content["textBody"][0]["content"] == "Main body.\n"
         assert len(content["attachments"]) == 1
         attachment = content["attachments"][0]
-        assert attachment.get("name") == "unnamed"
+        assert attachment.get("name") == "unnamed.pdf"
         assert attachment["type"] == "application/pdf"
         assert attachment["content"] == b"PDF data"
 


### PR DESCRIPTION
## Summary

  Fix MIME parsing issues where inline HTML and calendar invites were incorrectly treated as downloadable attachments, and bodytext as unnamed attachments.

  Cherry-picked from upstream PR #419 (suitenumerique/messages).

  ## Changes

  - Fix inline HTML being treated as attachment
  - Refactor parser to use Flanker's built-in `is_attachment()`, `is_body()`, and `is_inline()` methods
  - Fix text/calendar parts with `Content-Disposition: inline` being misclassified
  
  ## Commits

  - 🩹(mime) fix inline HTML being treated as attachment
  - ♻️(mime) refactor parser to use Flanker's built-in methods
  - fix: Add missing disposition_header variable definition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved email parsing to use library-driven part classification, streamlining identification of attachments, inline content, and message bodies.
  * Consolidated and simplified handling so text/HTML bodies and attachments are processed more reliably.

* **Bug Fixes**
  * Better filename inference for attachments (adds typical extensions when missing) so attachments and inline images get sensible names.
  * More robust fallback and error handling for unclassified parts, reducing dropped or misclassified content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->