### PR TITLE
🐛(frontend) use dynamic pattern matching on forgotten attachments alerting

### DIFF
--- a/src/frontend/src/features/i18n/attachments-detection-map.json
+++ b/src/frontend/src/features/i18n/attachments-detection-map.json
@@ -38,12 +38,12 @@
       "enc."
     ],
     "patterns": [
-      "please (see|find) (the )?attached",
-      "you will find (the )?attached",
-      "attached (is|are|you’ll find)",
-      "find (the )?attached file",
-      "enclosed (you will find|please find)?",
-      "I (forgot|didn’t) (to )?(attach|include)"
+      "/please (see|find) (the )?attached/",
+      "/you will find (the )?attached/",
+      "/attached (is|are|you['']ll find)/",
+      "/find (the )?attached file/",
+      "/enclosed (you will find|please find)?/",
+      "/I (forgot|didn['']t) (to )?(attach|include)/"
     ]
   },
   "fr": {
@@ -85,10 +85,10 @@
       "annexe"
     ],
     "patterns": [
-      "vous trouverez (ci-joint|en pièce jointe)",
-      "je (vous )?(joins|envoie) (le|la|les)? (fichier|document|pièce jointe)",
-      "en pièce jointe(,)? (vous trouverez|je vous ai mis)",
-      "j['']?ai oublié (de )?(joindre|mettre en pièce jointe)"
+      "/vous trouverez (ci-joint|en pièce jointe)/",
+      "/je (vous )?(joins|envoie) (le|la|les)? (fichier|document|pièce jointe)/",
+      "/en pièce jointe(,)? (vous trouverez|je vous ai mis)/",
+      "/j['']?ai oublié (de )?(joindre|mettre en pièce jointe)/"
     ]
   },
   "nl": {
@@ -127,11 +127,11 @@
       "bgv."
     ],
     "patterns": [
-      "(zie|vind(t)?) (je |u )?bijgevoegd",
-      "bijgevoegd (is|zijn|vindt u|vind je)",
-      "in de bijlage (vindt u|vind je)",
-      "ik (ben|was) vergeten (bij te voegen|toe te voegen)",
-      "(hierbij|anbij) (stuur|zend) ik( je| u)?( het| de)?( bestand| document)?"
+      "/(zie|vind(t)?) (je |u )?bijgevoegd/",
+      "/bijgevoegd (is|zijn|vindt u|vind je)/",
+      "/in de bijlage (vindt u|vind je)/",
+      "/ik (ben|was) vergeten (bij te voegen|toe te voegen)/",
+      "/(hierbij|anbij) (stuur|zend) ik( je| u)?( het| de)?( bestand| document)?/"
     ]
   }
 }

--- a/src/frontend/src/features/utils/mail-helper.test.tsx
+++ b/src/frontend/src/features/utils/mail-helper.test.tsx
@@ -1,4 +1,5 @@
 import MailHelper, { SUPPORTED_IMAP_DOMAINS, ATTACHMENT_SEPARATORS } from './mail-helper';
+import DetectionMap from '@/features/i18n/attachments-detection-map.json';
 
 describe('MailHelper', () => {
   describe('markdownToHtml', () => {
@@ -220,6 +221,12 @@ describe('MailHelper', () => {
 
     it('should handle empty safely', () => {
       expect(MailHelper.areAttachmentsMentionedInDraft('')).toBe(false);
+    });
+
+    it('should use regex patterns if present', () => {
+      const draftText = 'I didn\'t include the document.';
+      const result = MailHelper.areAttachmentsMentionedInDraft(draftText);
+      expect(result).toBe(true);
     });
   });
 
@@ -746,6 +753,16 @@ describe('MailHelper', () => {
           { id: '1', name: 'valid.pdf', url: 'https://example.com/valid.pdf', type: 'application/pdf', size: 100, created_at: '2021-01-01' }
         ]
       ]);
+    });
+  });
+
+  describe('DetectionMap', () => {
+    it('should not have invalid regex patterns', () => {
+      // A test guard to ensure that the detection map does not contain malformed regex patterns
+      const regexPatterns = MailHelper.getAttachmentKeywords(DetectionMap).filter((pattern) => pattern.startsWith('/') && pattern.endsWith('/'));
+      for (const pattern of regexPatterns) {
+        expect(() => new RegExp(pattern.slice(1, -1), 'i')).not.toThrowError();
+      }
     });
   });
 });

--- a/src/frontend/src/features/utils/mail-helper.tsx
+++ b/src/frontend/src/features/utils/mail-helper.tsx
@@ -118,10 +118,20 @@ class MailHelper {
     /**
      * Check if any attachment keyword is mentioned in the draft text.
      */
-    static areAttachmentsMentionedInDraft(draftText: string): boolean {
-        const keyWordsAttachments = MailHelper.getAttachmentKeywords(DetectionMap);
-        const messageEditorDraft = draftText?.toLowerCase() || "";
-        return keyWordsAttachments.some((keyword) => messageEditorDraft.includes(keyword));
+    static areAttachmentsMentionedInDraft(draftText: string = ''): boolean {
+        const patterns = MailHelper.getAttachmentKeywords(DetectionMap);
+        return patterns.some((pattern) => {
+            const isRegex = pattern.startsWith('/') && pattern.endsWith('/');
+            if (isRegex) {
+                try {
+                    return new RegExp(pattern.slice(1, -1), 'i').test(draftText);
+                } catch (e) {
+                    console.error('Invalid regex pattern', pattern, e);
+                    return false;
+                }
+            }
+            return draftText.toLowerCase().includes(pattern);
+        });
     }
 
     /**


### PR DESCRIPTION
## Purpose

Fix issue related to dynamic pattern matching in forgotten attachments alerting.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of attachment-related mentions in drafts using per-pattern, case-insensitive matching with safe fallback and robust handling of empty or malformed patterns — reduces missed reminders.

* **Tests**
  * Expanded coverage to validate pattern-based (including regex-style) matching and edge cases across multiple languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->