### PR TITLE
💄(frontend) fix icon size issue in thread message

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/_index.scss
@@ -141,7 +141,7 @@
     flex-direction: row;
     gap: var(--c--globals--spacings--xs);
     align-items: center;
-    font-size: var(--c--globals--font--sizes--sm);
+    font-size: var(--c--globals--font--sizes--xs);
     color: var(--c--contextuals--content--semantic--neutral--secondary);
 }
 

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/index.tsx
@@ -279,7 +279,7 @@ export const ThreadMessage = forwardRef<HTMLElement, ThreadMessageProps>(
                                                             color="brand"
                                                             variant="tertiary"
                                                             size="small"
-                                                            icon={<Icon type={IconType.FILLED} name={isFolded ? "unfold_more" : "unfold_less"} size={IconSize.LARGE} />}
+                                                            icon={<Icon type={IconType.FILLED} name={isFolded ? "unfold_more" : "unfold_less"} />}
                                                             aria-label={isFolded ? t('Unfold message') : t('Fold message')}
                                                             onClick={toggleFold}
                                                         />


### PR DESCRIPTION
## Purpose

Remove icon size large in thread message for the fold icon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced font size for metadata text in thread messages for improved visual hierarchy.
  * Updated expand/collapse icon sizing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->