### PR TITLE
✨(frontend) add lprobe healthchecks and checksum verification for lprobe + caddy

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -79,5 +79,7 @@ ENV DJANGO_ADMIN_URL=admin
 
 ENTRYPOINT ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
 
+# Port is hardcoded below because distroless has no shell to expand $PORT.
+# If you change ENV PORT above, update the healthcheck port to match.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s \
   CMD ["/usr/bin/lprobe", "-mode=http", "-port=8080", "-endpoint=/__lbheartbeat__"]


### PR DESCRIPTION
## Purpose
Having a distroless leaves no easy way to check health of the frontend container. 

## Proposal
Add [lprobe ](https://github.com/fivexl/lprobe?tab=readme-ov-file#add-to-a-container-image-from-lprobe-containter) to the final container image and the HEALTCHECK back to the container.

We are verifying binary sha256 against an hardcoded  checksum generated by commented command in the Dockerfile. This is to protect the application from a supply-chain attack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Added a lightweight runtime probe and configured container health checks to monitor the service endpoint at regular intervals
  * Enforced SHA-256 checksum verification for downloaded runtime tools
  * Strengthened multi-architecture build validation; unsupported architectures now fail early in the build process
  * Ensured required runtime tools are present in the final image for health monitoring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->