### PR TITLE
🐛(frontend) refresh thread view on new messages

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
@@ -38,7 +38,7 @@ export const ThreadMessage = forwardRef<HTMLElement, ThreadMessageProps>(
         const replyFormRef = useRef<HTMLDivElement>(null);
         const threadViewContext = useThreadViewContext()
         const isMessageReady = threadViewContext.isMessageReady(message.id);
-        const [isMessageBodyLoaded, setIsMessageBodyLoaded] = useState(false);
+        const [isMessageBodyLoaded, setIsMessageBodyLoaded] = useState(isMessageReady);
         const [isFolded, setIsFolded] = useState(!isLatest && !message.is_unread && !draftMessage?.is_draft);
         const [replyFormMode, setReplyFormMode] = useState<MessageFormMode | null>(getReplyFormMode)
         const previousReplyFormMode = usePrevious<MessageFormMode | null>(replyFormMode);
@@ -96,10 +96,6 @@ export const ThreadMessage = forwardRef<HTMLElement, ThreadMessageProps>(
         useEffect(() => {
             setReplyFormMode(getReplyFormMode())
         }, [message, draftMessage])
-
-        useEffect(() => {
-            setIsFolded(!isLatest && !message.is_unread && !draftMessage?.is_draft);
-        }, [isLatest, draftMessage?.is_draft])
 
         // Smooth scroll to the reply form when it is opened by the user
         useEffect(() => {

--- a/src/frontend/src/features/layouts/components/thread-view/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/index.tsx
@@ -42,7 +42,7 @@ const ThreadViewComponent = ({ messages, mailboxId, thread, showTrashedMessages,
     const rootRef = useRef<HTMLDivElement>(null);
     const { markAsRead } = useRead();
     const isAISummaryEnabled = useFeatureFlag(FEATURE_KEYS.AI_SUMMARY);
-    const { isReady, reset } = useThreadViewContext();
+    const { isReady, reset, hasBeenInitialized, setHasBeenInitialized } = useThreadViewContext();
     // Refs for all unread messages
     const unreadRefs = useRef<Record<string, HTMLElement | null>>({});
     // Find all unread message IDs
@@ -95,7 +95,7 @@ const ThreadViewComponent = ({ messages, mailboxId, thread, showTrashedMessages,
     }, [isReady, unreadMessageIds.join(","), thread.id]);
 
     useEffect(() => {
-        if (isReady) {
+        if (isReady && !hasBeenInitialized) {
             let messageToScroll = latestMessage?.id;
             let selector = `#thread-message-${messageToScroll}`;
             if (draftMessageIds.length > 0) {
@@ -109,14 +109,14 @@ const ThreadViewComponent = ({ messages, mailboxId, thread, showTrashedMessages,
             const el = document.querySelector<HTMLElement>(selector);
             if (el) {
                 rootRef.current?.scrollTo({ top: el.offsetTop - 225, behavior: 'instant' });
+                setHasBeenInitialized(true);
             }
         }
     }, [isReady]);
 
-    useEffect(() => {
+    useEffect(() => () => {
         reset();
     }, [thread.id]);
-
 
     return (
         <div className={clsx("thread-view", { "thread-view--talk": isThreadSender })} ref={rootRef}>

--- a/src/frontend/src/features/layouts/components/thread-view/provider.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/provider.tsx
@@ -9,6 +9,8 @@ type ThreadViewContextType = {
     isMessageReady: (messageId: string) => boolean | undefined;
     setMessageReadiness: (messageId: string, isReady: boolean) => void;
     reset: (messageId?: string) => void;
+    hasBeenInitialized: boolean;
+    setHasBeenInitialized: (hasBeenInitialized: boolean) => void;
 }
 
 const ThreadViewContext = createContext<ThreadViewContextType | undefined>(undefined);
@@ -19,6 +21,7 @@ const ThreadViewContext = createContext<ThreadViewContextType | undefined>(undef
  */
 const ThreadViewProvider = ({ messageIds, children }: ThreadViewProviderProps) => {
     const [messagesReadiness, setMessagesReadiness] = useState(new Map(messageIds.map((id) => [id, false])));
+    const [hasBeenInitialized, setHasBeenInitialized] = useState(false);
 
     const isReady = useMemo(() => {
         return Array.from(messagesReadiness.values()).every((isReady) => isReady === true);
@@ -48,6 +51,7 @@ const ThreadViewProvider = ({ messageIds, children }: ThreadViewProviderProps) =
             setMessageReadiness(messageId, false);
         } else {
             setMessagesReadiness(new Map(messageIds.map((id) => [id, false])));
+            setHasBeenInitialized(false);
         }
     }
 
@@ -56,8 +60,10 @@ const ThreadViewProvider = ({ messageIds, children }: ThreadViewProviderProps) =
         isMessageReady,
         setMessageReadiness,
         reset,
+        hasBeenInitialized,
+        setHasBeenInitialized,
         messagesReadiness,
-    }), [isReady, setMessageReadiness, isMessageReady, reset, messagesReadiness]);
+    }), [isReady, setMessageReadiness, isMessageReady, reset, messagesReadiness, hasBeenInitialized, setHasBeenInitialized]);
 
 
 

--- a/src/frontend/src/hooks/use-previous.ts
+++ b/src/frontend/src/hooks/use-previous.ts
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
  * @param value The value to track
  * @returns The previous value of the tracked variable
  */
-function usePrevious<T>(value: T): T | undefined {
+function usePrevious<T>(value: T): T {
   const ref = useRef<T>(value);
 
   useEffect(() => {


### PR DESCRIPTION
## Purpose

If the message count of the selected thread has changed the view should be refreshed to display the new message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated auto-scrolling in thread view by tracking initialization.
  * Improved unread-count handling and better detection/invalidation when new messages arrive in the selected thread.
  * Stopped automatic re-folding behavior tied to latest/draft updates.

* **Breaking Changes**
  * The "previous value" hook now always returns a value (no longer possibly undefined on first render).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->