### PR TITLE
♿(frontend) add skip navigation link for keyboard users

### DIFF
--- a/src/frontend/public/locales/common/en-US.json
+++ b/src/frontend/public/locales/common/en-US.json
@@ -438,6 +438,7 @@
   "Signatures for {{mailbox}}": "Signatures for {{mailbox}}",
   "Simple and intuitive messaging": "Simple and intuitive messaging",
   "Simple redirect (Coming soon)": "Simple redirect (Coming soon)",
+  "Skip to main content": "Skip to main content",
   "Some messages have not been delivered to all recipients.": "Some messages have not been delivered to all recipients.",
   "Some recipients have not received this message!": "Some recipients have not received this message!",
   "Spam": "Spam",

--- a/src/frontend/public/locales/common/fr-FR.json
+++ b/src/frontend/public/locales/common/fr-FR.json
@@ -476,6 +476,7 @@
   "Signatures for {{mailbox}}": "Signatures de {{mailbox}}",
   "Simple and intuitive messaging": "Une messagerie simple et intuitive",
   "Simple redirect (Coming soon)": "Créer une simple redirection (Bientôt disponible)",
+  "Skip to main content": "Aller au contenu principal",
   "Some messages have not been delivered to all recipients.": "Certains messages n'ont pas pu être délivrés à tous les destinataires.",
   "Some recipients have not received this message!": "Certains destinataires n'ont pas reçu ce message !",
   "Spam": "Pourriel",

--- a/src/frontend/src/features/layouts/components/admin/admin-layout.tsx
+++ b/src/frontend/src/features/layouts/components/admin/admin-layout.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from "@/features/layouts/components/main/layout";
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link";
 import { Breadcrumbs } from "@/features/ui/components/breadcrumbs";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
@@ -81,7 +82,7 @@ function AdminLayoutContent({
   }
 
   return (
-    <div className="admin-page">
+    <div id={SKIP_LINK_TARGET_ID} className="admin-page">
       <div className="admin-page__header">
         <div className="admin-page__breadcrumbs">
           <Breadcrumbs items={breadcrumbItems} />

--- a/src/frontend/src/features/layouts/components/main/layout/_index.scss
+++ b/src/frontend/src/features/layouts/components/main/layout/_index.scss
@@ -1,5 +1,3 @@
-@use "../../../../../styles/utils" as *;
-
 .c__main-layout {
   display: flex;
   flex-direction: column;

--- a/src/frontend/src/features/layouts/components/main/layout/index.tsx
+++ b/src/frontend/src/features/layouts/components/main/layout/index.tsx
@@ -9,6 +9,7 @@ import {
 import { DropdownMenuOption, LeftPanel, useResponsive } from "@gouvfr-lasuite/ui-kit";
 import { useControllableState } from "../hooks/useControllableState";
 import { Toaster } from "@/features/ui/components/toaster";
+import { SkipLink } from "@/features/ui/components/skip-link";
 import clsx from "clsx";
 export type MainLayoutProps = {
   icon?: React.ReactNode;
@@ -138,6 +139,11 @@ export const AppLayout = ({
 
   return (
     <div className={clsx("c__main-layout", isResizing && "c__main-layout--resizing")}>
+      <SkipLink onClick={() => {
+        if (!isDesktop) {
+          setIsLeftPanelOpen(false);
+        }
+      }} />
       <div className="c__main-layout__header">
         <Header
           onTogglePanel={onTogglePanel}

--- a/src/frontend/src/features/layouts/components/main/no-mailbox.tsx
+++ b/src/frontend/src/features/layouts/components/main/no-mailbox.tsx
@@ -1,12 +1,13 @@
 import { Button } from "@gouvfr-lasuite/cunningham-react"
 import { logout } from "@/features/auth";
 import { useTranslation } from "react-i18next";
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link";
 import { Icon, IconSize, IconType } from "@gouvfr-lasuite/ui-kit";
 
 export const NoMailbox = () => {
     const { t } = useTranslation();
     return (
-        <div className="no-mailbox">
+        <div id={SKIP_LINK_TARGET_ID} className="no-mailbox">
             <div>
                 <Icon name="report" type={IconType.OUTLINED} size={IconSize.LARGE} aria-hidden="true" />
                 <p>{t('No mailbox.')}</p>

--- a/src/frontend/src/features/layouts/components/thread-panel/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-panel/index.tsx
@@ -1,4 +1,5 @@
 import { useMailboxContext } from "@/features/providers/mailbox";
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link";
 import { ThreadItem } from "./components/thread-item";
 import { Spinner } from "@gouvfr-lasuite/ui-kit";
 import { useTranslation } from "react-i18next";
@@ -92,7 +93,7 @@ export const ThreadPanel = () => {
     }
 
     return (
-        <div className="thread-panel" tabIndex={-1}>
+        <div id={!selectedThread ? SKIP_LINK_TARGET_ID : undefined} className="thread-panel" tabIndex={-1}>
             <ThreadPanelHeader
                 selectedThreadIds={selectedThreadIds}
                 isAllSelected={isAllSelected}

--- a/src/frontend/src/features/layouts/components/thread-view/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/index.tsx
@@ -8,6 +8,7 @@ import { useDebounceCallback } from "@/hooks/use-debounce-callback"
 import { Message, Thread } from "@/features/api/gen/models"
 import { Icon, IconType, Spinner } from "@gouvfr-lasuite/ui-kit"
 import { Banner } from "@/features/ui/components/banner"
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link"
 import { useTranslation } from "react-i18next"
 import { ThreadViewLabelsList } from "./components/thread-view-labels-list"
 import { ThreadSummary } from "./components/thread-summary";
@@ -118,7 +119,7 @@ const ThreadViewComponent = ({ messages, mailboxId, thread, showTrashedMessages,
     }, [thread.id]);
 
     return (
-        <div className={clsx("thread-view", { "thread-view--talk": isThreadSender })} ref={rootRef}>
+        <div id={SKIP_LINK_TARGET_ID} className={clsx("thread-view", { "thread-view--talk": isThreadSender })} ref={rootRef}>
             <div className="thread-view__sticky-container" ref={stickyContainerRef}>
                 <header className="thread-view__header">
                     <div className="thread-view__header__top">

--- a/src/frontend/src/features/ui/components/skip-link/_index.scss
+++ b/src/frontend/src/features/ui/components/skip-link/_index.scss
@@ -1,0 +1,21 @@
+@use "../../../../styles/utils" as *;
+
+.c__skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  margin: var(--c--globals--spacings--xs);
+  z-index: 1001;
+  padding: var(--c--globals--spacings--xs) var(--c--globals--spacings--sm);
+  background-color: var(--c--contextuals--background--surface--primary);
+  color: var(--c--contextuals--content--semantic--brand--primary);
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom-right-radius: 4px;
+
+  &:focus {
+    top: 0;
+    outline: 2px solid var(--c--contextuals--border--semantic--brand--primary);
+    outline-offset: -2px;
+  }
+}

--- a/src/frontend/src/features/ui/components/skip-link/index.tsx
+++ b/src/frontend/src/features/ui/components/skip-link/index.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from "react-i18next";
+
+// Use this id to flag an element as the main content of the view
+export const SKIP_LINK_TARGET_ID = "skip-link-target";
+
+type SkipLinkProps = {
+  onClick?: () => void;
+};
+
+/**
+ * An a11y component that act like a shorcut to go the main content
+ * of the view by skipping all other elements before.
+ */
+export const SkipLink = ({ onClick }: SkipLinkProps) => {
+  const { t } = useTranslation();
+  return (
+    <a href={`#${SKIP_LINK_TARGET_ID}`} className="c__skip-link" onClick={onClick}>
+      {t("Skip to main content")}
+    </a>
+  );
+};

--- a/src/frontend/src/pages/index.tsx
+++ b/src/frontend/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { MainLayout } from "@/features/layouts/components/main";
 import { LanguagePicker } from "@/features/layouts/components/main/language-picker";
 import { AppLayout } from "@/features/layouts/components/main/layout";
 import { LeftPanel } from "@/features/layouts/components/main/left-panel";
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link";
 import { FeedbackWidget } from "@/features/ui/components/feedback-widget";
 import { useTheme } from "@/features/providers/theme";
 
@@ -25,7 +26,7 @@ export default function HomePage() {
         rightHeaderContent={<LanguagePicker />}
         icon={<img src={`/images/${theme}/app-logo-${variant}.svg`} alt="logo" height={40} />}
       >
-      <div className="app__home">
+      <div id={SKIP_LINK_TARGET_ID} className="app__home">
         <HomeGutter>
           <Hero
             logo={<img src={`/images/${theme}/app-icon-${variant}.svg`} alt="Messages Logo" width={64} />}

--- a/src/frontend/src/pages/mailbox/[mailboxId]/integrations/index.tsx
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/integrations/index.tsx
@@ -6,6 +6,7 @@ import { useMailboxContext } from "@/features/providers/mailbox";
 import { IntegrationsPageContent } from "@/features/layouts/components/mailbox-settings/integrations-view/page-content";
 import { CreateIntegrationAction } from "@/features/layouts/components/mailbox-settings/integrations-view/create-integration-action";
 import { useFeatureFlag, FEATURE_KEYS } from "@/hooks/use-feature";
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link";
 
 const MailboxIntegrationsPage = () => {
     const { t } = useTranslation();
@@ -30,7 +31,7 @@ const MailboxIntegrationsPage = () => {
     }
 
     return (
-        <div className="admin-page">
+        <div className="admin-page" id={SKIP_LINK_TARGET_ID}>
             <div className="admin-page__header">
                 <h1 className="title">{t("Integrations")}</h1>
                 <div className="admin-page__actions">

--- a/src/frontend/src/pages/mailbox/[mailboxId]/message-templates/index.tsx
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/message-templates/index.tsx
@@ -6,6 +6,7 @@ import { useMailboxContext } from "@/features/providers/mailbox";
 import { ManageMessageTemplatesViewPageContent } from "@/features/layouts/components/mailbox-settings/message-templates-view/page-content";
 import { ComposeTemplateAction } from "@/features/layouts/components/mailbox-settings/message-templates-view/compose-template-action";
 import { Banner } from "@/features/ui/components/banner";
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link";
 
 const MailboxMessageTemplatesPage = () => {
     const { t } = useTranslation();
@@ -21,7 +22,7 @@ const MailboxMessageTemplatesPage = () => {
     if (!selectedMailbox) return null;
 
     return (
-        <div className="admin-page">
+        <div className="admin-page" id={SKIP_LINK_TARGET_ID}>
             <div className="admin-page__header">
                 <h1 className="title">{t("Message templates for {{mailbox}}", { mailbox: selectedMailbox.email })}</h1>
                 <div className="admin-page__actions">

--- a/src/frontend/src/pages/mailbox/[mailboxId]/new/index.tsx
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/new/index.tsx
@@ -5,6 +5,7 @@ import { MainLayout } from "@/features/layouts/components/main";
 import { MessageForm } from "@/features/forms/components/message-form";
 import { useMailboxContext } from "@/features/providers/mailbox";
 import { MAILBOX_FOLDERS } from "@/features/layouts/components/mailbox-panel/components/mailbox-list";
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link";
 
 const NewMessageFormPage = () => {
     const { t } = useTranslation();
@@ -35,7 +36,7 @@ const NewMessageFormPage = () => {
     }
 
     return (
-        <div className="new-message-form">
+        <div className="new-message-form" id={SKIP_LINK_TARGET_ID}>
             <div className="new-message-form-container">
                 <h1>{t("New message")}</h1>
                 <MessageForm

--- a/src/frontend/src/pages/mailbox/[mailboxId]/signatures/index.tsx
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/signatures/index.tsx
@@ -6,6 +6,7 @@ import { useMailboxContext } from "@/features/providers/mailbox";
 import { ManageSignaturesViewPageContent } from "@/features/layouts/components/mailbox-settings/signatures-view/page-content";
 import { ComposeSignatureAction } from "@/features/layouts/components/mailbox-settings/signatures-view/compose-signature-action";
 import { Banner } from "@/features/ui/components/banner";
+import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link";
 
 const MailboxSignaturesPage = () => {
     const { t } = useTranslation();
@@ -21,7 +22,7 @@ const MailboxSignaturesPage = () => {
     if (!selectedMailbox) return null;
 
     return (
-        <div className="admin-page">
+        <div className="admin-page" id={SKIP_LINK_TARGET_ID}>
             <div className="admin-page__header">
                 <h1 className="title">{t("Signatures for {{mailbox}}", { mailbox: selectedMailbox.email })}</h1>
                 <div className="admin-page__actions">

--- a/src/frontend/src/styles/main.scss
+++ b/src/frontend/src/styles/main.scss
@@ -15,6 +15,7 @@
 // Application Components
 @use "./../features/layouts/components/main";
 @use "./../features/ui/components/breadcrumbs";
+@use "./../features/ui/components/skip-link";
 @use "./../features/ui/components/toaster";
 @use "./../features/ui/components/badge";
 @use "./../features/ui/components/label-badge";


### PR DESCRIPTION
## Purpose

Keyboard and screen reader users need a way to bypass repetitive navigation elements (header, sidebar) to reach the main content directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard-accessible skip link enabling users to jump directly to main content across the application.
  * Added "Skip to main content" translations for English and French locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->