### PR TITLE
🔊(inbound) log validation issues for recipient creation as warnings

### DIFF
--- a/src/backend/core/mda/inbound_create.py
+++ b/src/backend/core/mda/inbound_create.py
@@ -425,15 +425,16 @@ def _create_message_from_inbound(
                         mailbox.id,
                     )
 
-                # Create the link between message and contact
-                data = {
-                    "message": message,
-                    "contact": recipient_contact,
-                    "type": recipient_type,
-                }
+                # Create the link between message and contact (use get_or_create to handle duplicates)
+                defaults = {}
                 if is_import and not message.is_draft:
-                    data["delivery_status"] = enums.MessageDeliveryStatusChoices.SENT
-                models.MessageRecipient.objects.create(**data)
+                    defaults["delivery_status"] = enums.MessageDeliveryStatusChoices.SENT
+                models.MessageRecipient.objects.get_or_create(
+                    message=message,
+                    contact=recipient_contact,
+                    type=recipient_type,
+                    defaults=defaults,
+                )
             except ValidationError as e:
                 logger.warning(
                     "Validation error creating recipient contact/link (%s) for message %s: %s",


### PR DESCRIPTION
This kind of issue should not be an error, but only a warning :
https://sentry.incubateur.anct.gouv.fr/organizations/sentry/issues/14916/?project=30

Make this kind of log disappear :
`Validation error creating recipient contact/link ([email]) for message XXXX: {'__all__': ['Message recipient with this Message, Contact and Type already exists.']}`
-> see sentry



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inbound messages with duplicate recipient addresses are now handled gracefully, preventing duplicate recipient links and avoiding failures during import.

* **Logging Improvements**
  * Validation issues during recipient processing are downgraded to warnings so processing continues for other recipients.

* **Tests**
  * Added a test to verify duplicate recipients are deduplicated and processed without errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->