### PR TITLE
🔒(backend) prevent IDOR on ThreadAccess thread and mailbox fields

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -18,6 +18,23 @@ from core import enums, models
 from core.mda.rfc5322 import extract_base64_images_from_html
 
 
+class CreateOnlyFieldsMixin:
+    """Mixin that makes specified fields read-only on update (when instance exists).
+
+    Usage:
+        class MySerializer(CreateOnlyFieldsMixin, serializers.ModelSerializer):
+            class Meta:
+                create_only_fields = ["mailbox", "thread"]
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance is not None:
+            for field_name in getattr(self.Meta, "create_only_fields", []):
+                if field_name in self.fields:
+                    self.fields[field_name].read_only = True
+
+
 class IntegerChoicesField(serializers.ChoiceField):
     """
     Custom field to handle IntegerChoices that accepts string labels for input
@@ -520,7 +537,7 @@ class TreeLabelSerializer(serializers.ModelSerializer):
         """
 
 
-class LabelSerializer(serializers.ModelSerializer):
+class LabelSerializer(CreateOnlyFieldsMixin, serializers.ModelSerializer):
     """Serializer for Label model."""
 
     class Meta:
@@ -536,6 +553,7 @@ class LabelSerializer(serializers.ModelSerializer):
             "is_auto",
         ]
         read_only_fields = ["id", "slug"]
+        create_only_fields = ["mailbox"]
 
     def validate_mailbox(self, value):
         """Validate that user has access to the mailbox."""
@@ -867,7 +885,7 @@ class MessageSerializer(serializers.ModelSerializer):
         read_only_fields = fields  # Mark all as read-only
 
 
-class ThreadAccessSerializer(serializers.ModelSerializer):
+class ThreadAccessSerializer(CreateOnlyFieldsMixin, serializers.ModelSerializer):
     """Serialize thread access information."""
 
     role = IntegerChoicesField(choices_class=models.ThreadAccessRoleChoices)
@@ -876,6 +894,7 @@ class ThreadAccessSerializer(serializers.ModelSerializer):
         model = models.ThreadAccess
         fields = ["id", "thread", "mailbox", "role", "created_at", "updated_at"]
         read_only_fields = ["id", "created_at", "updated_at"]
+        create_only_fields = ["thread", "mailbox"]
 
 
 class MailboxAccessReadSerializer(serializers.ModelSerializer):

--- a/src/backend/core/tests/api/test_labels.py
+++ b/src/backend/core/tests/api/test_labels.py
@@ -488,6 +488,27 @@ class TestLabelViewSet:
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "You don't have access to this mailbox" in str(response.data["detail"])
 
+    def test_update_label_cannot_pivot_mailbox(self, api_client, label, mailbox, user):
+        """Regression test: PATCH must not allow changing the label's mailbox.
+
+        Even if a user has editor access on both mailboxes, they should not
+        be able to move a label from one mailbox to another via PATCH.
+        """
+        other_mailbox = MailboxFactory()
+        other_mailbox.accesses.create(user=user, role=models.MailboxRoleChoices.ADMIN)
+
+        url = reverse("labels-detail", args=[label.pk])
+        api_client.patch(
+            url,
+            {"mailbox": str(other_mailbox.id)},
+            format="json",
+        )
+
+        label.refresh_from_db()
+        assert label.mailbox_id == mailbox.id, (
+            "Label.mailbox was changed via PATCH — mailbox should be immutable on update"
+        )
+
     def test_delete_label(self, api_client, label):
         """Test deleting a label."""
         url = reverse("labels-detail", args=[label.pk])

--- a/src/backend/core/tests/api/test_thread_access.py
+++ b/src/backend/core/tests/api/test_thread_access.py
@@ -286,6 +286,80 @@ class TestThreadAccessCreate:
         response = api_client.post(get_thread_access_url(thread.id), {})
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    def test_create_thread_access_on_foreign_thread(self, api_client):
+        """An authenticated user must not be able to create a ThreadAccess
+        on a thread they have no access to."""
+        user_1 = factories.UserFactory()
+        user_1_mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=user_1_mailbox,
+            user=user_1,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+
+        # Another thread — user_1 has no ThreadAccess on it
+        not_owned_thread = factories.ThreadFactory()
+        factories.ThreadAccessFactory(
+            thread=not_owned_thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+
+        api_client.force_authenticate(user=user_1)
+
+        delegated_mailbox = factories.MailboxFactory()
+        response = api_client.post(
+            get_thread_access_url(not_owned_thread.id),
+            {"mailbox": str(delegated_mailbox.id), "role": "viewer"},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        # Verify no ThreadAccess was created for the not owned thread
+        assert not models.ThreadAccess.objects.filter(
+            thread=not_owned_thread, mailbox=delegated_mailbox
+        ).exists()
+
+    def test_create_thread_access_body_thread_ignored(self, api_client):
+        """POST body 'thread' field must not override the URL thread_id.
+
+        A user could POST to their own thread URL but send a another user's
+        thread ID in the body, hoping the serializer uses it instead.
+        The created ThreadAccess must always belong to the URL thread.
+        """
+        user_1 = factories.UserFactory()
+        user_1_mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=user_1_mailbox,
+            user=user_1,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+        user_1_thread = factories.ThreadFactory()
+        factories.ThreadAccessFactory(
+            mailbox=user_1_mailbox,
+            thread=user_1_thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+
+        not_owned_thread = factories.ThreadFactory()
+
+        api_client.force_authenticate(user=user_1)
+
+        delegated_mailbox = factories.MailboxFactory()
+        response = api_client.post(
+            get_thread_access_url(user_1_thread.id),
+            {
+                "thread": str(not_owned_thread.id),
+                "mailbox": str(delegated_mailbox.id),
+                "role": "viewer",
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # The created ThreadAccess must point to the URL thread, not the body thread
+        assert response.data["thread"] == user_1_thread.id
+        assert not models.ThreadAccess.objects.filter(
+            thread=not_owned_thread, mailbox=delegated_mailbox
+        ).exists()
+
 
 class TestThreadAccessUpdate:
     """Test the PUT/PATCH /threads/{thread_id}/accesses/{id}/ endpoint."""
@@ -392,6 +466,82 @@ class TestThreadAccessUpdate:
         url = get_thread_access_url(thread.id, uuid.uuid4())
         response = api_client.patch(url, {})
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_update_thread_access_cannot_pivot_thread(self, api_client):
+        """PATCH must not allow changing the thread FK (IDOR).
+
+        A user with editor access on their own thread could PATCH
+        the ThreadAccess record to point to another user's thread, gaining
+        full access to it. The 'thread' and 'mailbox' fields must be
+        read-only on update.
+        """
+        # Setup : user with mailbox and a thread they own
+        attacker = factories.UserFactory()
+        attacker_mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=attacker_mailbox,
+            user=attacker,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+        attacker_thread = factories.ThreadFactory()
+        attacker_access = factories.ThreadAccessFactory(
+            mailbox=attacker_mailbox,
+            thread=attacker_thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+
+        # Setup : another user with a private thread
+        victim_thread = factories.ThreadFactory()
+        factories.ThreadAccessFactory(
+            thread=victim_thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+
+        api_client.force_authenticate(user=attacker)
+
+        # Attempt to pivot the thread FK to the second user's thread
+        url = get_thread_access_url(attacker_thread.id, attacker_access.id)
+        api_client.patch(
+            url,
+            {"thread": str(victim_thread.id), "role": "editor"},
+        )
+
+        # The request may succeed (200) but must NOT change the thread
+        attacker_access.refresh_from_db()
+        assert attacker_access.thread_id == attacker_thread.id, (
+            "IDOR: ThreadAccess.thread was changed to another thread via PATCH"
+        )
+
+    def test_update_thread_access_cannot_pivot_mailbox(self, api_client):
+        """PATCH must not allow changing the mailbox FK on a ThreadAccess."""
+        user = factories.UserFactory()
+        mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=enums.MailboxRoleChoices.ADMIN,
+        )
+        thread = factories.ThreadFactory()
+        thread_access = factories.ThreadAccessFactory(
+            mailbox=mailbox,
+            thread=thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+
+        other_mailbox = factories.MailboxFactory()
+
+        api_client.force_authenticate(user=user)
+
+        url = get_thread_access_url(thread.id, thread_access.id)
+        api_client.patch(
+            url,
+            {"mailbox": str(other_mailbox.id), "role": "editor"},
+        )
+
+        thread_access.refresh_from_db()
+        assert thread_access.mailbox_id == mailbox.id, (
+            "IDOR: ThreadAccess.mailbox was changed via PATCH"
+        )
 
 
 class TestThreadAccessDelete:


### PR DESCRIPTION
## Purpose

The ThreadAccessSerializer allowed PATCH requests to modify the 'thread' and 'mailbox' foreign keys. An authenticated user could pivot their ThreadAccess record to any thread in the system, gaining unauthorized read/write access to other users' private threads. Adding both fields to read_only_fields closes this BOLA vulnerability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented labels from being reassigned to a different mailbox via updates.
  * Prevented thread-access records from being moved to a different thread or mailbox via updates.
  * Ensured thread-access creation respects the target thread in the URL and rejects attempts to create access on threads the user cannot reach.

* **Tests**
  * Added regression tests covering these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->