### PR TITLE
🔧(backend) use redis cache for development

### DIFF
--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -1007,9 +1007,23 @@ class Development(Base):
 
     USE_SWAGGER = True
     SESSION_CACHE_ALIAS = "session"
+    # Use Redis for caching (required for task owner tracking)
     CACHES = {
         "default": {
-            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": values.Value(
+                "redis://redis:6379",
+                environ_name="REDIS_URL",
+                environ_prefix=None,
+            ),
+            "TIMEOUT": values.IntegerValue(
+                30,  # timeout in seconds
+                environ_name="CACHES_DEFAULT_TIMEOUT",
+                environ_prefix=None,
+            ),
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            },
         },
         "session": {
             "BACKEND": "django_redis.cache.RedisCache",
@@ -1048,42 +1062,6 @@ class E2E(Development):
     # Trust X-Forwarded-* headers from nginx proxy
     USE_X_FORWARDED_HOST = True
 
-    # Use Redis for caching (required for task owner tracking)
-    CACHES = {
-        "default": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": values.Value(
-                "redis://redis:6379",
-                environ_name="REDIS_URL",
-                environ_prefix=None,
-            ),
-            "TIMEOUT": values.IntegerValue(
-                300,  # 5 minutes
-                environ_name="CACHES_DEFAULT_TIMEOUT",
-                environ_prefix=None,
-            ),
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            },
-        },
-        "session": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": values.Value(
-                "redis://redis:6379",
-                environ_name="REDIS_URL",
-                environ_prefix=None,
-            ),
-            "TIMEOUT": values.IntegerValue(
-                300,
-                environ_name="CACHES_DEFAULT_TIMEOUT",
-                environ_prefix=None,
-            ),
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            },
-        },
-    }
-
 
 class DevelopmentMinimal(Development):
     """
@@ -1093,9 +1071,7 @@ class DevelopmentMinimal(Development):
     CELERY_TASK_ALWAYS_EAGER = True
     OPENSEARCH_INDEX_THREADS = False
     CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-        },
+        "default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
         "session": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     }
 


### PR DESCRIPTION
## Purpose

By default the default cache backend was a dummy one. Since we store pending task into cache, this backend does not allow to track tasks so task api endpoint was always return a 403 error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development environment: switched default cache to Redis with a short timeout and aligned session caching to Redis.
  * E2E environment: removed explicit Redis cache configuration (reverted to no explicit default cache).
  * DevelopmentMinimal: consolidated default cache declaration without behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->