### PR TITLE
Fix/admin scroll

### DIFF
--- a/src/frontend/src/features/forms/components/message-composer/index.tsx
+++ b/src/frontend/src/features/forms/components/message-composer/index.tsx
@@ -97,21 +97,22 @@ export const MessageComposer = ({ mailboxId, blockNoteOptions, defaultValue, quo
         }]);
     };
 
+    const locale = i18n.resolvedLanguage?.split('-')[0] || 'en';
     const editor = useCreateBlockNote({
         schema: BLOCKNOTE_SCHEMA,
         tabBehavior: "prefer-navigate-ui",
         trailingBlock: false,
         initialContent: getInitialContent(),
         dictionary: {
-            ...(locales[(i18n.resolvedLanguage) as keyof typeof locales] || locales.en),
+            ...(locales[locale as keyof typeof locales] || locales.en),
             placeholders: {
-                ...(locales[(i18n.resolvedLanguage) as keyof typeof locales] || locales.en).placeholders,
+                ...(locales[locale as keyof typeof locales] || locales.en).placeholders,
                 emptyDocument: t('Start typing...'),
                 default: t('Start typing...'),
             }
         },
         ...blockNoteOptions,
-    }, [i18n.resolvedLanguage]);
+    }, [locale]);
 
     const handleChange = useCallback(async (editor: BlockNoteEditor<MessageComposerBlockSchema, MessageComposerInlineContentSchema, MessageComposerStyleSchema>, submitNeeded: boolean = true) => {
         const markdown = await editor.blocksToMarkdownLossy(editor.document);

--- a/src/frontend/src/features/layouts/components/admin/modal-compose-signature/signature-composer.tsx
+++ b/src/frontend/src/features/layouts/components/admin/modal-compose-signature/signature-composer.tsx
@@ -40,15 +40,16 @@ export const SignatureComposer = ({ blockNoteOptions, defaultValue, disabled = f
     const { data: { data: placeholders = {} } = {}, isLoading: isLoadingPlaceholders } = usePlaceholdersRetrieve();
     const canShowPlaceholdersMenu = !isLoadingPlaceholders && !!placeholders;
 
+    const locale = i18n.resolvedLanguage?.split('-')[0] || 'en';
     const editor = useCreateBlockNote({
         schema: SIGNATURE_BLOCKNOTE_SCHEMA,
         tabBehavior: "prefer-navigate-ui",
         initialContent: defaultValue ? JSON.parse(defaultValue): [{ type: "paragraph", content: "" }],
         trailingBlock: false,
         dictionary: {
-            ...(locales[(i18n.resolvedLanguage) as keyof typeof locales] || locales.en),
+            ...(locales[locale as keyof typeof locales] || locales.en),
             placeholders: {
-                ...(locales[(i18n.resolvedLanguage) as keyof typeof locales] || locales.en).placeholders,
+                ...(locales[locale as keyof typeof locales] || locales.en).placeholders,
                 emptyDocument: t('Start typing...'),
                 default: t('Start typing...'),
             }

--- a/src/frontend/src/features/layouts/components/mailbox-panel/_index.scss
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/_index.scss
@@ -3,8 +3,9 @@
     flex-direction: column;
     height: 100%;
     max-height: 100%;
-    overflow: hidden;
+    overflow: auto;
     font-size: var(--c--globals--font--sizes--sm);
+    position: relative;
 }
 
 .mailbox-panel__header {
@@ -12,6 +13,7 @@
     top: 0;
     z-index: 10;
     flex-shrink: 0;
+    background: var(--c--contextuals--background--surface--secondary);
 }
 
 .mailbox-panel__mailbox-title {

--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-labels/_index.scss
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-labels/_index.scss
@@ -3,6 +3,7 @@
     flex-direction: column;
     height: 100%;
     overflow-y: auto;
+    min-height: 200px;
 }
 
 .mailbox-labels__drag-over-indicator {

--- a/src/frontend/src/features/layouts/components/mailbox-panel/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/index.tsx
@@ -29,11 +29,8 @@ export const MailboxPanel = () => {
             <div className="mailbox-panel__header">
                 <MailboxPanelActions />
                 <HorizontalSeparator withPadding={false} />
-            </div>
-            {!selectedMailbox || queryStates.mailboxes.isLoading ? <Spinner /> :
-                (
-                    <>
-                        <div className="mailbox-panel__mailbox-title">
+                { selectedMailbox && (
+                <div className="mailbox-panel__mailbox-title">
                             <DropdownMenu
                                 options={getMailboxOptions()}
                                 isOpen={isOpen}
@@ -56,6 +53,12 @@ export const MailboxPanel = () => {
                                 </Button>
                             </DropdownMenu>
                         </div>
+                )}
+            </div>
+            {!selectedMailbox || queryStates.mailboxes.isLoading ? <Spinner /> :
+                (
+                    <>
+
                         <MailboxList />
                         <MailboxLabels mailbox={selectedMailbox} />
                     </>

--- a/src/frontend/src/features/layouts/components/mailbox-settings/modal-compose-template/template-composer.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-settings/modal-compose-template/template-composer.tsx
@@ -64,15 +64,16 @@ export const TemplateComposer = ({ blockNoteOptions, defaultValue, disabled = fa
         }
     );
 
+    const locale = i18n.resolvedLanguage?.split('-')[0] || 'en';
     const editor = useCreateBlockNote({
         schema: TEMPLATE_BLOCKNOTE_SCHEMA,
         tabBehavior: "prefer-navigate-ui",
         initialContent: defaultValue ? JSON.parse(defaultValue): [{ type: "paragraph", content: [{ type: "text", text: "", styles: {} }] }],
         trailingBlock: false,
         dictionary: {
-            ...(locales[(i18n.resolvedLanguage) as keyof typeof locales] || locales.en),
+            ...(locales[locale as keyof typeof locales] || locales.en),
             placeholders: {
-                ...(locales[(i18n.resolvedLanguage) as keyof typeof locales] || locales.en).placeholders,
+                ...(locales[locale as keyof typeof locales] || locales.en).placeholders,
                 emptyDocument: t('Start typing...'),
                 default: t('Start typing...'),
             }

--- a/src/frontend/src/styles/globals.scss
+++ b/src/frontend/src/styles/globals.scss
@@ -27,7 +27,7 @@ body {
 *[data-panel],
 *[data-panel-group],
 .c__main-layout__content__center__children {
-  overflow: inherit !important;
+  overflow: auto !important;
 }
 
 // Customize resize handle to add an hover effect to explicit that


### PR DESCRIPTION
## Purpose

It was not possible to scroll in views with long data grid.
Furthermore the mailbox panel was not usable on small height
viewport so we took opportunity to also fix that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled scrolling in mailbox panel and related layout areas

* **New Features**
  * Mailbox title dropdown appears only when a mailbox is selected

* **Style**
  * Visual header background and min-height improvements for mailbox panel
  * Updated global overflow behavior for better scrolling experience

* **Localization**
  * Consistent locale handling for message, signature and template editors, improving placeholders and editor language selection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->