### PR TITLE
✨(search) improve recipient search filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to
 - Add `is_trashed` flag to thread model
 - Add to select multiple threads in thread panel
 - Add image proxy endpoint to display external images in messages
+- Add `to_exact` modifier to search query
 
 ### Changed
 
 - Configure Drive App Name through environment variable (DRIVE_APP_NAME)
 - Inherit OIDC Authentication backend from django-lasuite #408
 - Exclude `is_trashed` and `is_spam` threads from search results by default
+- `to` search modifier now looks for messages where recipient fields (to, cc, bcc) contain the given email address.
 

--- a/src/backend/core/services/search/parse.py
+++ b/src/backend/core/services/search/parse.py
@@ -10,7 +10,8 @@ def parse_search_query(query: str) -> Dict[str, Any]:
 
     Supports Gmail-style modifiers:
     - from: (de:) - sender email/name
-    - to: (a:) - recipient
+    - to: (a:) - recipient (includes `to`, `cc`, `bcc` fields)
+    - to_exact: (a_exact:) - exact recipient match (`to` field only)
     - cc: (copie:) - carbon copy
     - bcc: (cci:) - blind carbon copy
     - subject: (sujet:) - subject text
@@ -41,6 +42,7 @@ def parse_search_query(query: str) -> Dict[str, Any]:
         # Value-taking modifiers
         "from": ["from:", "de:", "van:"],
         "to": ["to:", "a:", "à:", "aan:"],
+        "to_exact": ["to_exact:", "a_exact:", "à_exact:", "aan_exact:"],
         "cc": ["cc:", "copie:"],
         "bcc": ["bcc:", "cci:"],
         "subject": ["subject:", "sujet:", "objet:", "onderwerp:"],
@@ -56,7 +58,7 @@ def parse_search_query(query: str) -> Dict[str, Any]:
     }
 
     # Split modifiers into value-taking and flag modifiers
-    value_modifiers = ["from", "to", "cc", "bcc", "subject"]
+    value_modifiers = ["from", "to", "cc", "bcc", "to_exact", "subject"]
     flag_modifiers = {
         "in_trash": "in_trash",
         "in_sent": "in_sent",

--- a/src/backend/core/tests/search/test_e2e_modifiers.py
+++ b/src/backend/core/tests/search/test_e2e_modifiers.py
@@ -483,29 +483,37 @@ class TestSearchModifiersE2E:
     def test_search_e2e_modifiers_to_search_modifier(
         self, setup_search, api_client, test_url, test_threads
     ):
-        """Test searching with the 'to:' modifier."""
+        """
+        Test searching with the 'to:' modifier.
+        It looks for messages where recipient fields (to, cc, bcc) contain the given email address.
+        """
 
         # Test English version
-        response = api_client.get(f"{test_url}?search=to:sarah@example.com")
+        response = api_client.get(f"{test_url}?search=to:robert@example.com")
 
         # Verify response
         assert response.status_code == 200
 
         # Check if the correct threads are found
+        assert len(response.data["results"]) == 2
         thread_ids = [t["id"] for t in response.data["results"]]
-        assert str(test_threads["thread1"].id) in thread_ids
+        assert str(test_threads["thread2"].id) in thread_ids
+        assert str(test_threads["thread10"].id) in thread_ids
 
         # Test French version
-        response = api_client.get(f"{test_url}?search=à:sarah@example.com")
+        response = api_client.get(f"{test_url}?search=à:robert@example.com")
 
         # Verify the same results
         assert response.status_code == 200
+        assert len(response.data["results"]) == 2
         thread_ids = [t["id"] for t in response.data["results"]]
-        assert str(test_threads["thread1"].id) in thread_ids
+        assert str(test_threads["thread2"].id) in thread_ids
+        assert str(test_threads["thread10"].id) in thread_ids
 
     def test_search_e2e_modifiers_to_search_modifier_substring(
         self, setup_search, api_client, test_url, test_threads
     ):
+        """Test searching with the 'to:' modifier with substring search."""
         # Test substring search
         response = api_client.get(f"{test_url}?search=to:@example.com")
         assert response.status_code == 200
@@ -518,6 +526,31 @@ class TestSearchModifiersE2E:
         response = api_client.get(f"{test_url}?search=to:examples")
         assert response.status_code == 200
         assert len(response.data["results"]) == 0
+
+    def test_search_e2e_modifiers_to_exact_search_modifier(
+        self, setup_search, api_client, test_url, test_threads
+    ):
+        """Test searching with the 'to_exact:' modifier."""
+
+        # Test English version
+        response = api_client.get(f"{test_url}?search=to_exact:robert@example.com")
+
+        # Verify response
+        assert response.status_code == 200
+
+        # Check if the correct threads are found
+        assert len(response.data["results"]) == 1
+        thread_ids = [t["id"] for t in response.data["results"]]
+        assert str(test_threads["thread10"].id) in thread_ids
+
+        # Test French version
+        response = api_client.get(f"{test_url}?search=à_exact:robert@example.com")
+
+        # Verify the same results
+        assert response.status_code == 200
+        assert len(response.data["results"]) == 1
+        thread_ids = [t["id"] for t in response.data["results"]]
+        assert str(test_threads["thread10"].id) in thread_ids
 
     def test_search_e2e_modifiers_cc_search_modifier(
         self, setup_search, api_client, test_url, test_threads

--- a/src/backend/core/tests/search/test_search_modifiers.py
+++ b/src/backend/core/tests/search/test_search_modifiers.py
@@ -87,14 +87,24 @@ def test_search_threads_with_multiple_modifiers(mock_es_client):
     assert sender_query_found, "Sender query was not found in the OpenSearch query"
 
     # Check for to filter
-    to_query_found = False
-    for filter_item in call_args["body"]["query"]["bool"]["filter"]:
-        if "term" in filter_item and "to_email" in filter_item["term"]:
-            to_query_found = True
-            assert filter_item["term"]["to_email"] == "sarah@example.com"
+    to_query_found = 0
+    for filter_item in call_args["body"]["query"]["bool"]["should"]:
+        if "term" in filter_item:
+            if "to_email" in filter_item["term"]:
+                to_query_found += 1
+                assert filter_item["term"]["to_email"] == "sarah@example.com"
+            elif "cc_email" in filter_item["term"]:
+                to_query_found += 1
+                assert filter_item["term"]["cc_email"] == "sarah@example.com"
+            elif "bcc_email" in filter_item["term"]:
+                to_query_found += 1
+                assert filter_item["term"]["bcc_email"] == "sarah@example.com"
+        if to_query_found == 3:
             break
 
-    assert to_query_found, "To query was not found in the OpenSearch query"
+    assert to_query_found == 3, (
+        "Not all expected queries were found in the OpenSearch query (3 expected - to, cc, bcc)"
+    )
 
     # Check for subject filter
     subject_query_found = False


### PR DESCRIPTION
## Purpose

After a bug found search results, we identify weakness within our search logic.

- `to` query key now looks up within `to`, `cc` and `bcc` message fields
- Add a `to_exact` query key to looks up only in `to` message field


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "to_exact" modifier for exact email matching across recipient fields (to, cc, bcc).
  * Enhanced "to" modifier to search all recipient fields with both substring and exact matching behavior.

* **Tests**
  * Updated existing modifier tests and added an end-to-end test to validate the new to_exact behavior and updated recipient matching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->