### PR TITLE
🚸(frontend) Add loading state to the refresh button

### DIFF
--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/_index.scss
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/_index.scss
@@ -4,4 +4,46 @@
     align-items: center;
     padding: var(--c--globals--spacings--sm);
     gap: var(--c--globals--spacings--4xs);
+
+    &__refresh-wrapper {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+    }
+
+    &__refresh-icon,
+    &__refresh-spinner {
+        transition: opacity 150ms ease-out;
+    }
+
+    &__refresh-icon {
+        opacity: 1;
+
+        &--hidden {
+            opacity: 0;
+        }
+    }
+
+    &__refresh-spinner {
+        position: absolute;
+        inset: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+
+        &--visible {
+            opacity: 1;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        &__refresh-icon,
+        &__refresh-spinner {
+            transition: none;
+        }
+    }
 }

--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-actions/index.tsx
@@ -4,7 +4,8 @@ import { Button } from "@gouvfr-lasuite/cunningham-react";
 import { useMailboxContext } from "@/features/providers/mailbox";
 import { useLayoutContext } from "../../../main";
 import useAbility, { Abilities } from "@/hooks/use-ability";
-import { Icon, IconType } from "@gouvfr-lasuite/ui-kit";
+import { Icon, IconType, Spinner } from "@gouvfr-lasuite/ui-kit";
+import { useState } from "react";
 
 export const MailboxPanelActions = () => {
     const { t } = useTranslation();
@@ -12,6 +13,16 @@ export const MailboxPanelActions = () => {
     const { selectedMailbox, refetchMailboxes } = useMailboxContext();
     const { closeLeftPanel } = useLayoutContext();
     const canWriteMessages = useAbility(Abilities.CAN_WRITE_MESSAGES, selectedMailbox);
+    const [showSpinner, setShowSpinner] = useState(false);
+
+    const handleRefresh = async () => {
+        setShowSpinner(true);
+        try {
+            await refetchMailboxes();
+        } finally {
+            setShowSpinner(false);
+        }
+    };
 
     const goToNewMessageForm = (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
         event.preventDefault();
@@ -38,10 +49,18 @@ export const MailboxPanelActions = () => {
             </div>
             <div className="mailbox-panel-actions__extra">
                 <Button
-                    icon={<span className="material-icons">autorenew</span>}
+                    icon={
+                        <span className="mailbox-panel-actions__refresh-wrapper">
+                            <span className={`material-icons mailbox-panel-actions__refresh-icon${showSpinner ? ' mailbox-panel-actions__refresh-icon--hidden' : ''}`}>autorenew</span>
+                            <span className={`mailbox-panel-actions__refresh-spinner${showSpinner ? ' mailbox-panel-actions__refresh-spinner--visible' : ''}`}>
+                                <Spinner size="sm" />
+                            </span>
+                        </span>
+                    }
                     variant="tertiary"
-                    aria-label={t('Refresh')}
-                    onClick={refetchMailboxes}
+                    aria-label={showSpinner ? t('Loading…') : t('Refresh')}
+                    onClick={handleRefresh}
+                    disabled={showSpinner}
                 />
             </div>
         </div>

--- a/src/frontend/src/features/providers/mailbox.tsx
+++ b/src/frontend/src/features/providers/mailbox.tsx
@@ -1,6 +1,6 @@
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo } from "react";
 import { Mailbox, MailboxRoleChoices, Message, messagesListResponse200, PaginatedThreadList, Thread, useLabelsList, useMailboxesList, useMessagesList, useThreadsListInfinite } from "../api/gen";
-import { FetchStatus, QueryStatus, useQueryClient } from "@tanstack/react-query";
+import { FetchStatus, QueryStatus, RefetchOptions, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 import usePrevious from "@/hooks/use-previous";
 import { useSearchParams } from "next/navigation";
@@ -35,7 +35,7 @@ type MailboxContextType = {
     invalidateThreadMessages: (source?: MessageQueryInvalidationSource) => Promise<void>;
     invalidateThreadsStats: () => Promise<void>;
     invalidateLabels: () => Promise<void>;
-    refetchMailboxes: () => void;
+    refetchMailboxes: (options?: RefetchOptions) => Promise<unknown>;
     isPending: boolean;
     queryStates: {
         mailboxes: QueryState,
@@ -60,7 +60,7 @@ const MailboxContext = createContext<MailboxContextType>({
     invalidateThreadMessages: async () => {},
     invalidateThreadsStats: async () => {},
     invalidateLabels: async () => {},
-    refetchMailboxes: () => {},
+    refetchMailboxes: async () => {},
     isPending: false,
     queryStates: {
         mailboxes: {


### PR DESCRIPTION
## Purpose

When the user clicks on the refresh button it has no feedbkac that a request has been executed. So to improve ux, we had a smooth loading state transition on this action.


https://github.com/user-attachments/assets/0233137b-cbf6-4200-92b7-273c88efb690



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mailbox refresh button now shows a visual loading spinner during refresh
  * Button displays "Loading…" status while fetching updates
  * Refresh button is disabled during loading to prevent duplicate requests
  * Smooth transition animations for spinner/icon appearance
  * Accessibility: respects reduced-motion preferences and improves ARIA feedback

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->