### PR TITLE
Add dutch patterns for attachment detection

### DIFF
--- a/src/frontend/src/features/i18n/attachments-detection-map.json
+++ b/src/frontend/src/features/i18n/attachments-detection-map.json
@@ -98,9 +98,7 @@
       "bijgevoegd document",
       "ingesloten",
       "zie bijlage",
-      "in de bijlage",
-      "bijgevoegd is",
-      "bijgevoegd zijn"
+      "in de bijlage"
     ],
     "find_attached": [
       "bijgevoegd vindt u",
@@ -109,12 +107,7 @@
       "u vindt bijgevoegd",
       "hierbij vindt u",
       "bijgevoegd vind je",
-      "in de bijlage vindt u",
-      "vind je bijgevoegd",
-      "vind bijgevoegd",
-      "zie je bijgevoegd",
-      "zie u bijgevoegd",
-      "in de bijlage vind je"
+      "in de bijlage vindt u"
     ],
     "intent_to_attach": [
       "ik voeg toe",
@@ -123,12 +116,7 @@
       "ik voeg bij",
       "ik stuur u",
       "ik zend je",
-      "ik zal toevoegen",
-      "hierbij stuur ik",
-      "ik ben vergeten bij te voegen",
-      "ik was vergeten bij te voegen",
-      "ik ben vergeten toe te voegen",
-      "vergeten bij te voegen"
+      "ik zal toevoegen"
     ],
     "ambiguous_keywords": [
       "bijgevoegd",
@@ -137,6 +125,13 @@
     "abbreviations": [
       "bijl.",
       "bgv."
+    ],
+    "patterns": [
+      "(zie|vind(t)?) (je |u )?bijgevoegd",
+      "bijgevoegd (is|zijn|vindt u|vind je)",
+      "in de bijlage (vindt u|vind je)",
+      "ik (ben|was) vergeten (bij te voegen|toe te voegen)",
+      "(hierbij|anbij) (stuur|zend) ik( je| u)?( het| de)?( bestand| document)?"
     ]
   }
 }


### PR DESCRIPTION
## Purpose

The patterns that trigger an email attachment warning are currently only defined in English and French. 


## Proposal

Add detection patterns for Dutch. 🇳🇱🧀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Dutch localization for attachment-detection phrases, covering keywords, abbreviations, and varied expressions to improve Dutch-language support.
  * Standardized French apostrophe patterns in attachment-detection phrases to improve consistency and reliability of French-language processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->