### PR TITLE
✨(search) add spam folder and search functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Allow to save an attachment into Drive workspace #408
+- Add a SPAM folder in mailbox panel
+- Allow to search for spam messages
+
 ### Changed
 
 - Configure Drive App Name through environment variable (DRIVE_APP_NAME)
 - Inherit OIDC Authentication backend from django-lasuite #408
 
-### Added
-
-- Allow to save an attachment into Drive workspace #408

--- a/src/backend/core/api/viewsets/thread.py
+++ b/src/backend/core/api/viewsets/thread.py
@@ -369,8 +369,8 @@ class ThreadViewSet(
     def list(self, request, *args, **kwargs):
         """List threads with optional search functionality."""
         search_query = request.query_params.get("search", "").strip()
-
         mailbox_id = request.query_params.get("mailbox_id")
+
         if mailbox_id:
             mailbox_access = models.MailboxAccess.objects.filter(
                 mailbox=mailbox_id, user=request.user
@@ -438,6 +438,7 @@ class ThreadViewSet(
                 }
             )
         # Fall back to regular DB query if no search query or OpenSearch not available
+
         return super().list(request, *args, **kwargs)
 
     @extend_schema(

--- a/src/backend/core/services/search/index.py
+++ b/src/backend/core/services/search/index.py
@@ -134,6 +134,7 @@ def index_message(message: models.Message) -> bool:
         "is_draft": message.is_draft,
         "is_trashed": message.is_trashed,
         "is_archived": message.is_archived,
+        "is_spam": message.is_spam,
         "is_starred": message.is_starred,
         "is_unread": message.is_unread,
         "is_sender": message.is_sender,

--- a/src/backend/core/services/search/mapping.py
+++ b/src/backend/core/services/search/mapping.py
@@ -111,6 +111,7 @@ MESSAGE_MAPPING = {
             "is_draft": {"type": "boolean"},
             "is_trashed": {"type": "boolean"},
             "is_archived": {"type": "boolean"},
+            "is_spam": {"type": "boolean"},
             "is_starred": {"type": "boolean"},
             "is_unread": {"type": "boolean"},
             "is_sender": {"type": "boolean"},

--- a/src/backend/core/services/search/parse.py
+++ b/src/backend/core/services/search/parse.py
@@ -17,6 +17,7 @@ def parse_search_query(query: str) -> Dict[str, Any]:
     - "exact phrase" - quoted text for exact matching
     - in:trash (dans:corbeille) - in trash
     - in:archives (dans:archives or dans:archivés) - in archives
+    - in:spam (dans:spam) - in spam
     - in:sent (dans:envoyes or dans:envoyés) - sent items
     - in:drafts (dans:brouillons) - drafts
     - is:starred (est:suivi) - starred
@@ -47,6 +48,7 @@ def parse_search_query(query: str) -> Dict[str, Any]:
         "in_trash": ["in:trash", "dans:corbeille", "in:prullenbak"],
         "in_sent": ["in:sent", "dans:envoyes", "dans:envoyés", "in:verzonden"],
         "in_archives": ["in:archives", "dans:archives", "dans:archivés", "in:archief"],
+        "in_spam": ["in:spam", "dans:spam"],
         "in_drafts": ["in:drafts", "dans:brouillons", "in:concepten"],
         "is_starred": ["is:starred", "est:suivi", "is:gemarkeerd"],
         "is_read_true": ["is:read", "est:lu", "is:gelezen"],
@@ -59,6 +61,7 @@ def parse_search_query(query: str) -> Dict[str, Any]:
         "in_trash": "in_trash",
         "in_sent": "in_sent",
         "in_archives": "in_archives",
+        "in_spam": "in_spam",
         "in_drafts": "in_drafts",
         "is_starred": "is_starred",
         "is_read_true": "is_read",
@@ -68,6 +71,7 @@ def parse_search_query(query: str) -> Dict[str, Any]:
         "in_trash": True,
         "in_sent": True,
         "in_archives": True,
+        "in_spam": True,
         "in_drafts": True,
         "is_starred": True,
         "is_read_true": True,

--- a/src/backend/core/services/search/search.py
+++ b/src/backend/core/services/search/search.py
@@ -158,6 +158,11 @@ def search_threads(
             search_body["query"]["bool"]["filter"].append(
                 {"term": {"is_archived": True}}
             )
+        if parsed_query.get("in_spam"):
+            search_body["query"]["bool"]["filter"].append({"term": {"is_spam": True}})
+        else:
+            # Spam messages should be excluded from search results until the user explicitly searches for spam
+            search_body["query"]["bool"]["filter"].append({"term": {"is_spam": False}})
 
         # Add is: filters (starred, read, unread)
         if parsed_query.get("is_starred", False):

--- a/src/backend/core/tests/search/test_parse_query.py
+++ b/src/backend/core/tests/search/test_parse_query.py
@@ -160,6 +160,22 @@ def test_search_parse_query_in_archives_modifier_french_without_accent():
     assert result == {"text": "some text", "in_archives": True}
 
 
+def test_search_parse_query_in_spam_modifier_english():
+    """Test parsing 'in:spam' modifier in English."""
+    query = "in:spam some text"
+    result = parse_search_query(query)
+
+    assert result == {"text": "some text", "in_spam": True}
+
+
+def test_search_parse_query_in_spam_modifier_french():
+    """Test parsing 'dans:spam' modifier in French."""
+    query = "dans:spam some text"
+    result = parse_search_query(query)
+
+    assert result == {"text": "some text", "in_spam": True}
+
+
 def test_search_parse_query_in_sent_modifier_english():
     """Test parsing 'in:sent' modifier in English."""
     query = "in:sent some text"

--- a/src/frontend/public/locales/common/en-US.json
+++ b/src/frontend/public/locales/common/en-US.json
@@ -278,6 +278,7 @@
   "Signatures": "Signatures",
   "Simple and intuitive messaging": "Simple and intuitive messaging",
   "Simple redirect (Coming soon)": "Simple redirect (Coming soon)",
+  "Spam": "Spam",
   "Start typing...": "Start typing...",
   "Subject": "Subject",
   "Subject:": "Subject:",

--- a/src/frontend/public/locales/common/fr-FR.json
+++ b/src/frontend/public/locales/common/fr-FR.json
@@ -278,6 +278,7 @@
   "Signatures": "Signatures",
   "Simple and intuitive messaging": "Une messagerie simple et intuitive",
   "Simple redirect (Coming soon)": "Créer une simple redirection (Bientôt disponible)",
+  "Spam": "Spam",
   "Start typing...": "Commencez à écrire...",
   "Subject": "Objet",
   "Subject:": "Objet :",

--- a/src/frontend/src/features/i18n/search-filters-map.json
+++ b/src/frontend/src/features/i18n/search-filters-map.json
@@ -8,6 +8,7 @@
         "in_archives": ["in:archives"],
         "in_sent": ["in:sent"],
         "in_drafts": ["in:drafts"],
+        "in_spam": ["in:spam"],
         "is_read": ["is:read"],
         "is_unread": ["is:unread"]
     },
@@ -20,6 +21,7 @@
         "in_archives": ["dans:archives", "dans:archivés"],
         "in_sent": ["dans:envoyes", "dans:envoyés"],
         "in_drafts": ["dans:brouillons"],
+        "in_spam": ["dans:spam"],
         "is_read": ["est:lu"],
         "is_unread": ["est:nonlu"]
     },
@@ -32,6 +34,7 @@
         "in_archives": ["in:archief"],
         "in_sent": ["in:verzonden"],
         "in_drafts": ["in:concepten"],
+        "in_spam": ["in:spam"],
         "is_read": ["is:gelezen"],
         "is_unread": ["is:ongelezen"]
     }

--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-list/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-list/index.tsx
@@ -65,6 +65,15 @@ export const MAILBOX_FOLDERS = (): Folder[] => [
         },
     },
     {
+        id: "spam",
+        name: i18n.t("Spam"),
+        icon: "report",
+        searchable: true,
+        filter: {
+            is_spam: "1",
+        },
+    },
+    {
         id: "trash",
         name: i18n.t("Trash"),
         icon: "delete",
@@ -73,14 +82,6 @@ export const MAILBOX_FOLDERS = (): Folder[] => [
             has_trashed: "1",
         },
     },
-    // {
-    //     id: "spam",
-    //     name: "folders.spam",
-    //     icon: "report",
-    //     filter: {
-    //         is_spam: "1",
-    //     },
-    // },
 ];
 
 export const MailboxList = () => {


### PR DESCRIPTION
## Purpose

Display the SPAM folder in the mailbox panel and allow to search SPAM messages. Unlike other message flags, SPAM messages are not included in search result by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Spam folder in the mailbox panel.
  * Search supports spam-specific queries (in:spam / dans:spam).

* **Changes**
  * Spam messages are excluded from general search results by default.

* **Tests**
  * Added parser and end-to-end tests covering the in:spam modifier.

* **Localization**
  * Added Spam translations and search-filter entries for supported locales.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->