### PR TITLE
✨(dkim) add an optional DKIM verification just before sending emails

### DIFF
--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -331,6 +331,13 @@ class Base(Configuration):
         "stmessages", environ_name="MESSAGES_DKIM_DEFAULT_SELECTOR", environ_prefix=None
     )
 
+    # DKIM verification settings
+    MESSAGES_DKIM_VERIFY_OUTGOING = values.BooleanValue(
+        default=False,
+        environ_name="MESSAGES_DKIM_VERIFY_OUTGOING",
+        environ_prefix=None,
+    )
+
     # Technical domain for DNS records (MX, SPF, DKIM hosting)
     MESSAGES_TECHNICAL_DOMAIN = values.Value(
         "localhost", environ_name="MESSAGES_TECHNICAL_DOMAIN", environ_prefix=None


### PR DESCRIPTION
This will catch the case where people try to send email before having correctly configured their DNS, and would also avoid unwanted sends of messages not supposed to go out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DKIM signature verification for outgoing messages to external recipients before delivery
  * Failed verification triggers automatic message retry with error notification
  * New configuration option to enable/disable DKIM verification for outgoing messages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->