### PR TITLE
⚡(search) use bulk API and prefetching for reindex_all

### DIFF
--- a/src/backend/core/management/commands/search_reindex.py
+++ b/src/backend/core/management/commands/search_reindex.py
@@ -8,6 +8,7 @@ from core import models
 from core.services.search import create_index_if_not_exists, delete_index
 from core.services.search.tasks import (
     _reindex_all_base,
+    _reindex_mailbox_base,
     reindex_all,
     reindex_mailbox_task,
     reindex_thread_task,
@@ -152,7 +153,15 @@ class Command(BaseCommand):
                 self.style.SUCCESS(f"Reindexing task scheduled (ID: {task.id})")
             )
         else:
-            result = reindex_mailbox_task(mailbox_id)  # pylint: disable=no-value-for-parameter
+
+            def update_progress(current, total, success_count, failure_count):
+                """Update progress in the console."""
+                self.stdout.write(
+                    f"Progress: {current}/{total} threads processed "
+                    f"({success_count} succeeded, {failure_count} failed)"
+                )
+
+            result = _reindex_mailbox_base(str(mailbox_uuid), update_progress)
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Reindexing completed: {result.get('success_count', 0)} succeeded, "

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1306,10 +1306,8 @@ class ThreadAccess(BaseModel):
 
     @staticmethod
     def unread_filter():
-        """Return a `Q` for filtering a `ThreadAccess` queryset to unread entries.
-
-        Used by `MailboxSerializer._get_cached_counts()` and
-        `compute_unread_mailboxes()` in the search index.
+        """
+        Return a `Q` for filtering a `ThreadAccess` queryset to unread entries.
         """
         return Q(read_at__isnull=True, thread__messaged_at__isnull=False) | Q(
             read_at__lt=F("thread__messaged_at")
@@ -1347,7 +1345,7 @@ class ThreadAccess(BaseModel):
     def starred_filter():
         """Return a `Q` for filtering a `ThreadAccess` queryset to starred entries.
 
-        Used by `compute_starred_mailboxes()` in the search index.
+        Used by `_compute_unread_starred_from_accesses()` in the search index.
         """
         return Q(starred_at__isnull=False)
 

--- a/src/backend/core/services/search/index.py
+++ b/src/backend/core/services/search/index.py
@@ -1,18 +1,23 @@
 """OpenSearch client and indexing functionality."""
+
 # pylint: disable=unexpected-keyword-arg
 
 import logging
 
 from django.conf import settings
+from django.db.models import Prefetch, prefetch_related_objects
 
 from opensearchpy import OpenSearch
 from opensearchpy.exceptions import NotFoundError
+from opensearchpy.helpers import bulk
 
 from core import enums, models
 from core.mda.rfc5322 import parse_email_message
 from core.services.search.mapping import MESSAGE_INDEX, MESSAGE_MAPPING
 
 logger = logging.getLogger(__name__)
+
+BULK_CHUNK_SIZE = 100
 
 
 # OpenSearch client instantiation
@@ -50,13 +55,19 @@ def delete_index():
         return False
 
 
-def index_message(message: models.Message) -> bool:
-    """Index a single message."""
-    es = get_opensearch_client()
+def _build_message_doc(message, mailbox_ids, recipients=None):
+    """Build an OpenSearch document dict for a message.
 
-    # Parse message content if it has a blob
+    Args:
+        message: Message instance (with sender already loaded).
+        mailbox_ids: list of string mailbox IDs.
+        recipients: pre-fetched recipients with contact loaded.
+            If None, they will be fetched from the database.
+
+    Returns:
+        dict or None if the message blob cannot be parsed.
+    """
     parsed_data = {}
-
     try:
         if message.blob:
             parsed_data = parse_email_message(message.blob.get_content())
@@ -65,34 +76,29 @@ def index_message(message: models.Message) -> bool:
     # pylint: disable=broad-exception-caught
     except Exception as e:
         logger.error("Error parsing blob content for message %s: %s", message.id, e)
-        return False
+        return None
 
-    # Extract text content from parsed data
+    if recipients is None:
+        recipients = list(message.recipients.select_related("contact").all())
+
     text_body = ""
     html_body = ""
 
     if parsed_data.get("textBody"):
         text_body = " ".join(
-            [item.get("content", "") for item in parsed_data.get("textBody", [])]
+            item.get("content", "") for item in parsed_data["textBody"]
         )
 
     if parsed_data.get("htmlBody"):
         html_body = " ".join(
-            [item.get("content", "") for item in parsed_data.get("htmlBody", [])]
+            item.get("content", "") for item in parsed_data["htmlBody"]
         )
 
-    # Get recipient details
-    recipients = message.recipients.select_related("contact").all()
-
-    # Get mailbox information for this thread
-    mailbox_ids = list(message.thread.accesses.values_list("mailbox__id", flat=True))
-
-    # Build document
-    doc = {
+    return {
         "relation": {"name": "message", "parent": str(message.thread_id)},
         "message_id": str(message.id),
         "thread_id": str(message.thread_id),
-        "mailbox_ids": [str(mailbox_id) for mailbox_id in mailbox_ids],
+        "mailbox_ids": mailbox_ids,
         "mime_id": message.mime_id,
         "created_at": message.created_at.isoformat() if message.created_at else None,
         "sent_at": message.sent_at.isoformat() if message.sent_at else None,
@@ -138,6 +144,59 @@ def index_message(message: models.Message) -> bool:
         "is_sender": message.is_sender,
     }
 
+
+def _build_thread_doc(thread, mailbox_ids, unread_mailbox_ids, starred_mailbox_ids):
+    """Build an OpenSearch document dict for a thread."""
+    return {
+        "relation": "thread",
+        "thread_id": str(thread.id),
+        "subject": thread.subject,
+        "mailbox_ids": mailbox_ids,
+        "unread_mailboxes": unread_mailbox_ids,
+        "starred_mailboxes": starred_mailbox_ids,
+    }
+
+
+def _compute_unread_starred_from_accesses(thread):
+    """Compute unread and starred mailbox IDs from prefetched accesses.
+
+    Reproduces the logic of `ThreadAccess.unread_filter()` and
+    `ThreadAccess.starred_filter()` in Python, avoiding additional DB
+    queries when accesses are already prefetched.
+    """
+    unread_ids = []
+    starred_ids = []
+    messaged_at = thread.messaged_at
+
+    for access in thread.accesses.all():
+        # Reproduces: Q(read_at__isnull=True, thread__messaged_at__isnull=False)
+        #           | Q(read_at__lt=F("thread__messaged_at"))
+        if messaged_at is not None and (
+            access.read_at is None or access.read_at < messaged_at
+        ):
+            unread_ids.append(str(access.mailbox_id))
+
+        # Reproduces: Q(starred_at__isnull=False)
+        if access.starred_at is not None:
+            starred_ids.append(str(access.mailbox_id))
+
+    return unread_ids, starred_ids
+
+
+def index_message(message: models.Message, mailbox_ids=None) -> bool:
+    """Index a single message."""
+    es = get_opensearch_client()
+
+    if mailbox_ids is None:
+        mailbox_ids = [
+            str(mid)
+            for mid in message.thread.accesses.values_list("mailbox__id", flat=True)
+        ]
+
+    doc = _build_message_doc(message, mailbox_ids)
+    if doc is None:
+        return False
+
     try:
         # pylint: disable=no-value-for-parameter
         es.index(
@@ -154,52 +213,19 @@ def index_message(message: models.Message) -> bool:
         return False
 
 
-def compute_unread_mailboxes(thread: models.Thread) -> list:
-    """Return mailbox IDs for which the thread is unread.
-
-    Delegates to ``ThreadAccess.unread_filter()`` so that the definition of
-    "unread" stays consistent with ``ThreadViewSet`` and ``MailboxSerializer``.
-    """
-    return [
-        str(mid)
-        for mid in thread.accesses.filter(
-            models.ThreadAccess.unread_filter()
-        ).values_list("mailbox_id", flat=True)
-    ]
-
-
-def compute_starred_mailboxes(thread: models.Thread) -> list:
-    """Return mailbox IDs for which the thread is starred.
-
-    Delegates to ``ThreadAccess.starred_filter()`` so that the definition of
-    "starred" stays consistent with ``ThreadViewSet``.
-    """
-    return [
-        str(mid)
-        for mid in thread.accesses.filter(
-            models.ThreadAccess.starred_filter()
-        ).values_list("mailbox_id", flat=True)
-    ]
-
-
 def update_thread_mailbox_flags(thread: models.Thread) -> bool:
     """Re-index the thread parent document to update mailbox-scoped flags.
 
-    Updates both ``unread_mailboxes`` and ``starred_mailboxes``.
+    Updates both `unread_mailboxes` and `starred_mailboxes`.
     Uses full document replacement (es.index) instead of partial update
     (es.update) because partial updates don't work reliably with join field
     documents in OpenSearch.
     """
     es = get_opensearch_client()
-    mailbox_ids = list(thread.accesses.values_list("mailbox__id", flat=True))
-    thread_doc = {
-        "relation": "thread",
-        "thread_id": str(thread.id),
-        "subject": thread.subject,
-        "mailbox_ids": [str(mid) for mid in mailbox_ids],
-        "unread_mailboxes": compute_unread_mailboxes(thread),
-        "starred_mailboxes": compute_starred_mailboxes(thread),
-    }
+    prefetch_related_objects([thread], "accesses")
+    mailbox_ids = [str(access.mailbox_id) for access in thread.accesses.all()]
+    unread_ids, starred_ids = _compute_unread_starred_from_accesses(thread)
+    thread_doc = _build_thread_doc(thread, mailbox_ids, unread_ids, starred_ids)
     try:
         # pylint: disable=no-value-for-parameter
         es.index(index=MESSAGE_INDEX, id=str(thread.id), body=thread_doc)
@@ -214,18 +240,13 @@ def index_thread(thread: models.Thread) -> bool:
     """Index a thread and all its messages."""
     es = get_opensearch_client()
 
-    # Get mailbox IDs that have access to this thread
-    mailbox_ids = list(thread.accesses.values_list("mailbox__id", flat=True))
+    # Prefetch accesses once for mailbox IDs and unread/starred computation
+    prefetch_related_objects([thread], "accesses")
+    mailbox_ids = [str(access.mailbox_id) for access in thread.accesses.all()]
+    unread_ids, starred_ids = _compute_unread_starred_from_accesses(thread)
 
     # First, index the thread document
-    thread_doc = {
-        "relation": "thread",
-        "thread_id": str(thread.id),
-        "subject": thread.subject,
-        "mailbox_ids": [str(mailbox_id) for mailbox_id in mailbox_ids],
-        "unread_mailboxes": compute_unread_mailboxes(thread),
-        "starred_mailboxes": compute_starred_mailboxes(thread),
-    }
+    thread_doc = _build_thread_doc(thread, mailbox_ids, unread_ids, starred_ids)
 
     try:
         # Index thread as parent document
@@ -233,10 +254,9 @@ def index_thread(thread: models.Thread) -> bool:
         es.index(index=MESSAGE_INDEX, id=str(thread.id), body=thread_doc)
 
         # Index all messages in the thread
-        messages = thread.messages.all()
         success = True
-        for message in messages:
-            if not index_message(message):
+        for message in thread.messages.all():
+            if not index_message(message, mailbox_ids=mailbox_ids):
                 success = False
 
         return success
@@ -246,60 +266,134 @@ def index_thread(thread: models.Thread) -> bool:
         return False
 
 
-def reindex_all():
-    """Reindex all messages and threads."""
+def _bulk_reindex_threads(threads_qs, progress_callback=None):
+    """Reindex a queryset of threads using the bulk API for performance.
 
-    # Delete and recreate the index
-    delete_index()
+    Uses chunked prefetching and ``opensearchpy.helpers.bulk`` to minimize
+    both DB queries and HTTP calls to OpenSearch.
+
+    Args:
+        threads_qs: A ``Thread`` queryset (unordered is fine).
+        progress_callback: optional callable(current, total, success_count,
+            failure_count) called after each chunk.
+
+    Returns:
+        dict with ``total``, ``indexed_threads``, ``indexed_messages`` and
+        ``failure_count``.
+    """
+    es = get_opensearch_client()
+
     create_index_if_not_exists()
 
-    # Count indexed items
     indexed_threads = 0
     indexed_messages = 0
+    failure_count = 0
+    total = threads_qs.count()
 
-    # Index all threads
-    for thread in models.Thread.objects.all():
-        if index_thread(thread):
-            indexed_threads += 1
-            indexed_messages += thread.messages.count()
+    # Prefetch the full tree needed to build index documents without N+1:
+    # - accesses: to compute mailbox_ids, unread and starred flags
+    # - messages → sender: for sender name/email
+    # - messages → recipients → contact: for to/cc/bcc name/email
+    threads_qs = threads_qs.prefetch_related(
+        "accesses",
+        Prefetch(
+            "messages",
+            queryset=models.Message.objects.select_related("sender").prefetch_related(
+                Prefetch(
+                    "recipients",
+                    queryset=models.MessageRecipient.objects.select_related("contact"),
+                )
+            ),
+        ),
+    )
+
+    actions = []
+
+    for thread in threads_qs.iterator(chunk_size=BULK_CHUNK_SIZE):
+        mailbox_ids = [str(access.mailbox_id) for access in thread.accesses.all()]
+        unread_ids, starred_ids = _compute_unread_starred_from_accesses(thread)
+
+        # Thread action
+        thread_doc = _build_thread_doc(thread, mailbox_ids, unread_ids, starred_ids)
+        actions.append(
+            {
+                "_index": MESSAGE_INDEX,
+                "_id": str(thread.id),
+                "_source": thread_doc,
+            }
+        )
+
+        # Message actions
+        for message in thread.messages.all():
+            recipients = list(message.recipients.all())
+            doc = _build_message_doc(message, mailbox_ids, recipients=recipients)
+            if doc is not None:
+                actions.append(
+                    {
+                        "_index": MESSAGE_INDEX,
+                        "_id": str(message.id),
+                        "_routing": str(thread.id),
+                        "_source": doc,
+                    }
+                )
+                indexed_messages += 1
+
+        indexed_threads += 1
+
+        if len(actions) >= BULK_CHUNK_SIZE:
+            _, errors = bulk(es, actions, raise_on_error=False)
+            if errors:
+                failure_count += len(errors)
+                for error in errors:  # pylint: disable=not-an-iterable
+                    logger.error("Bulk indexing error: %s", error)
+            actions = []
+
+        if progress_callback and indexed_threads % BULK_CHUNK_SIZE == 0:
+            progress_callback(indexed_threads, total, indexed_threads, failure_count)
+
+    # Flush remaining actions
+    if actions:
+        _, errors = bulk(es, actions, raise_on_error=False)
+        if errors:
+            failure_count += len(errors)
+            for error in errors:  # pylint: disable=not-an-iterable
+                logger.error("Bulk indexing error: %s", error)
 
     return {
         "status": "success",
+        "total": total,
         "indexed_threads": indexed_threads,
         "indexed_messages": indexed_messages,
+        "failure_count": failure_count,
     }
 
 
-def reindex_mailbox(mailbox_id: str):
-    """Reindex all messages and threads for a specific mailbox."""
+def reindex_all(progress_callback=None):
+    """Reindex all threads using the bulk API for performance.
 
-    # Count indexed items
-    indexed_threads = 0
-    indexed_messages = 0
+    Args:
+        progress_callback: optional callable(current, total, success_count,
+            failure_count) called after each chunk.
+    """
+    return _bulk_reindex_threads(models.Thread.objects.all(), progress_callback)
 
+
+def reindex_mailbox(mailbox_id: str, progress_callback=None):
+    """Reindex all messages and threads for a specific mailbox.
+
+    Args:
+        mailbox_id: The mailbox UUID as a string.
+        progress_callback: optional callable(current, total, success_count,
+            failure_count) called after each chunk.
+    """
     try:
-        # Get the mailbox
         mailbox = models.Mailbox.objects.get(id=mailbox_id)
-
-        # Index all threads the mailbox has access to
-        for thread in mailbox.threads_viewer:
-            if index_thread(thread):
-                indexed_threads += 1
-                indexed_messages += thread.messages.count()
-
-        return {
-            "status": "success",
-            "mailbox": mailbox_id,
-            "indexed_threads": indexed_threads,
-            "indexed_messages": indexed_messages,
-        }
     except models.Mailbox.DoesNotExist:
         return {"status": "error", "mailbox": mailbox_id, "error": "Mailbox not found"}
 
-    # pylint: disable=broad-exception-caught
-    except Exception as e:
-        logger.error("Error reindexing mailbox %s: %s", mailbox_id, e)
-        return {"status": "error", "mailbox": mailbox_id, "error": str(e)}
+    result = _bulk_reindex_threads(mailbox.threads_viewer, progress_callback)
+    result["mailbox"] = mailbox_id
+    return result
 
 
 def reindex_thread(thread_id: str):

--- a/src/backend/core/services/search/tasks.py
+++ b/src/backend/core/services/search/tasks.py
@@ -14,6 +14,12 @@ from core.services.search import (
     index_thread,
     update_thread_mailbox_flags,
 )
+from core.services.search import (
+    reindex_all as _reindex_all_impl,
+)
+from core.services.search import (
+    reindex_mailbox as _reindex_mailbox_impl,
+)
 
 from messages.celery_app import app as celery_app
 
@@ -23,6 +29,9 @@ logger = get_task_logger(__name__)
 def _reindex_all_base(update_progress=None):
     """Base function for reindexing all threads and messages.
 
+    Delegates to the bulk ``reindex_all`` implementation in the search index
+    module.
+
     Args:
         update_progress: Optional callback function to update progress
     """
@@ -30,35 +39,13 @@ def _reindex_all_base(update_progress=None):
         logger.info("OpenSearch thread indexing is disabled.")
         return {"success": False, "reason": "disabled"}
 
-    # Ensure index exists first
-    create_index_if_not_exists()
-
-    # Get all threads and index them
-    threads = models.Thread.objects.all()
-    total = threads.count()
-    success_count = 0
-    failure_count = 0
-
-    for i, thread in enumerate(threads):
-        try:
-            if index_thread(thread):
-                success_count += 1
-            else:
-                failure_count += 1
-        # pylint: disable=broad-exception-caught
-        except Exception as e:
-            failure_count += 1
-            logger.exception("Error indexing thread %s: %s", thread.id, e)
-
-        # Update progress if callback provided
-        if update_progress and i % 100 == 0:
-            update_progress(i, total, success_count, failure_count)
+    result = _reindex_all_impl(progress_callback=update_progress)
 
     return {
         "success": True,
-        "total": total,
-        "success_count": success_count,
-        "failure_count": failure_count,
+        "total": result["total"],
+        "success_count": result["indexed_threads"],
+        "failure_count": result["failure_count"],
     }
 
 
@@ -136,52 +123,51 @@ def update_threads_mailbox_flags_task(self, thread_ids):
     return {"success": True, "results": results}
 
 
-@celery_app.task(bind=True)
-def reindex_mailbox_task(self, mailbox_id):
-    """Reindex all threads and messages in a specific mailbox."""
+def _reindex_mailbox_base(mailbox_id, update_progress=None):
+    """Base function for reindexing all threads in a mailbox.
+
+    Delegates to the bulk ``reindex_mailbox`` implementation in the search
+    index module.
+
+    Args:
+        mailbox_id: The mailbox ID to reindex.
+        update_progress: Optional callback function to update progress.
+    """
     if not settings.OPENSEARCH_INDEX_THREADS:
         logger.info("OpenSearch thread indexing is disabled.")
         return {"success": False, "reason": "disabled"}
 
-    # Ensure index exists first
-    create_index_if_not_exists()
+    result = _reindex_mailbox_impl(mailbox_id, progress_callback=update_progress)
 
-    # Get all threads in the mailbox
-    threads = models.Mailbox.objects.get(id=mailbox_id).threads_viewer
-    total = threads.count()
-    success_count = 0
-    failure_count = 0
-
-    for i, thread in enumerate(threads):
-        try:
-            if index_thread(thread):
-                success_count += 1
-            else:
-                failure_count += 1
-        # pylint: disable=broad-exception-caught
-        except Exception as e:
-            failure_count += 1
-            logger.exception("Error indexing thread %s: %s", thread.id, e)
-
-        # Update progress every 50 threads
-        if i % 50 == 0:
-            self.update_state(
-                state="PROGRESS",
-                meta={
-                    "current": i,
-                    "total": total,
-                    "success_count": success_count,
-                    "failure_count": failure_count,
-                },
-            )
+    if result.get("status") == "error":
+        return {"success": False, **result}
 
     return {
         "mailbox_id": str(mailbox_id),
         "success": True,
-        "total": total,
-        "success_count": success_count,
-        "failure_count": failure_count,
+        "total": result["total"],
+        "success_count": result["indexed_threads"],
+        "failure_count": result["failure_count"],
     }
+
+
+@celery_app.task(bind=True)
+def reindex_mailbox_task(self, mailbox_id):
+    """Celery task wrapper for reindexing all threads in a mailbox."""
+
+    def update_progress(current, total, success_count, failure_count):
+        """Update task progress."""
+        self.update_state(
+            state="PROGRESS",
+            meta={
+                "current": current,
+                "total": total,
+                "success_count": success_count,
+                "failure_count": failure_count,
+            },
+        )
+
+    return _reindex_mailbox_base(mailbox_id, update_progress)
 
 
 @celery_app.task(bind=True)

--- a/src/backend/core/tests/search/test_search.py
+++ b/src/backend/core/tests/search/test_search.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 import pytest
 
 from core.factories import (
+    BlobFactory,
     MailboxFactory,
     MessageFactory,
     ThreadAccessFactory,
@@ -23,7 +24,11 @@ from core.services.search import (
     search_threads,
     update_thread_mailbox_flags,
 )
-from core.services.search.index import compute_unread_mailboxes
+from core.services.search.index import (
+    _build_message_doc,
+    _build_thread_doc,
+    _compute_unread_starred_from_accesses,
+)
 
 
 @pytest.fixture(name="mock_es_client_search")
@@ -139,14 +144,14 @@ def test_reindex_all(mock_es_client_index):
     # Reset mock
     mock_es_client_index.indices.exists.return_value = False
 
-    # Call the function
-    result = reindex_all()
+    with mock.patch("core.services.search.index.bulk", return_value=(0, [])):
+        # Call the function
+        result = reindex_all()
 
     # Verify result
     assert result["status"] == "success"
 
     # Verify ES client calls
-    mock_es_client_index.indices.delete.assert_called_once()
     mock_es_client_index.indices.create.assert_called_once()
 
 
@@ -154,14 +159,13 @@ def test_reindex_all(mock_es_client_index):
 def test_reindex_mailbox(mock_es_client_index, test_mailbox, test_thread):  # pylint: disable=unused-argument
     """Test reindexing a specific mailbox."""
 
-    # Call the function
-    result = reindex_mailbox(str(test_mailbox.id))
-
-    assert mock_es_client_index.index.call_count > 0
+    with mock.patch("core.services.search.index.bulk", return_value=(2, [])):
+        result = reindex_mailbox(str(test_mailbox.id))
 
     # Verify result
     assert result["status"] == "success"
     assert result["mailbox"] == str(test_mailbox.id)
+    assert result["indexed_threads"] == 1
 
 
 def test_search_threads_with_query(mock_es_client_search):
@@ -240,87 +244,6 @@ def test_search_threads_disabled(mock_es_client_search):
 
 
 @pytest.mark.django_db
-class TestComputeUnreadMailboxes:
-    """Tests for compute_unread_mailboxes."""
-
-    def test_thread_without_active_messages(self):
-        """A thread with no active messages should return an empty list."""
-        thread = ThreadFactory(has_active=False)
-        mailbox = MailboxFactory()
-        ThreadAccessFactory(thread=thread, mailbox=mailbox, read_at=None)
-        assert compute_unread_mailboxes(thread) == []
-
-    def test_read_at_null_is_unread(self):
-        """A ThreadAccess with read_at=None should be unread."""
-        thread = ThreadFactory()
-        mailbox = MailboxFactory()
-        MessageFactory(thread=thread)
-        thread.update_stats()
-        thread.refresh_from_db()
-        ThreadAccessFactory(thread=thread, mailbox=mailbox, read_at=None)
-
-        result = compute_unread_mailboxes(thread)
-        assert str(mailbox.id) in result
-
-    def test_read_at_before_active_messaged_at_is_unread(self):
-        """A ThreadAccess with read_at < active_messaged_at should be unread."""
-        thread = ThreadFactory()
-        mailbox = MailboxFactory()
-        MessageFactory(thread=thread)
-        thread.update_stats()
-        thread.refresh_from_db()
-        old_time = thread.active_messaged_at - timezone.timedelta(hours=1)
-        ThreadAccessFactory(thread=thread, mailbox=mailbox, read_at=old_time)
-
-        result = compute_unread_mailboxes(thread)
-        assert str(mailbox.id) in result
-
-    def test_read_at_after_active_messaged_at_is_read(self):
-        """A ThreadAccess with read_at >= active_messaged_at should be read."""
-        thread = ThreadFactory()
-        mailbox = MailboxFactory()
-        MessageFactory(thread=thread)
-        thread.update_stats()
-        thread.refresh_from_db()
-        ThreadAccessFactory(thread=thread, mailbox=mailbox, read_at=timezone.now())
-
-        result = compute_unread_mailboxes(thread)
-        assert str(mailbox.id) not in result
-
-    def test_sender_only_thread_is_unread_when_not_read(self):
-        """A thread with only sent messages is unread when read_at is not set.
-
-        In practice, inbound_create.py sets read_at when sending a message,
-        so sender-only threads are read. But the unread filter itself is
-        agnostic to message type: it only compares read_at vs messaged_at.
-        """
-        thread = ThreadFactory()
-        mailbox = MailboxFactory()
-        MessageFactory(thread=thread, is_sender=True)
-        thread.update_stats()
-        thread.refresh_from_db()
-        ThreadAccessFactory(thread=thread, mailbox=mailbox, read_at=None)
-
-        result = compute_unread_mailboxes(thread)
-        assert str(mailbox.id) in result
-
-    def test_multiple_mailboxes_mixed_status(self):
-        """Different mailboxes can have different read status."""
-        thread = ThreadFactory()
-        mb_read = MailboxFactory()
-        mb_unread = MailboxFactory()
-        MessageFactory(thread=thread)
-        thread.update_stats()
-        thread.refresh_from_db()
-        ThreadAccessFactory(thread=thread, mailbox=mb_read, read_at=timezone.now())
-        ThreadAccessFactory(thread=thread, mailbox=mb_unread, read_at=None)
-
-        result = compute_unread_mailboxes(thread)
-        assert str(mb_unread.id) in result
-        assert str(mb_read.id) not in result
-
-
-@pytest.mark.django_db
 def test_update_thread_mailbox_flags(mock_es_client_index):
     """Test that update_thread_mailbox_flags re-indexes the thread document."""
     thread = ThreadFactory()
@@ -341,3 +264,287 @@ def test_update_thread_mailbox_flags(mock_es_client_index):
     assert call_args["id"] == str(thread.id)
     assert str(mailbox.id) in call_args["body"]["unread_mailboxes"]
     assert "starred_mailboxes" in call_args["body"]
+
+
+@pytest.mark.django_db
+class TestSearchIndexBuildMessageDoc:
+    """Tests for _build_message_doc."""
+
+    def test_search_index_build_message_doc_with_correct_document(self):
+        """Test that _build_message_doc builds a correct document."""
+        thread = ThreadFactory()
+        mailbox = MailboxFactory()
+        ThreadAccessFactory(mailbox=mailbox, thread=thread)
+        message = MessageFactory(thread=thread)
+
+        mailbox_ids = [str(mailbox.id)]
+        doc = _build_message_doc(message, mailbox_ids)
+
+        assert doc is not None
+        assert doc["message_id"] == str(message.id)
+        assert doc["thread_id"] == str(thread.id)
+        assert doc["mailbox_ids"] == mailbox_ids
+        assert doc["relation"] == {"name": "message", "parent": str(thread.id)}
+        assert doc["subject"] == message.subject
+        assert doc["sender_name"] == message.sender.name
+        assert doc["sender_email"] == message.sender.email
+
+    def test_search_index_build_message_doc_with_prefetched_recipients(self):
+        """Test that pre-fetched recipients are used without extra queries."""
+        thread = ThreadFactory()
+        message = MessageFactory(thread=thread)
+        recipients = list(message.recipients.select_related("contact").all())
+
+        doc = _build_message_doc(message, ["mb-1"], recipients=recipients)
+
+        assert doc is not None
+        assert doc["mailbox_ids"] == ["mb-1"]
+
+    def test_search_index_build_message_doc_returns_none_on_parse_error(self):
+        """Test that _build_message_doc returns None on blob parse error."""
+        thread = ThreadFactory()
+        message = MessageFactory(thread=thread)
+        message.blob = BlobFactory()
+        message.save()
+
+        with mock.patch(
+            "core.services.search.index.parse_email_message",
+            side_effect=RuntimeError("parse error"),
+        ):
+            doc = _build_message_doc(message, ["mb-1"])
+
+        assert doc is None
+
+
+@pytest.mark.django_db
+class TestBuildThreadDoc:
+    """Tests for _build_thread_doc."""
+
+    def test_search_index_build_thread_doc_with_correct_document(self):
+        """Test that _build_thread_doc builds a correct document."""
+        thread = ThreadFactory()
+        mailbox_ids = ["mb-1", "mb-2"]
+        unread = ["mb-1"]
+        starred = ["mb-2"]
+
+        doc = _build_thread_doc(thread, mailbox_ids, unread, starred)
+
+        assert doc["relation"] == "thread"
+        assert doc["thread_id"] == str(thread.id)
+        assert doc["subject"] == thread.subject
+        assert doc["mailbox_ids"] == mailbox_ids
+        assert doc["unread_mailboxes"] == unread
+        assert doc["starred_mailboxes"] == starred
+
+
+@pytest.mark.django_db
+class TestSearchIndexComputeUnreadStarredFromAccesses:
+    """Tests for _compute_unread_starred_from_accesses."""
+
+    def test_search_index_compute_unread_starred_from_accesses_unread_when_read_at_none(
+        self,
+    ):
+        """An access with read_at=None on a thread with messages is unread."""
+        thread = ThreadFactory()
+        mailbox = MailboxFactory()
+        MessageFactory(thread=thread)
+        thread.update_stats()
+        thread.refresh_from_db()
+        ThreadAccessFactory(thread=thread, mailbox=mailbox, read_at=None)
+
+        unread, starred = _compute_unread_starred_from_accesses(thread)
+        assert str(mailbox.id) in unread
+        assert not starred
+
+    def test_search_index_compute_unread_starred_from_accesses_starred_when_starred_at_set(
+        self,
+    ):
+        """An access with starred_at set is starred."""
+        thread = ThreadFactory(has_active=False)
+        mailbox = MailboxFactory()
+        ThreadAccessFactory(thread=thread, mailbox=mailbox, starred_at=timezone.now())
+
+        _unread, starred = _compute_unread_starred_from_accesses(thread)
+        assert str(mailbox.id) in starred
+
+    def test_search_index_compute_unread_starred_from_accesses_read_thread_is_not_unread(
+        self,
+    ):
+        """An access with read_at after messaged_at is not unread."""
+        thread = ThreadFactory()
+        mailbox = MailboxFactory()
+        MessageFactory(thread=thread)
+        thread.update_stats()
+        thread.refresh_from_db()
+        ThreadAccessFactory(thread=thread, mailbox=mailbox, read_at=timezone.now())
+
+        unread, starred = _compute_unread_starred_from_accesses(thread)
+        assert str(mailbox.id) not in unread
+        assert not starred
+
+    def test_search_index_compute_unread_starred_from_accesses_thread_without_messages_is_not_unread(
+        self,
+    ):
+        """A thread with no messages (messaged_at is None) is not unread."""
+        thread = ThreadFactory(has_active=False)
+        mailbox = MailboxFactory()
+        ThreadAccessFactory(thread=thread, mailbox=mailbox, read_at=None)
+
+        unread, _starred = _compute_unread_starred_from_accesses(thread)
+        assert not unread
+
+    def test_search_index_compute_unread_starred_from_accesses_multiple_mailboxes_mixed_status(
+        self,
+    ):
+        """Different mailboxes can have different unread/starred status."""
+        thread = ThreadFactory()
+        mb_read = MailboxFactory()
+        mb_unread = MailboxFactory()
+        mb_starred = MailboxFactory()
+        MessageFactory(thread=thread)
+        thread.update_stats()
+        thread.refresh_from_db()
+        ThreadAccessFactory(thread=thread, mailbox=mb_read, read_at=timezone.now())
+        ThreadAccessFactory(thread=thread, mailbox=mb_unread, read_at=None)
+        ThreadAccessFactory(
+            thread=thread,
+            mailbox=mb_starred,
+            starred_at=timezone.now(),
+            read_at=timezone.now(),
+        )
+
+        unread, starred = _compute_unread_starred_from_accesses(thread)
+        assert str(mb_unread.id) in unread
+        assert str(mb_read.id) not in unread
+        assert str(mb_starred.id) in starred
+
+
+@pytest.mark.django_db
+class TestSearchReindexAllBulk:
+    """Tests for the bulk reindex_all implementation."""
+
+    def test_search_reindex_all_uses_bulk_api(self, mock_es_client_index):
+        """Test that reindex_all uses opensearchpy.helpers.bulk."""
+        thread = ThreadFactory()
+        mailbox = MailboxFactory()
+        ThreadAccessFactory(mailbox=mailbox, thread=thread)
+        MessageFactory(thread=thread)
+
+        mock_es_client_index.indices.exists.return_value = False
+
+        with mock.patch("core.services.search.index.bulk") as mock_bulk:
+            mock_bulk.return_value = (2, [])
+            result = reindex_all()
+
+        assert result["status"] == "success"
+        assert result["indexed_threads"] == 1
+        assert result["indexed_messages"] == 1
+
+        mock_bulk.assert_called_once()
+        _, kwargs = mock_bulk.call_args
+        actions = mock_bulk.call_args[0][1]
+        assert len(actions) == 2  # 1 thread doc + 1 message doc
+        assert kwargs["raise_on_error"] is False
+
+    def test_search_reindex_all_progress_callback(self, mock_es_client_index):
+        """Test that the progress callback is called."""
+        thread = ThreadFactory()
+        mailbox = MailboxFactory()
+        ThreadAccessFactory(mailbox=mailbox, thread=thread)
+        MessageFactory(thread=thread)
+
+        mock_es_client_index.indices.exists.return_value = False
+        progress_calls = []
+
+        def on_progress(current, total, success_count, failure_count):
+            progress_calls.append((current, total, success_count, failure_count))
+
+        with (
+            mock.patch("core.services.search.index.BULK_CHUNK_SIZE", 1),
+            mock.patch("core.services.search.index.bulk", return_value=(2, [])),
+        ):
+            reindex_all(progress_callback=on_progress)
+
+        assert len(progress_calls) >= 1
+        last_call = progress_calls[-1]
+        assert last_call[0] == 1  # current
+        assert last_call[1] == 1  # total
+
+    def test_search_reindex_all_bulk_errors_are_counted_during_chunk_flush(
+        self, mock_es_client_index
+    ):
+        """Test that bulk errors during chunk flush are tracked in failure_count."""
+        thread = ThreadFactory()
+        mailbox = MailboxFactory()
+        ThreadAccessFactory(mailbox=mailbox, thread=thread)
+        MessageFactory(thread=thread)
+
+        mock_es_client_index.indices.exists.return_value = False
+        progress_calls = []
+
+        def on_progress(current, total, success_count, failure_count):
+            progress_calls.append((current, total, success_count, failure_count))
+
+        bulk_errors = [
+            {
+                "index": {
+                    "_id": "fake-id",
+                    "error": {
+                        "type": "mapper_parsing_exception",
+                        "reason": "failed to parse",
+                    },
+                    "status": 400,
+                }
+            },
+        ]
+
+        # Use BULK_CHUNK_SIZE=1 to trigger the mid-loop flush path
+        with (
+            mock.patch("core.services.search.index.BULK_CHUNK_SIZE", 1),
+            mock.patch(
+                "core.services.search.index.bulk", return_value=(1, bulk_errors)
+            ),
+        ):
+            result = reindex_all(progress_callback=on_progress)
+
+        assert result["status"] == "success"
+        assert result["indexed_threads"] == 1
+        assert result["indexed_messages"] == 1
+
+        # failure_count is reported via the progress callback
+        assert len(progress_calls) == 1
+        assert progress_calls[0][3] == 1  # failure_count
+
+    def test_bulk_errors_during_final_flush_are_logged(self, mock_es_client_index):
+        """Test that bulk errors during the final flush are logged."""
+        thread = ThreadFactory()
+        mailbox = MailboxFactory()
+        ThreadAccessFactory(mailbox=mailbox, thread=thread)
+        MessageFactory(thread=thread)
+
+        mock_es_client_index.indices.exists.return_value = False
+
+        bulk_errors = [
+            {
+                "index": {
+                    "_id": "fake-id",
+                    "error": {
+                        "type": "mapper_parsing_exception",
+                        "reason": "failed to parse",
+                    },
+                    "status": 400,
+                }
+            },
+        ]
+
+        # Default BULK_CHUNK_SIZE (100) > 2 actions, so all go to final flush
+        with (
+            mock.patch(
+                "core.services.search.index.bulk", return_value=(1, bulk_errors)
+            ),
+            mock.patch("core.services.search.index.logger") as mock_logger,
+        ):
+            result = reindex_all()
+
+        assert result["status"] == "success"
+        mock_logger.error.assert_called_with("Bulk indexing error: %s", bulk_errors[0])


### PR DESCRIPTION
## Purpose

The previous implementation indexed each thread and message with individual OpenSearch HTTP calls and triggered N+1 DB queries for accesses, recipients and sender lookups. This rewrites reindex_all to batch documents via opensearchpy.helpers.bulk and prefetch related objects in a single queryset, drastically reducing both DB round-trips and HTTP overhead.

Also fix the sync mailbox reindex command that currently raised an IntegrityError.

|`python manage.py search_reindex --all` (18626 msgs)|
|--------------------------------------|
| Before : 4min04s (76 msgs/s)| 
| After : 1min52s (166 msgs/s) +218% |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Search indexing now uses bulk operations and improved prefetching for faster, more efficient reindexing.
* **New Features**
  * Added ability to reindex a specific mailbox and show progress during reindexing.
* **Bug Fixes**
  * More robust handling of unread/starred thread status and safer parsing during indexing to prevent crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->