### PR TITLE
🐛(parser) strip NUL bytes from email content

### DIFF
--- a/src/backend/core/mda/rfc5322/parser.py
+++ b/src/backend/core/mda/rfc5322/parser.py
@@ -26,6 +26,18 @@ from flanker.mime import create
 logger = logging.getLogger(__name__)
 
 
+def _strip_nul_bytes(text: str) -> str:
+    """Strip NUL bytes from text.
+
+    PostgreSQL text fields cannot store NUL (0x00) bytes.
+    This char is used to mark the end of a string in C language
+    and is not valid in PostgreSQL text fields. Furthermore the
+    RFC 5322 section 4 defines it as an obsolete character.
+    https://datatracker.ietf.org/doc/html/rfc5322#page-31
+    """
+    return text.replace("\x00", "") if text else ""
+
+
 class EmailParseError(Exception):
     """Exception raised for errors during email parsing."""
 
@@ -475,7 +487,7 @@ def _build_body_part_dict(part_info: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "partId": part_info["part_id"],
         "type": part_type,
-        "content": content,
+        "content": _strip_nul_bytes(content),
     }
 
 
@@ -655,7 +667,11 @@ def parse_message_content(message) -> Dict[str, Any]:
     if not hasattr(message, "content_type") or not message.content_type:
         if hasattr(message, "body") and isinstance(message.body, str):
             result["textBody"].append(
-                {"partId": "", "type": "text/plain", "content": message.body}
+                {
+                    "partId": "",
+                    "type": "text/plain",
+                    "content": _strip_nul_bytes(message.body),
+                }
             )
         return result
 
@@ -792,7 +808,7 @@ def parse_email_message(raw_email_bytes: bytes) -> Optional[Dict[str, Any]]:
         default_date = datetime.now(dt_timezone.utc)
 
         return {
-            "subject": subject or "",
+            "subject": _strip_nul_bytes(subject or ""),
             "from": {"name": from_name, "email": from_addr},
             "to": [{"name": name, "email": email} for name, email in to_recipients],
             "cc": [{"name": name, "email": email} for name, email in cc_recipients],

--- a/src/backend/core/tests/mda/test_rfc5322_parser.py
+++ b/src/backend/core/tests/mda/test_rfc5322_parser.py
@@ -948,6 +948,40 @@ This is a test email body.
         with pytest.raises(EmailParseError, match="Input must be non-empty bytes."):
             parse_email_message(None)
 
+    def test_parse_email_with_nul_bytes(self):
+        """Test that NUL bytes are stripped from subject and body content.
+
+        PostgreSQL text fields cannot store NUL (0x00) bytes.
+        """
+        raw = b"Subject: Test\x00Subject\x00With\x00NUL\nFrom: a@b.c\nTo: d@e.f\n\nBody\x00with\x00NUL\x00bytes."
+        parsed = parse_email_message(raw)
+        assert parsed is not None
+        # Verify NUL bytes were stripped from subject
+        assert "\x00" not in parsed["subject"]
+        assert parsed["subject"] == "TestSubjectWithNUL"
+        # Verify NUL bytes were stripped from body content
+        assert len(parsed["textBody"]) == 1
+        assert "\x00" not in parsed["textBody"][0]["content"]
+        assert parsed["textBody"][0]["content"] == "BodywithNULbytes."
+
+    def test_parse_message_content_strips_nul_bytes_in_fallback_path(self):
+        """Test NUL bytes are stripped in the fallback path for malformed messages.
+
+        When a message has no content-type but has a body, the fallback path
+        in parse_message_content should still strip NUL bytes.
+        """
+
+        class MockMessage:
+            """Mock message without content_type to trigger fallback path."""
+
+            content_type = None
+            body = "Body\x00with\x00NUL\x00bytes"
+
+        result = parse_message_content(MockMessage())
+        assert len(result["textBody"]) == 1
+        assert "\x00" not in result["textBody"][0]["content"]
+        assert result["textBody"][0]["content"] == "BodywithNULbytes"
+
     def test_parse_message_content_simple(self, flanker_simple_message):
         """Test parsing content of a simple text message."""
         content = parse_message_content(flanker_simple_message)


### PR DESCRIPTION
## Purpose

Introduced a new helper function to remove NUL bytes from parsed email subjects and body content, ensuring compatibility with PostgreSQL text fields.

We only remove NUL bytes at there is the single char not allowed in [PostgreSQL text fields](https://www.postgresql.org/docs/current/datatype-character.html) and also a vector attack to split strings in C context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email parsing now strips invalid NUL (0x00) characters from subjects and message content, preventing corrupted or unreadable text.

* **Tests**
  * Added tests verifying NUL bytes are removed from email subjects and bodies, including a fallback parsing path to ensure robust handling of missing content-type scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->