### PR TITLE
🐛(backend) disable pagination for thread messages

### DIFF
--- a/src/backend/core/api/viewsets/message.py
+++ b/src/backend/core/api/viewsets/message.py
@@ -25,6 +25,7 @@ class MessageViewSet(
         permissions.IsAuthenticated,
         permissions.IsAllowedToAccess,
     ]
+    pagination_class = None  # Show all messages in a thread without pagination
     queryset = models.Message.objects.all()
     lookup_field = "id"
     lookup_url_kwarg = "id"


### PR DESCRIPTION
Long threads (more than 20 messages) only displayed the first 20 messages because the MessageViewSet used the default PAGE_SIZE of 20. The frontend doesn't handle pagination for messages, so additional messages were silently hidden from users.

This fix disables pagination for the messages endpoint since threads typically don't have enough messages to require pagination.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Disabled pagination for thread messages, enabling all messages to display together in conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->