### PR TITLE
🔧(backend) update Django admin URL handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Now `DJANGO_ADMIN_URL` must not end with `/`.
+
 ## [0.1.0] - 2026-01-20
 
 ### Added

--- a/docs/env.md
+++ b/docs/env.md
@@ -34,6 +34,7 @@ The application uses a new environment file structure with `.defaults` and `.loc
 | `DJANGO_SETTINGS_MODULE` | `messages.settings` | Django settings module | Required |
 | `DJANGO_SUPERUSER_PASSWORD` | `admin` | Default superuser password for development | Dev |
 | `DJANGO_DATA_DIR` | `/data` | Base directory for data storage | Optional |
+| `DJANGO_ADMIN_URL` | `admin` | admin route (must not be ended by `/`) | Optional |
 
 ### Database Configuration
 

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -69,7 +69,7 @@ class Base(Configuration):
     API_VERSION = "v1.0"
 
     # Admin URL configuration
-    ADMIN_URL = values.Value("admin/")
+    ADMIN_URL = values.Value("admin")
 
     # OpenSearch configuration
     OPENSEARCH_HOSTS = values.ListValue(

--- a/src/backend/messages/urls.py
+++ b/src/backend/messages/urls.py
@@ -31,7 +31,7 @@ def heartbeat(request):
 
 
 urlpatterns = [
-    path(settings.ADMIN_URL, admin.site.urls),
+    path(f"{settings.ADMIN_URL}/", admin.site.urls),
     path("", include("core.urls")),
     path(
         "__heartbeat__/",


### PR DESCRIPTION
## Purpose

Modified the Django admin URL configuration to ensure it ends with a trailing slash. Updated related references in the Nginx configuration and environment variables for consistency.

✅ Tested on staging instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added DJANGO_ADMIN_URL environment variable docs with default value and usage guidance (must not end with a trailing slash).

* **Changes**
  * Enforced no-trailing-slash requirement for the admin URL configuration.
  * Adjusted admin routing to remain compatible with the revised configuration format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->