### PR TITLE
🚸(frontend) do not show image display banner when only pixel tracker

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/renderers/utils.ts
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/renderers/utils.ts
@@ -1,0 +1,19 @@
+// Helper to parse a dimension string (with or without units) and return pixels as a number.
+export const parseDimension = (dimension: string = ''): number => {
+    const [, value, unit] = dimension.trim().match(/(^[\d\.]+)(.*)/) ?? [dimension, dimension, null];
+    const size = parseFloat(value);
+    if (isNaN(size)) return Infinity;
+
+    switch (unit) {
+        case "":
+        case "px":
+            // Treat plain number as pixels
+            return size;
+        case "em":
+        case "rem":
+            // em or rem: make a guess (commonly 16px = 1em)
+            return size * 16;
+        default:
+            return Infinity;
+    }
+};


### PR DESCRIPTION
## Purpose

If the message contains only pixel tracker, the image banner to display images should not showned.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lazy loading for images to improve performance and reduce unnecessary downloads.
  * Introduced a minimum image-size threshold to avoid rendering tiny/tracking images.

* **Bug Fixes**
  * Improved detection and removal of hidden or tiny images using enhanced size and visibility checks.
  * More accurate parsing of image dimensions from attributes and inline styles to fix display issues.
  * More reliable handling of embedded and external images while preserving existing sanitization and proxying behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->