### PR TITLE
🌐(frontend) set html lang attribute on language change

### DIFF
--- a/src/frontend/src/features/i18n/initI18n.ts
+++ b/src/frontend/src/features/i18n/initI18n.ts
@@ -37,6 +37,7 @@ i18n
 // Save language in local storage
 i18n.on("languageChanged", (lng) => {
   if (typeof window !== "undefined") {
+    document.documentElement.setAttribute("lang", lng);
     localStorage.setItem(LANGUAGE_LOCAL_STORAGE, lng);
   }
 });

--- a/src/frontend/src/pages/_document.tsx
+++ b/src/frontend/src/pages/_document.tsx
@@ -7,7 +7,7 @@ export default function Document() {
   const { t } = useTranslation();
 
   return (
-    <Html lang="en">
+    <Html>
       <Head>
         {/*
         PWA Attributes


### PR DESCRIPTION
## Purpose

Currently the html lang attribute is always set to `en`, we want to update it when application language is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The document language attribute now dynamically updates based on user language preference instead of remaining hardcoded to English, improving internationalization and browser compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->