### PR TITLE
🚸(frontend) use display_name for labels and auto-unfold active parents

### DIFF
--- a/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-labels/components/label-item/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/components/mailbox-labels/components/label-item/index.tsx
@@ -5,7 +5,7 @@ import { Button, useModals } from "@gouvfr-lasuite/cunningham-react";
 import clsx from "clsx";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { useLayoutContext } from "@/features/layouts/components/main";
@@ -56,8 +56,15 @@ export const LabelItem = ({ level = 0, onEdit, canManage, defaultFoldState, ...l
   const hasActiveChild = Boolean(searchParams.get('label_slug')?.startsWith(`${label.slug}-`));
   const isFoldedByDefault = label.children.length === 0 ? null : (defaultFoldState ?? !hasActiveChild);
   const foldKey = useMemo(() => `label-item-${label.display_name}${label.children.length > 0 ? `-with-children` : ''}`, [label.display_name, label.children.length]);
-  const { isFolded, toggle } = useFold(foldKey, isFoldedByDefault);
+  const { isFolded, toggle, setFoldState } = useFold(foldKey, isFoldedByDefault);
   const foldTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const unfoldIfNeeded = useEffectEvent(() => {
+    if (isFolded) {
+      setFoldState(false);
+    }
+  });
+
   const goToDefaultFolder = () => {
     const defaultFolder = MAILBOX_FOLDERS()[0];
     router.push(pathname + `?${new URLSearchParams(defaultFolder.filter).toString()}`);
@@ -232,6 +239,12 @@ export const LabelItem = ({ level = 0, onEdit, canManage, defaultFoldState, ...l
 
     return `${offset * level}rem`;
   }
+
+  useEffect(() => {
+    if (hasActiveChild) {
+      unfoldIfNeeded();
+    }
+  }, [hasActiveChild]);
 
   return (
     <>

--- a/src/frontend/src/features/providers/fold.tsx
+++ b/src/frontend/src/features/providers/fold.tsx
@@ -3,6 +3,7 @@ import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRe
 type FoldContextType = {
     isFolded: (key: string) => boolean | undefined;
     toggle: (key: string) => void;
+    setFoldState: (key: string, isFolded: boolean) => void;
     subscribe: (key: string, isFolded?: boolean) => void;
     unsubscribe: (key: string) => void;
     areAllFolded: boolean | undefined;
@@ -17,6 +18,7 @@ type FoldGlobalHookContext = {
 type FoldHookContext = FoldGlobalHookContext & {
     isFolded: boolean | undefined;
     toggle: () => void;
+    setFoldState: (isFolded: boolean) => void;
 }
 
 const FoldContext = createContext<FoldContextType | undefined>(undefined);
@@ -75,6 +77,19 @@ export const FoldProvider = ({ children }: PropsWithChildren) => {
         });
     }
 
+    const setFoldState = (id: string, folded: boolean) => {
+        setSubscribers((prev) => {
+            if (!prev.has(id)) {
+                console.warn(`FoldProvider: subscriber with key "${id}" not registered`);
+                return prev;
+            }
+            if (prev.get(id) === folded) return prev;
+            const newSubscribers = new Map(prev);
+            newSubscribers.set(id, folded);
+            return newSubscribers;
+        });
+    }
+
     const toggleAll = () => {
         setSubscribers((prev) => {
             // Unfold all if all are folded, otherwise fold all
@@ -90,9 +105,10 @@ export const FoldProvider = ({ children }: PropsWithChildren) => {
         unsubscribe,
         isFolded,
         toggle,
+        setFoldState,
         areAllFolded,
         toggleAll,
-    }), [subscribe, unsubscribe, isFolded, toggle, areAllFolded, toggleAll, subscribers]);
+    }), [subscribe, unsubscribe, isFolded, toggle, setFoldState, areAllFolded, toggleAll, subscribers]);
 
     return (
         <FoldContext.Provider value={context}>
@@ -115,6 +131,7 @@ export function useFold(id?: string, isFolded: boolean | null = true): FoldHookC
         ...(id ? {
             isFolded: isRegistered.current ? ctx.isFolded(id) : undefined,
             toggle: () => ctx.toggle(id),
+            setFoldState: (folded: boolean) => ctx.setFoldState(id, folded),
         } : {}),
         areAllFolded: ctx.areAllFolded,
         toggleAll: ctx.toggleAll,

--- a/src/frontend/src/features/ui/components/label-badge/index.tsx
+++ b/src/frontend/src/features/ui/components/label-badge/index.tsx
@@ -66,7 +66,7 @@ export const LabelBadge = ({ label, removable = false, linkable = false, compact
 
     return (
         <Badge title={label.name} className={clsx("label-badge", {"label-badge--compact": compact })} style={{ backgroundColor: label.color, color: badgeColor }}>
-            {showLink ? <Link className="label-badge__label" href={link}>{label.name}</Link> : <span className="label-badge__label">{label.name}</span>}
+            {showLink ? <Link className="label-badge__label" href={link}>{label.display_name}</Link> : <span className="label-badge__label">{label.display_name}</span>}
             {canManageLabels && selectedThread?.id && removable && (
                 <Tooltip content={t('Delete')} placement="right">
                     <button


### PR DESCRIPTION
## Purpose

Labels now show their display_name instead of name in badges,
ensuring users just see the label name instead of the full
path name that could be long so hard to read.
Parent labels automatically unfold when a child label is active,
improving navigation discoverability.


https://github.com/user-attachments/assets/1429f89f-8ba7-411e-8efb-89828653d5c1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Labels in the mailbox panel now automatically expand when they contain an active child item
  * Label badges now display the correct display name for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->