### PR TITLE
(chore) bump keycloak to 26.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Bump keycloak to 26.5.3 #543
+
 ## [0.2.0] - 2026-02-03
 
 ### Added

--- a/compose.yaml
+++ b/compose.yaml
@@ -337,7 +337,7 @@ services:
     pull_policy: build
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.2.5
+    image: quay.io/keycloak/keycloak:26.5.3
     volumes:
       - ./src/keycloak/realm.json:/opt/keycloak/data/import/realm.json:ro
       - ./src/keycloak/themes/dsfr-2.2.1.jar:/opt/keycloak/providers/keycloak-theme.jar:ro
@@ -348,7 +348,8 @@ services:
       - start-dev
       - --features=preview
       - --import-realm
-      - --proxy=edge
+      - --proxy-headers=xforwarded
+      - --http-enabled=true
       - --hostname=$${HOST}
       - --hostname-admin=$${ADMIN_HOST}
       - --http-port=8802

--- a/src/e2e/compose.yaml
+++ b/src/e2e/compose.yaml
@@ -54,7 +54,8 @@ services:
       - start-dev
       - --features=preview
       - --import-realm
-      - --proxy=edge
+      - --proxy-headers=xforwarded
+      - --http-enabled=true
       - --hostname=$${HOST}
       - --hostname-admin=$${ADMIN_HOST}
       - --http-port=8802

--- a/src/keycloak/Dockerfile
+++ b/src/keycloak/Dockerfile
@@ -13,7 +13,7 @@ fi
 zip -r /custom-scripts.jar META-INF *.js
 EOR
 
-FROM quay.io/keycloak/keycloak:26.4.7 AS builder
+FROM quay.io/keycloak/keycloak:26.5.3 AS builder
 
 WORKDIR /opt/keycloak
 COPY --chown=keycloak:keycloak --chmod=644 themes/dsfr-2.2.1.jar /opt/keycloak/providers/dsfr.jar
@@ -25,7 +25,7 @@ ARG KC_DB=postgres
 
 RUN /opt/keycloak/bin/kc.sh build
 
-FROM quay.io/keycloak/keycloak:26.4.7
+FROM quay.io/keycloak/keycloak:26.5.3
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/src/keycloak/buildpack/scalingo_postcompile.sh
+++ b/src/keycloak/buildpack/scalingo_postcompile.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-KEYCLOAK_VERSION="26.2.1"
+KEYCLOAK_VERSION="26.5.3"
 KEYCLOAK_DIST="https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.tar.gz"
 
 echo "-----> Downloading Keycloak $KEYCLOAK_VERSION"


### PR DESCRIPTION
## Purpose

Description...


## Proposal

Description...

- [] item 1...
- [] item 2...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Keycloak to 26.5.3 across the deployment artifacts.
* **New Features**
  * Keycloak now enables HTTP by default and uses proxy-headers for forwarded headers.
  * Runtime image now includes bundled custom scripts/provider to extend Keycloak behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->