### PR TITLE
🐛(frontend) hide banner image in thread message when folded

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-body.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-body.tsx
@@ -353,7 +353,7 @@ const ThreadMessageBody = ({ bodyParts, attachments = [], isHidden = false, mess
 
     return (
         <>
-            {canDisplayExternalImages && hasExternalImagesRef.current && !displayExternalImages &&
+            {!isHidden && canDisplayExternalImages && hasExternalImagesRef.current && !displayExternalImages &&
                 <Banner
                     type="neutral"
                     icon={<Icon name="security" />}


### PR DESCRIPTION
## Purpose

When a thread is folded, the message banner should not be displayed...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the external image consent banner to no longer appear when thread messages are hidden, ensuring the banner only displays for visible messages with pending image consent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->