### PR TITLE
✅(e2e) fix date format change since 2026

### DIFF
--- a/src/e2e/src/__tests__/message-import.spec.ts
+++ b/src/e2e/src/__tests__/message-import.spec.ts
@@ -94,7 +94,7 @@ test.describe("Import Message", () => {
 
     // Then expect the new message to be visible in the thread list
     await expect(
-      page.getByRole("link", { name: "Sardine 18 Nov An old message" })
+      page.getByRole("link", { name: "Sardine 18/11/2025 An old message" })
     ).toBeVisible();
   });
 


### PR DESCRIPTION
<img width="464" height="170" alt="Capture d’écran 2026-01-03 à 01 20 49" src="https://github.com/user-attachments/assets/7db655d0-55f9-4d6e-9ef1-ade9c1cbd19d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated message import test to verify correct date format in message timestamp display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->