### PR TITLE
(chore) bump keycloak to 26.5.4

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -333,7 +333,7 @@ services:
     pull_policy: build
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.5.3
+    image: quay.io/keycloak/keycloak:26.5.4
     volumes:
       - ./src/keycloak/realm.json:/opt/keycloak/data/import/realm.json:ro
       - ./src/keycloak/themes/dsfr-2.2.1.jar:/opt/keycloak/providers/keycloak-theme.jar:ro

--- a/src/keycloak/Dockerfile
+++ b/src/keycloak/Dockerfile
@@ -13,7 +13,7 @@ fi
 zip -r /custom-scripts.jar META-INF *.js
 EOR
 
-FROM quay.io/keycloak/keycloak:26.5.3 AS builder
+FROM quay.io/keycloak/keycloak:26.5.4 AS builder
 
 WORKDIR /opt/keycloak
 COPY --chown=keycloak:keycloak --chmod=644 themes/dsfr-2.2.1.jar /opt/keycloak/providers/dsfr.jar
@@ -25,7 +25,7 @@ ARG KC_DB=postgres
 
 RUN /opt/keycloak/bin/kc.sh build
 
-FROM quay.io/keycloak/keycloak:26.5.3
+FROM quay.io/keycloak/keycloak:26.5.4
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/src/keycloak/buildpack/scalingo_postcompile.sh
+++ b/src/keycloak/buildpack/scalingo_postcompile.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-KEYCLOAK_VERSION="26.5.3"
+KEYCLOAK_VERSION="26.5.4"
 KEYCLOAK_DIST="https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.tar.gz"
 
 echo "-----> Downloading Keycloak $KEYCLOAK_VERSION"


### PR DESCRIPTION
## Purpose

Description...


## Proposal

Description...

- [] item 1...
- [] item 2...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Keycloak authentication service to version 26.5.4
  * Implemented service health checks to monitor availability and reliability
  * Added support for custom scripts integration within Keycloak

<!-- end of auto-generated comment: release notes by coderabbit.ai -->