### PR TITLE
🚑(importer) fix memory leak with large mbox file import

### DIFF
--- a/src/backend/core/services/importer/tasks.py
+++ b/src/backend/core/services/importer/tasks.py
@@ -89,15 +89,15 @@ def process_mbox_file_task(self, file_key: str, recipient_id: str) -> Dict[str, 
             if content_type not in enums.MBOX_SUPPORTED_MIME_TYPES:
                 raise Exception(f"Expected MBOX file, got {content_type}")
 
-            # First pass: count total messages
+            # First pass: scan for message positions (also gives us the count)
             file.seek(0)
-            total_messages = count_mbox_messages(file)
+            message_positions, file_end = scan_mbox_messages(file)
+            total_messages = len(message_positions)
 
-            # Reset file pointer
-            file.seek(0)
-
-            # Second pass: process messages
-            for i, message_content in enumerate(stream_mbox_messages(file), 1):
+            # Second pass: process messages using pre-computed positions
+            for i, message_content in enumerate(
+                stream_mbox_messages(file, message_positions, file_end), 1
+            ):
                 current_message = i
                 try:
                     # Update task state with progress
@@ -186,59 +186,75 @@ def process_mbox_file_task(self, file_key: str, recipient_id: str) -> Dict[str, 
         }
 
 
-def count_mbox_messages(file) -> int:
+def scan_mbox_messages(file) -> tuple[list[int], int]:
     """
-    Count the number of messages in an MBOX file without loading everything into memory.
-    """
-    count = 0
-    for line in file:
-        if line.startswith(b"From "):
-            count += 1
-    return count
+    Scan an MBOX file and return message positions without loading content into memory.
 
-
-def stream_mbox_messages(file) -> Generator[bytes, None, None]:
-    """
-    Stream individual email messages from an MBOX file without loading everything into memory.
-
-    Note: To maintain chronological order (needed for reply threading), we first collect
-    all messages and then yield them in reverse order, since mbox files store messages
-    with the most recent first.
+    This function performs a single pass through the file to record the byte offset
+    where each message starts. The count of messages is simply len(positions).
 
     Args:
         file: File-like object to read from
 
+    Returns:
+        A tuple of (message_positions, file_end) where:
+        - message_positions: list of byte offsets where each message starts
+        - file_end: byte offset of end of file (needed to compute last message size)
+    """
+    message_positions = []
+    position = 0
+
+    for line in file:
+        if line.startswith(b"From "):
+            message_positions.append(position)
+        position += len(line)
+
+    return message_positions, position
+
+
+def stream_mbox_messages(
+    file, message_positions: list[int], file_end: int | None = None
+) -> Generator[bytes, None, None]:
+    """
+    Stream individual email messages from an MBOX file without loading everything into memory.
+
+    Yields messages in reverse order (oldest first) for proper reply threading,
+    since mbox files store messages with the most recent first.
+
+    Args:
+        file: File-like object to read from (must support seek)
+        message_positions: Pre-computed list of byte offsets where messages start.
+        file_end: Byte offset of end of file.
+
     Yields:
         Individual email messages as bytes
     """
-    current_message = []
-    in_message = False
-    messages = []
+    if message_positions is None or file_end is None:
+        logger.warning(
+            "Cannot stream MBOX messages: message positions or file end not provided"
+        )
+        return
 
-    # Read line by line to avoid loading entire file into memory at once
-    # We still need to collect messages for reversing due to mbox format
-    for line in file:
-        # Check for mbox message separator
-        if line.startswith(b"From "):
-            if in_message and current_message:
-                # End of previous message - store it
-                messages.append(b"".join(current_message))
-                current_message = []
-            in_message = True
-            # Skip the mbox From line
-            continue
+    # Read messages in reverse order for chronological processing
+    # Process from last message to first (oldest to newest in real time)
+    for i in range(len(message_positions) - 1, -1, -1):
+        start_pos = message_positions[i]
+        # End position is either the next message start or end of file
+        end_pos = (
+            message_positions[i + 1] if i + 1 < len(message_positions) else file_end
+        )
 
-        if in_message:
-            current_message.append(line)
+        # Seek to message start
+        file.seek(start_pos)
 
-    # Add the last message if there is one
-    if current_message:
-        messages.append(b"".join(current_message))
+        # Read the message content (excluding the "From " line)
+        first_line = file.readline()  # Skip the "From " separator line
+        content_start = start_pos + len(first_line)
+        content_length = end_pos - content_start
 
-    # Yield messages in reverse order to treat replies correctly
-    # (mbox format stores newest messages first)
-    for message in reversed(messages):
-        yield message
+        # Read just this message's content
+        message_content = file.read(content_length)
+        yield message_content
 
 
 @celery_app.task(bind=True)

--- a/src/backend/core/tests/tasks/test_task_importer.py
+++ b/src/backend/core/tests/tasks/test_task_importer.py
@@ -14,7 +14,11 @@ from core import models
 from core.factories import MailboxFactory, UserFactory
 from core.mda.inbound import deliver_inbound_message
 from core.models import Message
-from core.services.importer.tasks import process_mbox_file_task, stream_mbox_messages
+from core.services.importer.tasks import (
+    process_mbox_file_task,
+    scan_mbox_messages,
+    stream_mbox_messages,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -561,7 +565,8 @@ class TestStreamMboxMessages:
     def test_task_stream_mbox_messages_success(self, sample_mbox_content):
         """Test successful streaming of MBOX file."""
         file = BytesIO(sample_mbox_content)
-        messages = list(stream_mbox_messages(file))
+        message_positions, file_end = scan_mbox_messages(file)
+        messages = list(stream_mbox_messages(file, message_positions, file_end))
         assert len(messages) == 3
         # Messages are in reverse order (newest first) due to the reversing in stream_mbox_messages
         assert b"Test Message 3" in messages[0]
@@ -571,7 +576,8 @@ class TestStreamMboxMessages:
     def test_task_stream_mbox_messages_empty(self):
         """Test streaming an empty MBOX file."""
         file = BytesIO(b"")
-        messages = list(stream_mbox_messages(file))
+        message_positions, file_end = scan_mbox_messages(file)
+        messages = list(stream_mbox_messages(file, message_positions, file_end))
         assert len(messages) == 0
 
     def test_task_stream_mbox_messages_single_message(self):
@@ -584,7 +590,8 @@ To: recipient@example.com
 This is a single message.
 """
         file = BytesIO(content)
-        messages = list(stream_mbox_messages(file))
+        message_positions, file_end = scan_mbox_messages(file)
+        messages = list(stream_mbox_messages(file, message_positions, file_end))
         assert len(messages) == 1
         assert b"Single Message" in messages[0]
 
@@ -598,5 +605,93 @@ To: recipient@example.com
 This is a malformed message.
 """
         file = BytesIO(content)
-        messages = list(stream_mbox_messages(file))
+        message_positions, file_end = scan_mbox_messages(file)
+        messages = list(stream_mbox_messages(file, message_positions, file_end))
         assert len(messages) == 0  # No valid messages should be found
+
+    def test_task_stream_mbox_messages_not_fully_loaded_in_memory(
+        self, sample_mbox_content
+    ):
+        """Test that mbox processing uses a memory-efficient two-pass approach.
+
+        The workflow should:
+        1. First pass (scan_mbox_messages): iterate line by line, no seek, only stores integers
+        2. Second pass (stream_mbox_messages): seek to each position and read one message at a time
+
+        This test verifies the file is processed efficiently without loading all content.
+        """
+
+        class SpyFile:
+            """A file wrapper that tracks seek and read operations."""
+
+            def __init__(self, content: bytes):
+                self._file = BytesIO(content)
+                self.seek_calls = []
+                self.read_calls = []
+                self.readline_calls = []
+                self.iter_count = 0
+
+            def __iter__(self):
+                self.iter_count += 1
+                return iter(self._file)
+
+            def seek(self, pos, *args):
+                self.seek_calls.append(pos)
+                return self._file.seek(pos, *args)
+
+            def read(self, size=-1):
+                result = self._file.read(size)
+                self.read_calls.append(len(result))
+                return result
+
+            def readline(self):
+                result = self._file.readline()
+                self.readline_calls.append(len(result))
+                return result
+
+        # Test scan_mbox_messages (first pass)
+        scan_spy = SpyFile(sample_mbox_content)
+        positions, file_end = scan_mbox_messages(scan_spy)
+
+        # Verify scan only iterates once and doesn't seek
+        assert scan_spy.iter_count == 1, "scan_mbox_messages should iterate once"
+        assert len(scan_spy.seek_calls) == 0, (
+            "scan_mbox_messages should not seek - it only scans line by line"
+        )
+        assert len(positions) == 3, (
+            f"Expected 3 message positions, got {len(positions)}"
+        )
+
+        # Test stream_mbox_messages with pre-computed positions (second pass)
+        stream_spy = SpyFile(sample_mbox_content)
+        messages = list(stream_mbox_messages(stream_spy, positions, file_end))
+
+        # Verify we got all 3 messages
+        assert len(messages) == 3
+
+        # Verify stream didn't iterate (positions were pre-computed)
+        assert stream_spy.iter_count == 0, (
+            "stream_mbox_messages should not iterate when positions are provided"
+        )
+
+        # Verify seek was called for each message
+        assert len(stream_spy.seek_calls) == 3, (
+            f"Expected 3 seek calls (one per message), got {len(stream_spy.seek_calls)}. "
+            "This suggests the file might be fully loaded into memory."
+        )
+
+        # Verify read was called for each message individually
+        assert len(stream_spy.read_calls) == 3, (
+            f"Expected 3 read calls (one per message), got {len(stream_spy.read_calls)}. "
+            "This suggests messages might be accumulated in memory."
+        )
+
+        # Verify readline was called for each message (to skip "From " separator)
+        assert len(stream_spy.readline_calls) == 3, (
+            f"Expected 3 readline calls, got {len(stream_spy.readline_calls)}."
+        )
+
+        # Verify messages are still in correct order (oldest first for threading)
+        assert b"Test Message 3" in messages[0]
+        assert b"Test Message 2" in messages[1]
+        assert b"Test Message 1" in messages[2]


### PR DESCRIPTION
## Purpose

We were parsing the mbox and store each message in a list... so for large mbox it leads to memory overflow.

Refactored the MBOX file processing to first scan for message positions without loading the entire file into memory, improving efficiency. The second pass now streams messages using pre-computed positions, ensuring memory usage is minimized while maintaining correct message order for threading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized message import processing with improved memory efficiency and performance through a two-pass scanning and streaming approach
  * Enhanced input validation for message processing

* **Tests**
  * Added and updated test coverage for the revised message streaming methodology, including validation of correct message ordering and per-message processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->