### PR TITLE
🐛(autoreply) do not mark thread as read when sending autoreply

### DIFF
--- a/src/backend/core/mda/autoreply.py
+++ b/src/backend/core/mda/autoreply.py
@@ -267,12 +267,9 @@ def send_autoreply_for_message(
     # 7. Trigger async send (outside transaction to avoid sending before commit)
     send_message_task.delay(str(message.id))
 
-    # 8. Update thread stats
-    models.ThreadAccess.objects.filter(
-        thread=thread,
-        mailbox=mailbox,
-    ).update(read_at=message.created_at)
-
+    # 8. Update thread stats — do NOT update read_at here: the autoreply
+    # sender is away, so the thread must stay unread for them to notice
+    # new messages when they return.
     thread.update_stats()
 
     logger.info(

--- a/src/backend/core/tests/mda/test_autoreply.py
+++ b/src/backend/core/tests/mda/test_autoreply.py
@@ -919,10 +919,14 @@ class TestSendAutoreplyForMessage:
         assert autoreply_msg.has_attachments is True
 
 
-    def test_updates_sender_read_at(
+    def test_does_not_update_sender_read_at(
         self, mailbox, autoreply_template, inbound_message
     ):
-        """Autoreply should update read_at so the thread does not appear unread."""
+        """Autoreply must NOT mark the thread as read for the sender.
+
+        The sender has autoreply enabled because they are away. The thread
+        should remain unread so they can see new messages when they return.
+        """
         access = models.ThreadAccess.objects.get(
             mailbox=mailbox, thread=inbound_message.thread
         )
@@ -931,8 +935,4 @@ class TestSendAutoreplyForMessage:
         send_autoreply_for_message(autoreply_template, mailbox, inbound_message)
 
         access.refresh_from_db()
-        autoreply_msg = models.Message.objects.filter(
-            parent=inbound_message, is_sender=True
-        ).last()
-        assert access.read_at is not None
-        assert access.read_at >= autoreply_msg.created_at
+        assert access.read_at is None


### PR DESCRIPTION
## Purpose

The autoreply sender is away — marking the thread as read prevents them from seeing new messages when they return.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-reply behavior to no longer mark threads as read when an auto-reply is sent, preserving inbox threads as unread for the sender.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->