### PR TITLE
Feat/improve panel responsiveness

### DIFF
--- a/src/frontend/public/locales/common/en-US.json
+++ b/src/frontend/public/locales/common/en-US.json
@@ -388,6 +388,7 @@
   "To be able to import emails from an IMAP server, you may need to allow IMAP access on your account.": "To be able to import emails from an IMAP server, you may need to allow IMAP access on your account.",
   "To:": "To:",
   "To: ": "To: ",
+  "Today": "Today",
   "Trash": "Trash",
   "Type": "Type",
   "Unable to copy credentials.": "Unable to copy credentials.",

--- a/src/frontend/public/locales/common/fr-FR.json
+++ b/src/frontend/public/locales/common/fr-FR.json
@@ -420,6 +420,7 @@
   "To be able to import emails from an IMAP server, you may need to allow IMAP access on your account.": "Pour pouvoir importer des courriels depuis un serveur IMAP, vous aurez peut-être à autoriser les connexions IMAP à votre compte.",
   "To:": "À :",
   "To: ": "À : ",
+  "Today": "Aujourd'hui",
   "Trash": "Corbeille",
   "Type": "Type",
   "Unable to copy credentials.": "Impossible de copier les identifiants.",

--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/_index.scss
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/_index.scss
@@ -3,4 +3,5 @@
     justify-content: space-between;
     align-items: center;
     padding: var(--c--globals--spacings--sm);
+    gap: var(--c--globals--spacings--4xs);
 }

--- a/src/frontend/src/features/layouts/components/main/index.tsx
+++ b/src/frontend/src/features/layouts/components/main/index.tsx
@@ -22,16 +22,21 @@ export const MainLayout = ({ children }: PropsWithChildren) => {
     )
 }
 
-const LayoutContext = createContext({
-    toggleLeftPanel: () => {},
-    closeLeftPanel: () => {},
-    openLeftPanel: () => {},
-})
+type LayoutContextType = {
+    toggleLeftPanel: () => void;
+    closeLeftPanel: () => void;
+    openLeftPanel: () => void;
+    isDragging: boolean;
+    setIsDragging: (prevState: boolean) => void;
+}
+
+const LayoutContext = createContext<LayoutContextType | undefined>(undefined);
 
 const MainLayoutContent = ({ children }: PropsWithChildren<{ simple?: boolean }>) => {
     const { mailboxes, queryStates } = useMailboxContext();
     const hasNoMailbox = queryStates.mailboxes.status === 'success' && mailboxes!.length === 0;
     const [leftPanelOpen, setLeftPanelOpen] = useState(false);
+    const [isDragging, setIsDragging] = useState(false);
     const { theme, variant } = useTheme();
 
     return (
@@ -39,6 +44,8 @@ const MainLayoutContent = ({ children }: PropsWithChildren<{ simple?: boolean }>
             toggleLeftPanel: () => setLeftPanelOpen(!leftPanelOpen),
             closeLeftPanel: () => setLeftPanelOpen(false),
             openLeftPanel: () => setLeftPanelOpen(true),
+            isDragging,
+            setIsDragging,
         }}>
             <AppLayout
                 enableResize
@@ -47,6 +54,7 @@ const MainLayoutContent = ({ children }: PropsWithChildren<{ simple?: boolean }>
                 leftPanelContent={<LeftPanel hasNoMailbox={hasNoMailbox} />}
                 icon={<img src={`/images/${theme}/app-logo-${variant}.svg`} alt="logo" height={40} />}
                 hideLeftPanelOnDesktop={hasNoMailbox}
+                isDragging={isDragging}
             >
                 {hasNoMailbox ? (
                     <NoMailbox />
@@ -61,5 +69,5 @@ const MainLayoutContent = ({ children }: PropsWithChildren<{ simple?: boolean }>
 export const useLayoutContext = () => {
     const context = useContext(LayoutContext);
     if (!context) throw new Error("useLayoutContext must be used within a LayoutContext.Provider");
-    return useContext(LayoutContext)
+    return context;
 }

--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
@@ -13,6 +13,7 @@ import { PORTALS } from "@/features/config/constants"
 import { Checkbox } from "@gouvfr-lasuite/cunningham-react"
 import { Icon, IconSize, IconType } from "@gouvfr-lasuite/ui-kit"
 import { LabelBadge } from "@/features/ui/components/label-badge"
+import { useLayoutContext } from "../../../main"
 
 type ThreadItemProps = {
     thread: Thread
@@ -28,6 +29,7 @@ export const ThreadItem = ({ thread, index, isSelected, onToggleSelection, selec
     const params = useParams<{ mailboxId: string, threadId: string }>()
     const searchParams = useSearchParams()
     const [isDragging, setIsDragging] = useState(false)
+    const { setIsDragging: setGlobalDragging } = useLayoutContext();
     const dragPreviewContainer = useRef(document.getElementById(PORTALS.DRAG_PREVIEW));
 
     const hasSelection = isSelectionMode || selectedThreadIds.size > 0;
@@ -59,6 +61,7 @@ export const ThreadItem = ({ thread, index, isSelected, onToggleSelection, selec
 
     const handleDragStart = (e: React.DragEvent<HTMLAnchorElement>) => {
         setIsDragging(true)
+        setGlobalDragging(true)
 
         // If this thread is selected, drag all selected threads
         const threadsToDrag = isSelectionMode ? Array.from(selectedThreadIds) : [thread.id];
@@ -74,7 +77,10 @@ export const ThreadItem = ({ thread, index, isSelected, onToggleSelection, selec
             e.dataTransfer.setDragImage(dragPreviewContainer.current, 40, 40)
         }
     }
-    const handleDragEnd = () => setIsDragging(false);
+    const handleDragEnd = () => {
+        setIsDragging(false);
+        setGlobalDragging(false);
+    };
 
     const dragCount = selectedThreadIds.size > 0 ? selectedThreadIds.size : 1;
 

--- a/src/frontend/src/features/layouts/components/thread-view/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-view/_index.scss
@@ -40,7 +40,7 @@
     margin-left: var(--c--globals--spacings--xxl);
 }
 
-@media screen and (max-width: breakpoint(tablet)) {
+@media screen and (max-width: breakpoint(mobile)) {
     .thread-view {
         position: fixed;
         top: var(--header-height);

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/_index.scss
@@ -110,15 +110,10 @@
         & .thread-message__sender-chip {
             min-width: 0;
 
-            .contact-chip__identity-email {
-                font-size: var(--c--globals--font--sizes--sm);
-                color: var(--c--contextuals--content--semantic--neutral--secondary);
+            .contact-chip__identity-name {
+                font-size: var(--c--globals--font--sizes--md);
             }
 
-            .contact-chip__identity-name {
-                font-size: var(--c--globals--font--sizes-base);
-                color: var(--c--contextuals--content--semantic--neutral--primary);
-            }
         }
     }
 
@@ -128,7 +123,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: center;
     gap: var(--c--globals--spacings--base);
     min-width: 0;
 }
@@ -164,6 +159,7 @@
 .thread-message__correspondents dd {
     margin: 0;
     word-break: break-word;
+    min-width: 0;
 }
 
 .thread-message__correspondents .recipient-chip-list {

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-body.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-body.tsx
@@ -219,7 +219,7 @@ const ThreadMessageBody = ({ bodyParts, attachments = [], isHidden = false, mess
                 }
 
                 img {
-                    max-width: 100vw;
+                    max-width: 100%;
                 }
 
                 pre {

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-header.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-header.tsx
@@ -125,7 +125,7 @@ const ThreadMessageHeader = ({
                                     {message.created_at && (
                                         <p className="thread-message__date">
                                             {t('{{date}} at {{time}}', {
-                                                date: DateHelper.formatDate(message.created_at, i18n.resolvedLanguage),
+                                                date: DateHelper.formatDate(message.created_at, i18n.resolvedLanguage, false),
                                                 time: new Date(message.created_at).toLocaleString(i18n.resolvedLanguage, {
                                                     minute: '2-digit',
                                                     hour: '2-digit',

--- a/src/frontend/src/features/ui/components/contact-chip/_index.scss
+++ b/src/frontend/src/features/ui/components/contact-chip/_index.scss
@@ -49,6 +49,11 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 100%;
+    color: var(--c--contextuals--content--semantic--neutral--primary);
+
+    &::first-letter {
+        text-transform: uppercase;
+    }
 }
 
 .contact-chip__identity-email {
@@ -58,6 +63,11 @@
     text-overflow: ellipsis;
     overflow: hidden;
     flex: 0 1 auto;
+}
+
+.contact-chip__identity-name + .contact-chip__identity-email {
+    color: var(--c--contextuals--content--semantic--neutral--secondary);
+    font-size: var(--c--globals--font--sizes--xs);
 }
 
 .contact-chip__icon {
@@ -104,7 +114,7 @@
 
 .contact-popover__identity-name {
     display: inline-block;
-    font-size: var(--c--globals--font--sizes--h4);
+    font-size: var(--c--globals--font--sizes--h6);
     font-weight: bold;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -112,6 +122,10 @@
     max-width: 100%;
     margin: 0;
     line-height: 1;
+
+    &::first-letter {
+        text-transform: uppercase;
+    }
 }
 
 .contact-popover__identity-email {
@@ -122,7 +136,8 @@
     align-items: center;
     padding: 0;
     margin: 0;
-    line-height: 1.2;
+    font-size: var(--c--globals--font--sizes--sm);
+    line-height: 1.37;
     cursor: pointer;
     display: flex;
     position: relative;
@@ -138,8 +153,7 @@
 
     & > .contact-popover__copy-icon {
         height: 100%;
-        font-size: var(--c--globals--font--sizes--base);
-        height: 1.2em;
+        font-size: var(--c--globals--font--sizes--md);
         padding: 2px;
         display: none;
         text-decoration: none;

--- a/src/frontend/src/features/ui/components/contact-chip/index.tsx
+++ b/src/frontend/src/features/ui/components/contact-chip/index.tsx
@@ -23,13 +23,13 @@ type ContactChipProps = {
     isUser?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-export const ContactChip = ({ contact, status, displayEmail = false, isUser = false, ...props }: ContactChipProps) => {
+export const ContactChip = ({ contact, status, displayEmail = false, isUser = false, className, ...props }: ContactChipProps) => {
     const { t } = useTranslation();
     const popoverTriggerRef = useRef<HTMLButtonElement | null>(null);
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
     const chipContent = (
-        <div className={clsx("contact-chip", props.className)} {...props}>
+        <div className={clsx(["contact-chip", className])} {...props}>
             <button type="button" ref={popoverTriggerRef} className="contact-chip__content" onClick={() => setIsPopoverOpen(open => !open)}>
                 {status === 'unverified' && (
                     <Icon name="warning" type={IconType.OUTLINED} size={IconSize.SMALL} className="contact-chip__icon contact-chip__icon--warning" />

--- a/src/frontend/src/features/utils/date-helper.test.ts
+++ b/src/frontend/src/features/utils/date-helper.test.ts
@@ -19,6 +19,17 @@ describe('DateHelper', () => {
       expect(DateHelper.formatDate(todayDate, 'en')).toBe('17:30');
     });
 
+    it('should format time when date is today and showTime is true', () => {
+      const todayDate = '2025-04-17T17:30:00';
+      expect(DateHelper.formatDate(todayDate, 'fr', true)).toBe('17:30');
+      expect(DateHelper.formatDate(todayDate, 'en', true)).toBe('17:30');
+    });
+
+    it('should format as "Today" when date is today and showTime is false', () => {
+      const todayDate = '2025-04-17T17:30:00';
+      expect(DateHelper.formatDate(todayDate, 'en', false)).toBe('Today');
+    });
+
     it('should format as "Yesterday" when date is yesterday', () => {
       const yesterdayDate = '2025-04-16T15:30:00';
       expect(DateHelper.formatDate(yesterdayDate, 'en')).toBe('Yesterday');

--- a/src/frontend/src/features/utils/date-helper.ts
+++ b/src/frontend/src/features/utils/date-helper.ts
@@ -13,15 +13,19 @@ export class DateHelper {
    *
    * @param dateString - The date string to format
    * @param locale - The locale code (e.g., 'fr', 'en')
+   * @param showTime - Whether to show the time (default: true)
    * @returns Formatted date string
    */
-  public static formatDate(dateString: string, lng: string = 'en'): string {
+  public static formatDate(dateString: string, lng: string = 'en', showTime: boolean = true): string {
     const date = new Date(dateString);
     const locale = lng.length > 2 ? lng.split('-')[0] : lng;
     const dateLocale = locales[locale as keyof typeof locales];
 
     if (isToday(date)) {
-      return format(date, 'HH:mm', { locale: dateLocale });
+      if (showTime) {
+        return format(date, 'HH:mm', { locale: dateLocale });
+      }
+      return i18n.t('Today');
     }
 
     if (isYesterday(date)) {

--- a/src/frontend/src/pages/mailbox/[mailboxId]/index.tsx
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/index.tsx
@@ -9,8 +9,8 @@ import { Panel, Group, Separator, useDefaultLayout } from "react-resizable-panel
 const Mailbox = () => {
     const { t } = useTranslation();
     const { threads } = useMailboxContext();
-    const { isDesktop } = useResponsive();
-    const showSelectThreadPlaceholder = (isDesktop && (threads?.results?.length ?? 0) > 0);
+    const { isMobile } = useResponsive();
+    const showSelectThreadPlaceholder = (!isMobile && (threads?.results?.length ?? 0) > 0);
     const { defaultLayout, onLayoutChange } = useDefaultLayout({
         groupId: showSelectThreadPlaceholder ? "threads" : "threads-single",
         storage: localStorage,
@@ -18,13 +18,13 @@ const Mailbox = () => {
 
     return (
         <Group defaultLayout={defaultLayout} onLayoutChange={onLayoutChange} orientation="horizontal" className="threads__container">
-            <Panel id={showSelectThreadPlaceholder ? "panel-thread-list" : "panel-thread-list-single"} className="thread-list-panel" defaultSize="35%" minSize="20%">
+            <Panel id={showSelectThreadPlaceholder ? "panel-thread-list" : "panel-thread-list-single"} className="thread-list-panel" defaultSize="35%" minSize="20%" maxSize="50%">
                 <ThreadPanel />
             </Panel>
             {showSelectThreadPlaceholder && (
                 <>
                     <Separator className="panel__resize-handle" />
-                    <Panel id="panel-thread-view" className="thread-view-panel" defaultSize="65%" minSize="50%">
+                    <Panel id="panel-thread-view" className="thread-view-panel">
                         <div className="thread-view thread-view--empty">
                             <div>
                                 <Image src="/images/svg/read-mail.svg" alt="" width={60} height={60} />

--- a/src/frontend/src/pages/mailbox/[mailboxId]/thread/[threadId].tsx
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/thread/[threadId].tsx
@@ -11,11 +11,11 @@ const Mailbox = () => {
 
     return (
         <Group defaultLayout={defaultLayout} onLayoutChange={onLayoutChange} orientation="horizontal" className="threads__container">
-            <Panel id="panel-thread-list" className="thread-list-panel" defaultSize="35%" minSize="20%">
+            <Panel id="panel-thread-list" className="thread-list-panel" defaultSize="30%" minSize="250px" maxSize="50%">
                 <ThreadPanel />
             </Panel>
             <Separator className="panel__resize-handle" />
-            <Panel id="panel-thread-view" className="thread-view-panel" defaultSize="65%" minSize="50%">
+            <Panel id="panel-thread-view" className="thread-view-panel">
                 <ThreadView />
             </Panel>
         </Group>

--- a/src/frontend/src/styles/globals.scss
+++ b/src/frontend/src/styles/globals.scss
@@ -47,7 +47,7 @@ body {
     position: absolute;
     opacity: 0;
     transition: opacity 250ms var(--c--globals--transitions--ease-in-out);
-    z-index: 5;
+    z-index: 10;
   }
 
   // Little tricks to expand the area to catch hover


### PR DESCRIPTION
## Purpose

Improve responsive experience :
- On tablet still show both thread-panel and thread-view.
- On tablet & mobile open menu when drag thread item
- Fix some issues on small viewport (element overflows, etc.)


https://github.com/user-attachments/assets/3d66dc14-eb84-46e7-b143-7918c7bc2653



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized "Today" label (EN/FR) and improved drag-aware layout behavior on mobile/tablet.

* **Bug Fixes / UI**
  * Better image scaling in message bodies and refined message header date formatting.
  * Improved contact chip typography and popover layout.
  * Adjusted responsive breakpoints, panel sizing limits, resize-handle stacking, and mailbox action spacing.

* **Tests**
  * Added tests covering today/date formatting behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->