### PR TITLE
Fix/drive save indicator

### DIFF
--- a/src/frontend/eslint.config.mjs
+++ b/src/frontend/eslint.config.mjs
@@ -18,6 +18,7 @@ const eslintConfig = [
     rules: {
       "react-hooks/exhaustive-deps": "off",
       "no-console": ["error", { allow: ["error", "warn"] }],
+      "@typescript-eslint/no-unused-vars": "error",
     },
   },
 ];

--- a/src/frontend/src/features/layouts/components/main/header/authenticated.tsx
+++ b/src/frontend/src/features/layouts/components/main/header/authenticated.tsx
@@ -13,6 +13,7 @@ import { useImportTaskStatus } from "@/hooks/use-import-task";
 import { StatusEnum } from "@/features/api/gen";
 import { CircularProgress } from "@/features/ui/components/circular-progress";
 import { TaskImportCacheHelper } from "@/features/utils/task-import-cache";
+import { useTheme } from "@/features/providers/theme";
 
 
 type AuthenticatedHeaderProps = HeaderProps & {
@@ -58,6 +59,7 @@ export const AuthenticatedHeader = ({
 export const HeaderRight = () => {
   const { user } = useAuth();
   const { isDesktop } = useResponsive();
+  const { themeConfig } = useTheme();
 
   return (
     <>
@@ -70,7 +72,7 @@ export const HeaderRight = () => {
           email: user.email || ""
         } : null}
         logout={logout}
-        termOfServiceUrl={process.env.NEXT_PUBLIC_TERMS_OF_SERVICE_URL}
+        termOfServiceUrl={themeConfig.terms_of_service_url}
         actions={
           <div className="user-menu__footer-action">
             <LanguagePicker size="small" compact />

--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next"
 import Link from "next/link"
 import { useParams, useSearchParams } from "next/navigation"
-import { useEffect, useRef, useState } from "react"
+import { useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import clsx from "clsx"
 import { DateHelper } from "@/features/utils/date-helper"

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-attachment-list/drive-upload-button.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-attachment-list/drive-upload-button.tsx
@@ -108,7 +108,6 @@ export const DriveUploadButton = ({ attachment }: DriveUploadButtonProps) => {
         if (!driveFileId && driveFiles.length > 0) {
             const file = driveFiles.find((file) =>
                 file.filename === attachment.name
-                && file.mimetype === attachment.type
                 && file.size === attachment.size
             );
             if (file) {

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/message-body.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/message-body.tsx
@@ -7,7 +7,6 @@ import { UnquoteMessage } from '@/features/utils/unquote-message';
 import { useTranslation } from "react-i18next";
 import { tokens } from '@/styles/cunningham-tokens'
 import { useTheme } from "@/features/providers/theme";
-import { C } from "vitest/dist/chunks/reporters.d.BFLkQcL6.js";
 
 type MessageBodyProps = {
     rawHtmlBody?: string;


### PR DESCRIPTION
## Purpose

Currently to know if an attachment already exists in configured Drive instance,
we compare file retrieved by name, size and mime type but sometimes the mime
type cannot match. As it appears that name and size are enough to compare
resources we remove the mime type check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ESLint updated to treat unused variables as errors.
  * Removed unused imports and unused hook references to clean up code.
  * Theme configuration now supplies the Terms of Service URL used in the header user menu.

* **Bug Fixes**
  * File upload matching improved to match by filename and size (mimetype no longer required).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->