### PR TITLE
✨(frontend) customize editor menus and side panel

### DIFF
--- a/src/frontend/src/features/blocknote/blocknote-view-field/_index.scss
+++ b/src/frontend/src/features/blocknote/blocknote-view-field/_index.scss
@@ -80,6 +80,14 @@
         flex-shrink: 0;
         min-height: var(--toolbar-height);
 
+        // Override the max-height set by the Floating UI `size` middleware
+        // on toolbar select dropdowns. Without portal rendering, the dropdown
+        // is constrained to the available space inside the toolbar container,
+        // which becomes too small when the toolbar wraps onto multiple lines.
+        .mantine-Menu-dropdown {
+            max-height: none !important;
+        }
+
         .bn-toolbar-separator {
             width: 1px;
             align-self: stretch;
@@ -104,7 +112,10 @@
         border-radius: var(--c--components--forms-input--border-radius);
         min-height: calc(100% - var(--toolbar-height));
         padding-inline: var(--c--globals--spacings--base);
+        // Extra left padding to make room for the side menu drag handle
+        padding-left: calc(var(--c--globals--spacings--base) + 8px);
         flex: 1;
+        overflow: visible;
 
         // Overide blocknote default styles to fix some contrast issues
         blockquote {

--- a/src/frontend/src/features/blocknote/blocknote-view-field/index.tsx
+++ b/src/frontend/src/features/blocknote/blocknote-view-field/index.tsx
@@ -6,6 +6,9 @@ import clsx from "clsx";
 import { PropsWithChildren } from "react";
 import { createPortal } from "react-dom";
 
+import { CustomSideMenuController } from "../custom-side-menu";
+import { CustomSlashMenu } from "../custom-slash-menu";
+
 type BlockNoteViewFieldProps<BSchema extends BlockSchema, ISchema extends InlineContentSchema, SSchema extends StyleSchema> = PropsWithChildren<FieldProps & {
     composerProps: Parameters<typeof BlockNoteView<BSchema, ISchema, SSchema>>[0];
     disabled?: boolean;
@@ -26,6 +29,8 @@ export const BlockNoteViewField = <BSchema extends BlockSchema, ISchema extends 
                 className={clsx(composerProps.className, "composer-field-input")}
                 editable={!disabled}
             >
+                <CustomSideMenuController />
+                <CustomSlashMenu />
                 <PortalledFilePanel />
                 {children}
             </BlockNoteView>

--- a/src/frontend/src/features/blocknote/custom-side-menu.tsx
+++ b/src/frontend/src/features/blocknote/custom-side-menu.tsx
@@ -1,0 +1,32 @@
+import { SideMenuExtension } from '@blocknote/core/extensions';
+import {
+    DragHandleButton,
+    SideMenu,
+    SideMenuController,
+    useBlockNoteEditor,
+    useExtensionState,
+} from '@blocknote/react';
+
+const READ_ONLY_BLOCKS = new Set(['signature', 'quoted-message']);
+
+const FilteredSideMenu = () => {
+    const editor = useBlockNoteEditor();
+    const block = useExtensionState(SideMenuExtension, {
+        editor,
+        selector: (state) => state?.block,
+    });
+
+    if (!block || READ_ONLY_BLOCKS.has(block.type)) {
+        return null;
+    }
+
+    return (
+        <SideMenu>
+            <DragHandleButton />
+        </SideMenu>
+    );
+};
+
+export const CustomSideMenuController = () => (
+    <SideMenuController sideMenu={FilteredSideMenu} />
+);

--- a/src/frontend/src/features/blocknote/custom-slash-menu.tsx
+++ b/src/frontend/src/features/blocknote/custom-slash-menu.tsx
@@ -1,0 +1,40 @@
+import {
+    filterSuggestionItems,
+    getDefaultSlashMenuItems,
+} from '@blocknote/core/extensions';
+import {
+    SuggestionMenuController,
+    useBlockNoteEditor,
+} from '@blocknote/react';
+
+import { HIDDEN_BLOCK_TYPES } from './utils';
+
+const HIDDEN_SLASH_MENU_KEYS = new Set([
+    ...HIDDEN_BLOCK_TYPES,
+    'code_block',
+    'toggle_list',
+    'toggle_heading',
+    'toggle_heading_2',
+    'toggle_heading_3',
+    'signature',
+    'quoted-message',
+]);
+
+export const CustomSlashMenu = () => {
+    const editor = useBlockNoteEditor();
+
+    const getItems = async (query: string) => {
+        const defaultItems = getDefaultSlashMenuItems(editor);
+        const filtered = defaultItems.filter(
+            (item) => !HIDDEN_SLASH_MENU_KEYS.has(item.key),
+        );
+        return filterSuggestionItems(filtered, query);
+    };
+
+    return (
+        <SuggestionMenuController
+            triggerCharacter="/"
+            getItems={getItems}
+        />
+    );
+};

--- a/src/frontend/src/features/blocknote/email-exporter/index.tsx
+++ b/src/frontend/src/features/blocknote/email-exporter/index.tsx
@@ -164,7 +164,6 @@ function getListTag(blockType: string): ListTag | null {
     switch (blockType) {
         case 'bulletListItem':
         case 'checkListItem':
-        case 'toggleListItem':
             return 'ul';
         case 'numberedListItem':
             return 'ol';

--- a/src/frontend/src/features/blocknote/toolbar.tsx
+++ b/src/frontend/src/features/blocknote/toolbar.tsx
@@ -1,5 +1,6 @@
 import {
     BasicTextStyleButton,
+    blockTypeSelectItems,
     BlockTypeSelect,
     ColorStyleButton,
     CreateLinkButton,
@@ -9,8 +10,12 @@ import {
     FileReplaceButton,
     FormattingToolbar,
     TextAlignButton,
+    useBlockNoteEditor,
 } from "@blocknote/react";
+import { useMemo } from "react";
+
 import { ImageUploadButton } from "./image-upload-button";
+import { isHiddenBlockTypeSelectItem } from "./utils";
 
 const ToolbarSeparator = () => (
     <div className="bn-toolbar-separator" role="separator" />
@@ -20,9 +25,17 @@ type ToolbarProps = {
     children?: React.ReactNode;
 }
 export const Toolbar = ({ children }: ToolbarProps) => {
+    const editor = useBlockNoteEditor();
+    const filteredItems = useMemo(
+        () => blockTypeSelectItems(editor.dictionary).filter(
+            (item) => !isHiddenBlockTypeSelectItem(item),
+        ),
+        [editor.dictionary],
+    );
+
     return (
         <FormattingToolbar>
-            <BlockTypeSelect key={"blockTypeSelect"} />
+            <BlockTypeSelect key={"blockTypeSelect"} items={filteredItems} />
             <ImageUploadButton />
 
             <ToolbarSeparator key={"separator-1"} />

--- a/src/frontend/src/features/blocknote/utils.ts
+++ b/src/frontend/src/features/blocknote/utils.ts
@@ -44,6 +44,33 @@ export const createNonImageFileBlockers = () => ({
 });
 
 /**
+ * Block types to hide from the slash menu and BlockTypeSelect.
+ * These blocks remain in the schema for backward-compatibility
+ * (existing drafts may contain them) but are hidden from the UI.
+ */
+export const HIDDEN_BLOCK_TYPES = new Set([
+    'toggleListItem',
+    'file',
+    'video',
+    'audio',
+    'table',
+]);
+
+/**
+ * Returns true if a BlockTypeSelect item should be hidden.
+ * Toggle headings share `type: "heading"` with normal headings
+ * but have `props.isToggleable: true`, so we need to check props too.
+ */
+export const isHiddenBlockTypeSelectItem = (item: {
+    type: string;
+    props?: Record<string, unknown>;
+}): boolean => {
+    if (HIDDEN_BLOCK_TYPES.has(item.type)) return true;
+    if (item.type === 'heading' && item.props?.isToggleable) return true;
+    return false;
+};
+
+/**
  * Replaces `template-variable` inline content nodes with plain text
  * using resolved placeholder values. Recurses into children blocks.
  */


### PR DESCRIPTION
## Purpose

Hide block types that are not relevant for the email composer (toggle lists, code blocks, file/video/audio, tables) from both the slash menu and the block type selector. Add a custom side menu with drag handle that is hidden on read-only blocks (signature, quoted-message). Fix toolbar dropdown being clipped by the Floating UI size middleware when the toolbar wraps.


https://github.com/user-attachments/assets/278db7a9-6df0-4695-bf45-a7dc49d180f1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customizable side menu for BlockNote blocks with drag-handle functionality.
  * Implemented a filtered slash menu for block insertion options.

* **Bug Fixes**
  * Fixed toolbar dropdown overflow when wrapping to multiple lines.
  * Improved editor layout spacing for side menu integration.

* **UI Changes**
  * Hidden certain block types from menus and block selection options.
  * Modified rendering behavior of toggle list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->