### PR TITLE
🐛(frontend) fix cursor position when clicking in combobox input

### DIFF
--- a/src/frontend/src/features/forms/components/combobox/_index.scss
+++ b/src/frontend/src/features/forms/components/combobox/_index.scss
@@ -197,6 +197,7 @@
   &::after {
     content: attr(data-value) ' ';
     white-space: pre-wrap;
+    pointer-events: none;
   }
 
   &::after,


### PR DESCRIPTION
## Purpose

The combobox input uses a CSS technique with a ::after pseudo-element (containing the input value via `content: attr(data-value)`) overlaid on the actual input to enable auto-sizing. However, this ::after element was intercepting mouse clicks instead of letting them pass through to the underlying input.

When a user clicked to reposition the cursor within the text:
1. The click landed on ::after (not the input directly)
2. This caused the input to lose focus (blur)
3. The wrapper's onClick handler then called focus() on the input
4. focus() placed the cursor at the end of the text by default

Adding `pointer-events: none` to the ::after pseudo-element allows clicks to pass through to the input, preserving the expected cursor positioning behavior.

https://github.com/user-attachments/assets/21eecb72-9206-4fb8-8ff2-b5e1b90eefdb




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed unintended pointer interactions affecting the combobox component's dropdown indicator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->