### PR TITLE
✨(dns) add recursive SPF check and optional send-time validation

### DIFF
--- a/src/backend/.pylintrc
+++ b/src/backend/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=pypff
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=migrations
+ignore=migrations,.venv
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/src/backend/core/api/viewsets/maildomain.py
+++ b/src/backend/core/api/viewsets/maildomain.py
@@ -31,7 +31,7 @@ from core.api import serializers as core_serializers
 from core.api.viewsets.message_template import BODIES_PARAMETER
 from core.api.viewsets.mixins import MessageTemplateResponseMixin
 from core.enums import MessageTemplateTypeChoices
-from core.services.dns.check import check_dns_records
+from core.services.dns.check import check_dns_records, invalidate_spf_check_cache
 
 logger = getLogger(__name__)
 
@@ -130,8 +130,11 @@ class AdminMailDomainViewSet(
         """
         maildomain = get_object_or_404(models.MailDomain, pk=maildomain_pk)
 
-        # Perform DNS check
+        # Perform DNS check (always fresh, never cached)
         check_results = check_dns_records(maildomain)
+
+        # Invalidate outgoing SPF cache so send path picks up this fresh result
+        invalidate_spf_check_cache(maildomain)
 
         return Response(
             {

--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -546,6 +546,26 @@ def send_message(message: models.Message, force_mta_out: bool = False):
                     external_recipients.add(recipient_email)
 
             if external_recipients:
+                # Check SPF include chain if enabled (only for external recipients)
+                if settings.MESSAGES_SPF_CHECK_OUTGOING:
+                    from core.services.dns.check import (
+                        check_spf_status,  # pylint: disable=import-outside-toplevel
+                    )
+
+                    sender_domain = message.sender.mailbox.domain
+                    if not check_spf_status(sender_domain):
+                        error_msg = f"SPF check failed for domain {sender_domain.name}"
+                        logger.warning(
+                            "SPF check failed for message %s (domain: %s), marking recipients for retry",
+                            message.id,
+                            sender_domain.name,
+                        )
+                        for recipient_email in external_recipients:
+                            _mark_delivered(
+                                recipient_email, False, False, error_msg, True
+                            )
+                        return
+
                 # Verify DKIM signature if enabled (only for external recipients)
                 if settings.MESSAGES_DKIM_VERIFY_OUTGOING:
                     sender_domain = message.sender.mailbox.domain

--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -25,6 +25,7 @@ from core.mda.rfc5322 import (
 )
 from core.mda.signing import sign_message_dkim, verify_message_dkim
 from core.mda.smtp import send_smtp_mail
+from core.services.dns.check import check_spf_status
 from core.services.throttle import check_and_increment_throttle
 from core.utils import ThreadStatsUpdateDeferrer
 
@@ -548,10 +549,6 @@ def send_message(message: models.Message, force_mta_out: bool = False):
             if external_recipients:
                 # Check SPF include chain if enabled (only for external recipients)
                 if settings.MESSAGES_SPF_CHECK_OUTGOING:
-                    from core.services.dns.check import (
-                        check_spf_status,  # pylint: disable=import-outside-toplevel
-                    )
-
                     sender_domain = message.sender.mailbox.domain
                     if not check_spf_status(sender_domain):
                         error_msg = f"SPF check failed for domain {sender_domain.name}"

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -2,12 +2,22 @@
 DNS checking functionality for mail domains.
 """
 
+import collections
+import logging
 import re
 from typing import Dict, List, Optional, Tuple
+
+from django.conf import settings
+from django.core.cache import cache
 
 import dns.resolver
 
 from core.models import MailDomain
+
+logger = logging.getLogger(__name__)
+
+SPF_CHECK_CACHE_KEY_PREFIX = "dns:spf_check:"
+SPF_CHECK_CACHE_TIMEOUT = 600  # 10 minutes
 
 
 def normalize_txt_value(value: str) -> str:
@@ -82,14 +92,19 @@ def _check_dkim_semantic(
     return None
 
 
-def _check_spf_semantic(
-    expected_value: str, found_values: List[str]
-) -> Optional[Dict[str, any]]:
-    """Semantic comparison for SPF records (term order doesn't matter)."""
+def _check_spf(expected_value: str, found_values: List[str]) -> Dict[str, any]:
+    """Full SPF check: semantic comparison, recursive include verification.
+
+    1. Compares SPF terms ignoring order (RFC 7208).
+    2. If there are include: targets under the technical domain, verifies
+       they resolve to valid SPF records via BFS.
+    """
     expected_spf = parse_spf_terms(expected_value)
     if not expected_spf:
-        return None
+        return {"status": "incorrect", "found": found_values}
+
     expected_all, expected_terms = expected_spf
+    terms_match = False
     for found_value in found_values:
         found_spf = parse_spf_terms(found_value)
         if not found_spf:
@@ -97,11 +112,103 @@ def _check_spf_semantic(
         found_all, found_terms = found_spf
         if not expected_terms <= found_terms:
             continue
-        if expected_all == found_all:
-            return {"status": "correct", "found": found_values}
-        if expected_all == "-all" and found_all == "~all":
-            return {"status": "correct", "found": found_values}
-    return None
+        if expected_all == found_all or (
+            expected_all == "-all" and found_all == "~all"
+        ):
+            terms_match = True
+            break
+
+    # Verify include chain if there are technical domain includes
+    expected_includes = _extract_include_domains(expected_value)
+    technical_domain = settings.MESSAGES_TECHNICAL_DOMAIN
+    includes_ok = None  # None = no check needed
+    if expected_includes and technical_domain:
+        expected_technical = {
+            d for d in expected_includes if d.endswith(f".{technical_domain}")
+        }
+        if expected_technical:
+            resolved, error = _resolve_spf_includes(found_values)
+            if error and error.startswith("duplicate:"):
+                return {"status": "duplicate", "found": found_values}
+            if error == "limit_reached":
+                return {"status": "invalid", "found": found_values}
+            includes_ok = expected_technical <= resolved
+
+    if terms_match and includes_ok is not False:
+        return {"status": "correct", "found": found_values}
+    if includes_ok is True:
+        # Terms don't match our template but includes chain is valid
+        return {"status": "correct", "found": found_values}
+    if terms_match:
+        # Terms match but includes don't resolve
+        return {"status": "incomplete", "found": found_values}
+    return {"status": "incorrect", "found": found_values}
+
+
+def _extract_include_domains(spf_value: str) -> List[str]:
+    """Extract include: domains from an SPF value, preserving order."""
+    return [
+        term[len("include:") :]
+        for term in spf_value.split()
+        if term.startswith("include:")
+    ]
+
+
+def _resolve_spf_includes(
+    found_values: List[str], max_lookups: int = 10
+) -> Tuple[set, Optional[str]]:
+    """BFS through SPF include chains, return all domains with valid SPF records.
+
+    Seeds from include: domains in found_values, follows the chain via BFS.
+    Per RFC 7208, stops after max_lookups DNS lookups.
+
+    Returns:
+        (resolved_domains, error) where error is None on success, or a string
+        describing the issue ("limit_reached", "duplicate:domain.com").
+    """
+    queue = collections.deque()
+    for found_value in found_values:
+        if found_value.startswith("v=spf1"):
+            queue.extend(_extract_include_domains(found_value))
+
+    visited = set()
+    resolved = set()
+    lookup_count = 0
+
+    while queue:
+        if lookup_count >= max_lookups:
+            return resolved, "limit_reached"
+
+        include_domain = queue.popleft()
+        if include_domain in visited:
+            continue
+        visited.add(include_domain)
+        lookup_count += 1
+
+        try:
+            answers = dns.resolver.resolve(include_domain, "TXT")
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("DNS resolution failed for %s", include_domain)
+            continue
+
+        spf_records = []
+        for answer in answers:
+            txt_value = normalize_txt_value(answer.to_text())
+            if txt_value.startswith("v=spf1"):
+                spf_records.append(txt_value)
+
+        if len(spf_records) > 1:
+            return resolved, f"duplicate:{include_domain}"
+
+        if not spf_records:
+            continue
+
+        resolved.add(include_domain)
+        for child_domain in _extract_include_domains(spf_records[0]):
+            if child_domain not in visited:
+                queue.append(child_domain)
+
+    return resolved, None
 
 
 def _resolve_dns_values(record_type, target, query_name):
@@ -179,24 +286,18 @@ def check_single_record(
             if security_result:
                 return security_result
 
-        # Exact match
+        # SPF: always use semantic check (handles exact match, reordering,
+        # ~all acceptance, and recursive include verification)
+        if record_type.upper() == "TXT" and expected_value.startswith("v=spf1"):
+            return _check_spf(expected_value, found_values)
+
+        # Exact match (non-SPF)
         if expected_value in found_values:
             return {"status": "correct", "found": found_values}
 
-        # Accept ~all as correct when -all is expected for SPF records
-        if record_type.upper() == "TXT" and expected_value.endswith("-all"):
-            softfail_variant = expected_value[:-4] + "~all"
-            if softfail_variant in found_values:
-                return {"status": "correct", "found": found_values}
-
-        # Semantic fallback comparisons for DKIM and SPF
+        # Semantic fallback for DKIM
         if record_type.upper() == "TXT" and target.endswith("._domainkey"):
             result = _check_dkim_semantic(expected_value, found_values)
-            if result:
-                return result
-
-        if record_type.upper() == "TXT" and expected_value.startswith("v=spf1"):
-            result = _check_spf_semantic(expected_value, found_values)
             if result:
                 return result
 
@@ -214,6 +315,50 @@ def check_single_record(
         return {"status": "error", "error": "Domain name too long"}
     except Exception as e:  # pylint: disable=broad-exception-caught
         return {"status": "error", "error": f"DNS query failed: {str(e)}"}
+
+
+def _spf_check_cache_key(maildomain: MailDomain) -> str:
+    return f"{SPF_CHECK_CACHE_KEY_PREFIX}{maildomain.pk}"
+
+
+def check_spf_status(maildomain: MailDomain) -> bool:
+    """Check if the SPF include chain is correctly set up for a mail domain.
+
+    Results are cached for 10 minutes. Returns True if SPF is correct
+    (or if no SPF record is expected), False otherwise.
+    """
+    cache_key = _spf_check_cache_key(maildomain)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    result = _check_spf_status_uncached(maildomain)
+    cache.set(cache_key, result, SPF_CHECK_CACHE_TIMEOUT)
+    return result
+
+
+def _check_spf_status_uncached(maildomain: MailDomain) -> bool:
+    """Perform the actual SPF check (no cache)."""
+    expected_records = maildomain.get_expected_dns_records()
+    spf_records = [
+        r
+        for r in expected_records
+        if r["type"].upper() == "TXT" and r["value"].startswith("v=spf1")
+    ]
+    if not spf_records:
+        return True
+
+    for expected_record in spf_records:
+        result = check_single_record(maildomain, expected_record)
+        if result.get("status") != "correct":
+            return False
+
+    return True
+
+
+def invalidate_spf_check_cache(maildomain: MailDomain) -> None:
+    """Clear the cached SPF check result for a mail domain."""
+    cache.delete(_spf_check_cache_key(maildomain))
 
 
 def check_dns_records(maildomain: MailDomain) -> List[Dict[str, any]]:

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -7,7 +7,6 @@ import logging
 import re
 from typing import Dict, List, Optional, Tuple
 
-from django.conf import settings
 from django.core.cache import cache
 
 import dns.resolver
@@ -93,56 +92,60 @@ def _check_dkim_semantic(
 
 
 def _check_spf(expected_value: str, found_values: List[str]) -> Dict[str, any]:
-    """Full SPF check: semantic comparison, recursive include verification.
-
-    1. Compares SPF terms ignoring order (RFC 7208).
-    2. If there are include: targets under the technical domain, verifies
-       they resolve to valid SPF records via BFS.
-    """
-    expected_spf = parse_spf_terms(expected_value)
-    if not expected_spf:
+    """SPF check: verify expected includes resolve, fall back to terms comparison."""
+    expected = parse_spf_terms(expected_value)
+    if not expected:
         return {"status": "incorrect", "found": found_values}
 
-    expected_all, expected_terms = expected_spf
-    terms_match = False
+    expected_all, expected_terms = expected
+    expected_includes = set(_extract_include_domains(expected_value))
+
+    # Check there's at least one valid SPF record in found values
+    found_spf_values = [v for v in found_values if parse_spf_terms(v)]
+    if not found_spf_values:
+        return {"status": "missing", "found": found_values}
+
+    # If there are expected includes, check they resolve via BFS.
+    # This is the primary signal: includes being set up is what matters.
+    if expected_includes:
+        resolved, error = _resolve_spf_includes(found_values)
+        if error and error.startswith("duplicate:"):
+            return {"status": "duplicate", "found": found_values}
+        if error == "limit_reached":
+            return {"status": "incorrect", "found": found_values}
+        if not expected_includes <= resolved:
+            return {"status": "incorrect", "found": found_values}
+        # Includes resolve — check if "all" mechanism is acceptable
+        if _found_all_matches(expected_all, found_spf_values):
+            return {"status": "correct", "found": found_values}
+        return {"status": "insecure", "found": found_values}
+
+    # No includes: direct terms comparison (order-independent, ~all accepted for -all)
+    for found_value in found_spf_values:
+        found_all, found_terms = parse_spf_terms(found_value)
+        all_ok = expected_all == found_all or (
+            expected_all == "-all" and found_all == "~all"
+        )
+        if expected_terms <= found_terms:
+            if all_ok:
+                return {"status": "correct", "found": found_values}
+            return {"status": "insecure", "found": found_values}
+
+    return {"status": "incorrect", "found": found_values}
+
+
+def _found_all_matches(expected_all: str, found_values: List[str]) -> bool:
+    """Check if any found SPF record has an acceptable "all" mechanism."""
     for found_value in found_values:
-        found_spf = parse_spf_terms(found_value)
-        if not found_spf:
+        found = parse_spf_terms(found_value)
+        if not found:
             continue
-        found_all, found_terms = found_spf
-        if not expected_terms <= found_terms:
-            continue
+        found_all, _ = found
         if expected_all == found_all or (
             expected_all == "-all" and found_all == "~all"
         ):
-            terms_match = True
-            break
-
-    # Verify include chain if there are technical domain includes
-    expected_includes = _extract_include_domains(expected_value)
-    technical_domain = settings.MESSAGES_TECHNICAL_DOMAIN
-    includes_ok = None  # None = no check needed
-    if expected_includes and technical_domain:
-        expected_technical = {
-            d for d in expected_includes if d.endswith(f".{technical_domain}")
-        }
-        if expected_technical:
-            resolved, error = _resolve_spf_includes(found_values)
-            if error and error.startswith("duplicate:"):
-                return {"status": "duplicate", "found": found_values}
-            if error == "limit_reached":
-                return {"status": "invalid", "found": found_values}
-            includes_ok = expected_technical <= resolved
-
-    if terms_match and includes_ok is not False:
-        return {"status": "correct", "found": found_values}
-    if includes_ok is True:
-        # Terms don't literally match but the include chain resolves
-        return {"status": "correct", "found": found_values}
-    if terms_match:
-        # Terms match but includes don't resolve
-        return {"status": "incomplete", "found": found_values}
-    return {"status": "incorrect", "found": found_values}
+            return True
+    return False
 
 
 def _extract_include_domains(spf_value: str) -> List[str]:
@@ -187,16 +190,15 @@ def _resolve_spf_includes(
 
         try:
             answers = dns.resolver.resolve(include_domain, "TXT")
+            spf_records = []
+            for rr in answers.rrset:
+                for s in rr.strings:
+                    txt_value = normalize_txt_value(s.decode())
+                    if txt_value.startswith("v=spf1"):
+                        spf_records.append(txt_value)
         except Exception:  # pylint: disable=broad-exception-caught
             logger.debug("DNS resolution failed for %s", include_domain)
             continue
-
-        spf_records = []
-        for rr in answers.rrset:
-            for s in rr.strings:
-                txt_value = normalize_txt_value(s.decode())
-                if txt_value.startswith("v=spf1"):
-                    spf_records.append(txt_value)
 
         if len(spf_records) > 1:
             return resolved, f"duplicate:{include_domain}"
@@ -366,8 +368,9 @@ def _check_spf_status_uncached(maildomain: MailDomain) -> Tuple[bool, bool]:
 
     for expected_record in spf_records:
         result = check_single_record(maildomain, expected_record)
-        if result.get("status") != "correct":
-            is_transient = result.get("status") == "error"
+        status = result.get("status")
+        if status not in ("correct", "insecure"):
+            is_transient = status == "error"
             return False, not is_transient
 
     return True, True

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -137,7 +137,7 @@ def _check_spf(expected_value: str, found_values: List[str]) -> Dict[str, any]:
     if terms_match and includes_ok is not False:
         return {"status": "correct", "found": found_values}
     if includes_ok is True:
-        # Terms don't match our template but includes chain is valid
+        # Terms don't literally match but the include chain resolves
         return {"status": "correct", "found": found_values}
     if terms_match:
         # Terms match but includes don't resolve
@@ -192,10 +192,11 @@ def _resolve_spf_includes(
             continue
 
         spf_records = []
-        for answer in answers:
-            txt_value = normalize_txt_value(answer.to_text())
-            if txt_value.startswith("v=spf1"):
-                spf_records.append(txt_value)
+        for rr in answers.rrset:
+            for s in rr.strings:
+                txt_value = normalize_txt_value(s.decode())
+                if txt_value.startswith("v=spf1"):
+                    spf_records.append(txt_value)
 
         if len(spf_records) > 1:
             return resolved, f"duplicate:{include_domain}"
@@ -219,12 +220,21 @@ def _resolve_dns_values(record_type, target, query_name):
 
     if record_type.upper() == "TXT":
         answers = dns.resolver.resolve(query_name, "TXT")
-        if target.endswith("._domainkey"):
-            return [
-                normalize_txt_value(answer.to_text().strip('"').replace('" "', ""))
-                for answer in answers
-            ]
-        return [normalize_txt_value(answer.to_text()) for answer in answers]
+        # Some local resolvers (e.g. systemd-resolved) merge separate TXT
+        # records into a single RR with multiple strings. DKIM keys can also
+        # legitimately span multiple strings within one record. We handle
+        # both by emitting each individual string as a value, plus the
+        # concatenated form for DKIM.
+        values = []
+        for rr in answers.rrset:
+            if target.endswith("._domainkey"):
+                # DKIM: concatenate strings (long key split across strings)
+                values.append(normalize_txt_value(b"".join(rr.strings).decode()))
+            else:
+                # Other TXT: treat each string as a separate value
+                for s in rr.strings:
+                    values.append(normalize_txt_value(s.decode()))
+        return values
 
     answers = dns.resolver.resolve(query_name, record_type)
     return [answer.to_text() for answer in answers]
@@ -332,13 +342,19 @@ def check_spf_status(maildomain: MailDomain) -> bool:
     if cached is not None:
         return cached
 
-    result = _check_spf_status_uncached(maildomain)
-    cache.set(cache_key, result, SPF_CHECK_CACHE_TIMEOUT)
+    result, is_definitive = _check_spf_status_uncached(maildomain)
+    if is_definitive:
+        cache.set(cache_key, result, SPF_CHECK_CACHE_TIMEOUT)
     return result
 
 
-def _check_spf_status_uncached(maildomain: MailDomain) -> bool:
-    """Perform the actual SPF check (no cache)."""
+def _check_spf_status_uncached(maildomain: MailDomain) -> Tuple[bool, bool]:
+    """Perform the actual SPF check (no cache).
+
+    Returns:
+        (is_correct, is_definitive) where is_definitive is False when the
+        result was caused by a transient DNS error (timeout, no nameservers).
+    """
     expected_records = maildomain.get_expected_dns_records()
     spf_records = [
         r
@@ -346,14 +362,15 @@ def _check_spf_status_uncached(maildomain: MailDomain) -> bool:
         if r["type"].upper() == "TXT" and r["value"].startswith("v=spf1")
     ]
     if not spf_records:
-        return True
+        return True, True
 
     for expected_record in spf_records:
         result = check_single_record(maildomain, expected_record)
         if result.get("status") != "correct":
-            return False
+            is_transient = result.get("status") == "error"
+            return False, not is_transient
 
-    return True
+    return True, True
 
 
 def invalidate_spf_check_cache(maildomain: MailDomain) -> None:

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -6,6 +6,7 @@ Tests for DNS checking functionality.
 import json
 from unittest.mock import MagicMock, patch
 
+from django.core.cache import cache
 from django.test import override_settings
 
 import pytest
@@ -15,6 +16,8 @@ from core.models import MailDomain
 from core.services.dns.check import (
     check_dns_records,
     check_single_record,
+    check_spf_status,
+    invalidate_spf_check_cache,
     parse_dkim_tags,
     parse_spf_terms,
 )
@@ -1068,3 +1071,563 @@ def fixture_maildomain_factory():
         return MailDomain.objects.create(name=name)
 
     return _create_maildomain
+
+
+@pytest.mark.django_db
+class TestSPFRecursiveCheck:
+    """Test recursive SPF include checking."""
+
+    def test_spf_include_single_level_found(self, maildomain_factory, settings):
+        """Include target under technical_domain resolves to valid SPF."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_spf_main = MagicMock()
+            mock_spf_main.to_text.return_value = (
+                '"v=spf1 include:_spf.messages.org -all"'
+            )
+            mock_spf_include = MagicMock()
+            mock_spf_include.to_text.return_value = '"v=spf1 ip4:1.2.3.4 -all"'
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [mock_spf_main]
+                if name == "_spf.messages.org":
+                    return [mock_spf_include]
+                return []
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "correct"
+
+    def test_spf_include_not_found_on_incorrect_record(
+        self, maildomain_factory, settings
+    ):
+        """When the found SPF doesn't match, recursive check still runs."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_spf_main = MagicMock()
+            mock_spf_main.to_text.return_value = '"v=spf1 include:_spf.other.com -all"'
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [mock_spf_main]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incorrect"
+
+    def test_spf_no_include_no_recursive_check(self, maildomain_factory):
+        """SPF without include: terms gets no recursive check."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 ip4:1.2.3.4 -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_answer = MagicMock()
+            mock_answer.to_text.return_value = '"v=spf1 ip4:1.2.3.4 -all"'
+            mock_resolve.return_value = [mock_answer]
+
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "correct"
+            assert result["status"] == "correct"
+
+    def test_spf_real_recursion_two_levels(self, maildomain_factory, settings):
+        """BFS follows found chain to reach expected technical include 2 levels deep."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        # Expected: we want _spf2.messages.org to be reachable
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf2.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    # Found: includes _spf.messages.org (not _spf2 directly)
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                # Level 1: _spf.messages.org includes _spf2.messages.org
+                if name == "_spf.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf2.messages.org -all"'
+                            )
+                        )
+                    ]
+                # Level 2: _spf2.messages.org has actual IPs
+                if name == "_spf2.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
+                        )
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "correct"
+
+    def test_spf_bfs_breadth_first_ordering(self, maildomain_factory, settings):
+        """BFS processes siblings before children to reach nested target."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        # We expect child-a.messages.org — only reachable through a.messages.org
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:child-a.messages.org -all",
+        }
+        resolved_order = []
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:a.messages.org include:b.messages.org -all"'
+                            )
+                        )
+                    ]
+                resolved_order.append(name)
+                if name == "a.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:child-a.messages.org -all"'
+                            )
+                        )
+                    ]
+                if name == "b.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:2.3.4.5 -all"')
+                        )
+                    ]
+                if name == "child-a.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
+                        )
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "correct"
+            # BFS: a, b processed before child-a
+            assert resolved_order == [
+                "a.messages.org",
+                "b.messages.org",
+                "child-a.messages.org",
+            ]
+
+    def test_spf_10_lookup_limit(self, maildomain_factory, settings):
+        """RFC 7208: max 10 DNS lookups total. Hitting the limit = invalid."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        # Expected include is deep — unreachable within 10 lookups
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf-final.messages.org -all",
+        }
+        lookup_count = {"n": 0}
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf1.messages.org -all"'
+                            )
+                        )
+                    ]
+                # Each include points to the next, creating a long chain
+                lookup_count["n"] += 1
+                level = lookup_count["n"]
+                return [
+                    MagicMock(
+                        to_text=MagicMock(
+                            return_value=f'"v=spf1 include:_spf{level + 1}.messages.org -all"'
+                        )
+                    )
+                ]
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "invalid"
+
+    def test_spf_dns_error_means_not_found(self, maildomain_factory, settings):
+        """DNS resolution failure on an include target = include_found: False."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                # Include target fails to resolve
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incomplete"
+
+    def test_spf_duplicate_record_in_include_chain(self, maildomain_factory, settings):
+        """Duplicate SPF records on an include target = duplicate status."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                if name == "_spf.messages.org":
+                    # Two SPF records — customer duplicated the record
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
+                        ),
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:5.6.7.8 -all"')
+                        ),
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "duplicate"
+
+
+@pytest.mark.django_db
+class TestCheckSPFStatus:
+    """Test check_spf_status with caching."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_returns_true_when_spf_correct(self, maildomain_factory):
+        """Correct SPF with valid include returns True."""
+        maildomain = maildomain_factory(name="example.com")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                if name == "_spf.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
+                        )
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            assert check_spf_status(maildomain) is True
+
+    @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_returns_false_when_spf_missing(self, maildomain_factory):
+        """Missing SPF record returns False."""
+        maildomain = maildomain_factory(name="example.com")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = NXDOMAIN()
+            assert check_spf_status(maildomain) is False
+
+    @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_returns_false_when_include_not_found(self, maildomain_factory):
+        """SPF exists but include target doesn't resolve returns False."""
+        maildomain = maildomain_factory(name="example.com")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            assert check_spf_status(maildomain) is False
+
+    @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_result_is_cached(self, maildomain_factory):
+        """Second call uses cache, no DNS queries."""
+        maildomain = maildomain_factory(name="example.com")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                if name == "_spf.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
+                        )
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+
+            # First call does DNS
+            assert check_spf_status(maildomain) is True
+            first_call_count = mock_resolve.call_count
+
+            # Second call uses cache — no additional DNS queries
+            assert check_spf_status(maildomain) is True
+            assert mock_resolve.call_count == first_call_count
+
+    @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_invalidate_clears_cache(self, maildomain_factory):
+        """After invalidation, next call does fresh DNS queries."""
+        maildomain = maildomain_factory(name="example.com")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                if name == "_spf.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
+                        )
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+
+            # Populate cache
+            assert check_spf_status(maildomain) is True
+            first_call_count = mock_resolve.call_count
+
+            # Invalidate
+            invalidate_spf_check_cache(maildomain)
+
+            # Next call does DNS again
+            assert check_spf_status(maildomain) is True
+            assert mock_resolve.call_count > first_call_count
+
+    @override_settings(
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 ip4:1.2.3.4 -all"}]',
+    )
+    def test_returns_true_when_no_spf_expected(self, maildomain_factory):
+        """No includes in expected SPF = always True."""
+        maildomain = maildomain_factory(name="example.com")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = [
+                MagicMock(to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"'))
+            ]
+            assert check_spf_status(maildomain) is True
+
+    def test_spf_non_technical_domain_includes_still_traversed(
+        self, maildomain_factory, settings
+    ):
+        """Non-technical-domain includes are resolved (BFS traversal) but
+        DNS errors on them don't cause include_found=False."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.other.com include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            resolved_names = []
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.other.com include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                resolved_names.append(name)
+                if name == "_spf.other.com":
+                    # Non-technical include resolves fine, has no children
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:9.9.9.9 -all"')
+                        )
+                    ]
+                if name == "_spf.messages.org":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
+                        )
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "correct"
+            # Both includes were resolved (BFS follows everything)
+            assert "_spf.other.com" in resolved_names
+            assert "_spf.messages.org" in resolved_names
+
+    def test_spf_no_recursive_check_in_exception_handler(
+        self, maildomain_factory, settings
+    ):
+        """When the initial DNS query fails, no recursive check should run."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = Exception("Connection refused")
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "error"
+
+    def test_spf_include_target_no_spf_record(self, maildomain_factory, settings):
+        """Include target exists but has no SPF record = include_found: False."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return [
+                        MagicMock(
+                            to_text=MagicMock(
+                                return_value='"v=spf1 include:_spf.messages.org -all"'
+                            )
+                        )
+                    ]
+                if name == "_spf.messages.org":
+                    # TXT record exists but is not SPF
+                    return [
+                        MagicMock(to_text=MagicMock(return_value='"not an spf record"'))
+                    ]
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incomplete"

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -282,6 +282,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
                             "some-garbage",
                         )
 
+                    if record_type == "TXT" and name == "_spf.example.com":
+                        return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+
                     if (
                         record_type == "TXT"
                         and name == "_dmarc.example.com"
@@ -308,7 +311,7 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
                 assert results[4]["_check"]["status"] == "missing"
 
     def test_check_dns_records_mixed_status(self, maildomain_factory):
-        """Test checking DNS records with mixed status (correct, incorrect, missing)."""
+        """Test checking DNS records with mixed status (correct, missing SPF, missing A)."""
         maildomain = maildomain_factory(name="example.com")
 
         with patch.object(maildomain, "get_expected_dns_records") as mock_get_records:
@@ -323,14 +326,14 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
             ]
 
             with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-                # Mock responses: correct MX, incorrect TXT, missing A
+                # Mock responses: correct MX, no SPF found, missing A
                 mock_mx_answer = MagicMock()
                 mock_mx_answer.preference = 10
                 mock_mx_answer.exchange = "mx1.example.com"
 
                 mock_resolve.side_effect = [
                     [mock_mx_answer],  # Correct MX
-                    _txt_answer("some-unrelated-record"),  # Incorrect TXT
+                    _txt_answer("some-unrelated-record"),  # No SPF record
                     NoAnswer(),  # Missing A record
                 ]
 
@@ -338,7 +341,7 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
 
                 assert len(results) == 3
                 assert results[0]["_check"]["status"] == "correct"
-                assert results[1]["_check"]["status"] == "incorrect"
+                assert results[1]["_check"]["status"] == "missing"
                 assert results[2]["_check"]["status"] == "missing"
 
     def test_check_single_record_spf_duplicate(self, maildomain_factory):
@@ -517,10 +520,8 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
             # ~all is accepted as correct when -all is expected
             assert result["status"] == "correct"
 
-    def test_check_single_record_spf_insecure_not_triggered_when_expected_not_dash_all(
-        self, maildomain_factory
-    ):
-        """Test that insecure check is skipped when expected SPF doesn't end with -all."""
+    def test_check_single_record_spf_insecure_when_all_weaker(self, maildomain_factory):
+        """Test that weaker 'all' mechanism is reported as insecure when includes resolve."""
         maildomain = maildomain_factory(name="example.com")
         expected_record = {
             "type": "TXT",
@@ -535,8 +536,8 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
 
             result = check_single_record(maildomain, expected_record)
 
-            # Expected uses ~all, so insecure check doesn't apply
-            assert result["status"] == "incorrect"
+            # Includes resolve but +all is weaker than ~all
+            assert result["status"] == "insecure"
 
     def test_check_single_record_dmarc_duplicate(self, maildomain_factory):
         """Test that duplicate DMARC records are detected."""
@@ -1289,7 +1290,7 @@ class TestSPFRecursiveCheck:
 
             mock_resolve.side_effect = resolve_side_effect_11
             result = check_single_record(maildomain, expected_record_11)
-            assert result["status"] == "invalid"
+            assert result["status"] == "incorrect"
 
     def test_spf_dns_error_means_not_found(self, maildomain_factory, settings):
         """DNS resolution failure on an include target = include_found: False."""
@@ -1312,7 +1313,7 @@ class TestSPFRecursiveCheck:
             mock_resolve.side_effect = resolve_side_effect
             result = check_single_record(maildomain, expected_record)
 
-            assert result["status"] == "incomplete"
+            assert result["status"] == "incorrect"
 
     def test_spf_duplicate_record_in_include_chain(self, maildomain_factory, settings):
         """Duplicate SPF records on an include target = duplicate status."""
@@ -1597,4 +1598,4 @@ class TestCheckSPFStatus:
             mock_resolve.side_effect = resolve_side_effect
             result = check_single_record(maildomain, expected_record)
 
-            assert result["status"] == "incomplete"
+            assert result["status"] == "incorrect"

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -23,6 +23,27 @@ from core.services.dns.check import (
 )
 
 
+def _txt_rr(value):
+    """Create a mock TXT resource record with .strings for dnspython rrset."""
+    rr = MagicMock()
+    rr.strings = (value.encode(),)
+    return rr
+
+
+def _txt_answer(*values):
+    """Create a mock dns.resolver answer for TXT records.
+
+    Returns an object that works with both iteration and .rrset access.
+    Each value becomes a separate TXT record in the rrset.
+    """
+    rrs = [_txt_rr(v) for v in values]
+    answer = MagicMock()
+    answer.rrset = rrs
+    answer.__iter__ = lambda self: iter(rrs)
+    answer.__len__ = lambda self: len(rrs)
+    return answer
+
+
 @pytest.mark.django_db
 class TestDNSChecking:  # pylint: disable=too-many-public-methods
     """Test DNS checking functionality."""
@@ -72,9 +93,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
             # Mock correct TXT record
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=spf1 include:_spf.example.com -all"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com -all"
+            )
 
             result = check_single_record(maildomain, expected_record)
 
@@ -255,24 +276,18 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
                         return [mock_mx_answer]
 
                     if record_type == "TXT" and name == "@.example.com":
-                        mock_txt_answer = MagicMock()
-                        mock_txt_answer.to_text.return_value = (
-                            '"v=spf1 include:_spf.example.com -all"'
+                        return _txt_answer(
+                            "some-garbage",
+                            "v=spf1 include:_spf.example.com -all",
+                            "some-garbage",
                         )
-                        garbage = MagicMock()
-                        garbage.to_text.return_value = "some-garbage"
-                        return [garbage, mock_txt_answer, garbage]
 
                     if (
                         record_type == "TXT"
                         and name == "_dmarc.example.com"
                         or name == "_dmarc_stripped.example.com"
                     ):
-                        mock_txt_dmarc_answer = MagicMock()
-                        mock_txt_dmarc_answer.to_text.return_value = (
-                            '"v=DMARC1; p=reject; adkim=s; aspf=s;"'
-                        )
-                        return [mock_txt_dmarc_answer]
+                        return _txt_answer("v=DMARC1; p=reject; adkim=s; aspf=s;")
 
                     return []
 
@@ -315,7 +330,7 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
 
                 mock_resolve.side_effect = [
                     [mock_mx_answer],  # Correct MX
-                    [],  # Incorrect TXT (empty response)
+                    _txt_answer("some-unrelated-record"),  # Incorrect TXT
                     NoAnswer(),  # Missing A record
                 ]
 
@@ -343,13 +358,10 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
             # Mock two SPF TXT records (invalid per RFC 7208)
-            mock_answer1 = MagicMock()
-            mock_answer1.to_text.return_value = '"v=spf1 include:_spf.example.com -all"'
-            mock_answer2 = MagicMock()
-            mock_answer2.to_text.return_value = (
-                '"v=spf1 include:_spf.legacy-provider.com ~all"'
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com -all",
+                "v=spf1 include:_spf.legacy-provider.com ~all",
             )
-            mock_resolve.return_value = [mock_answer1, mock_answer2]
 
             result = check_single_record(maildomain, expected_record)
 
@@ -370,13 +382,10 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_correct = MagicMock()
-            mock_correct.to_text.return_value = '"v=spf1 include:_spf.example.com -all"'
-            mock_legacy = MagicMock()
-            mock_legacy.to_text.return_value = (
-                '"v=spf1 include:_spf.legacy-provider.com ~all"'
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com -all",
+                "v=spf1 include:_spf.legacy-provider.com ~all",
             )
-            mock_resolve.return_value = [mock_correct, mock_legacy]
 
             result = check_single_record(maildomain, expected_record)
 
@@ -393,15 +402,41 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_spf = MagicMock()
-            mock_spf.to_text.return_value = '"v=spf1 include:_spf.example.com -all"'
             # Also has a non-SPF TXT record
-            mock_other = MagicMock()
-            mock_other.to_text.return_value = '"google-site-verification=abc123"'
-            mock_resolve.return_value = [mock_spf, mock_other]
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com -all",
+                "google-site-verification=abc123",
+            )
 
             result = check_single_record(maildomain, expected_record)
 
+            assert result["status"] == "correct"
+
+    def test_check_single_record_spf_found_when_resolver_merges_txt_records(
+        self, maildomain_factory
+    ):
+        """Regression: some local resolvers (e.g. systemd-resolved) merge
+        separate TXT records into a single RR with multiple strings. SPF must
+        still be found by iterating individual strings."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            # Single RR with two strings (merged by local resolver)
+            merged_rr = MagicMock()
+            merged_rr.strings = (
+                b"google-site-verification=abc123",
+                b"v=spf1 include:_spf.example.com -all",
+            )
+            answer = MagicMock()
+            answer.rrset = [merged_rr]
+            mock_resolve.return_value = answer
+
+            result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
 
     def test_check_single_record_dmarc_not_affected_by_spf_duplicate_check(
@@ -416,9 +451,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=DMARC1; p=reject; adkim=s; aspf=s;"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer(
+                "v=DMARC1; p=reject; adkim=s; aspf=s;"
+            )
 
             result = check_single_record(maildomain, expected_record)
 
@@ -434,9 +469,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=spf1 include:_spf.example.com +all"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com +all"
+            )
 
             result = check_single_record(maildomain, expected_record)
 
@@ -453,9 +488,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=spf1 include:_spf.example.com ?all"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com ?all"
+            )
 
             result = check_single_record(maildomain, expected_record)
 
@@ -473,9 +508,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=spf1 include:_spf.example.com ~all"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com ~all"
+            )
 
             result = check_single_record(maildomain, expected_record)
 
@@ -494,9 +529,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=spf1 include:_spf.example.com +all"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com +all"
+            )
 
             result = check_single_record(maildomain, expected_record)
 
@@ -513,11 +548,10 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer1 = MagicMock()
-            mock_answer1.to_text.return_value = '"v=DMARC1;p=reject;adkim=s;aspf=s"'
-            mock_answer2 = MagicMock()
-            mock_answer2.to_text.return_value = '"v=DMARC1;p=none"'
-            mock_resolve.return_value = [mock_answer1, mock_answer2]
+            mock_resolve.return_value = _txt_answer(
+                "v=DMARC1;p=reject;adkim=s;aspf=s",
+                "v=DMARC1;p=none",
+            )
 
             result = check_single_record(maildomain, expected_record)
 
@@ -534,9 +568,7 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=DMARC1;p=none"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=DMARC1;p=none")
 
             result = check_single_record(maildomain, expected_record)
 
@@ -555,9 +587,7 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=DMARC1;p=none"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=DMARC1;p=none")
 
             result = check_single_record(maildomain, expected_record)
 
@@ -869,9 +899,7 @@ class TestDKIMSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=DKIM1; k=rsa; p=MIGfMA0; t=s"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=DKIM1; k=rsa; p=MIGfMA0; t=s")
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
@@ -886,9 +914,7 @@ class TestDKIMSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=DKIM1; k=rsa; p=MIGfMA0; t=y"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=DKIM1; k=rsa; p=MIGfMA0; t=y")
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "insecure"
@@ -903,9 +929,7 @@ class TestDKIMSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=DKIM1; k=rsa; p=MIGfMA0; t=y:s"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=DKIM1; k=rsa; p=MIGfMA0; t=y:s")
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "insecure"
@@ -920,9 +944,7 @@ class TestDKIMSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=DKIM1; p=MIGfMA0; k=rsa"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=DKIM1; p=MIGfMA0; k=rsa")
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
@@ -937,9 +959,7 @@ class TestDKIMSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=DKIM1; k=rsa; p=WRONG_KEY"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=DKIM1; k=rsa; p=WRONG_KEY")
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "incorrect"
@@ -956,11 +976,16 @@ class TestDKIMSemanticComparison:
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
             # Simulate DNS returning a split TXT record with extra t=s tag
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = (
-                '"v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBA" "QUAA4GNADCBiQKBgQC; t=s"'
+            rr = MagicMock()
+            rr.strings = (
+                b"v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBA",
+                b"QUAA4GNADCBiQKBgQC; t=s",
             )
-            mock_resolve.return_value = [mock_answer]
+            answer = MagicMock()
+            answer.rrset = [rr]
+            answer.__iter__ = lambda self: iter([rr])
+            answer.__len__ = lambda self: 1
+            mock_resolve.return_value = answer
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
@@ -976,11 +1001,16 @@ class TestDKIMSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = (
-                '"v=DKIM1; t=y; p=MIGfMA0GCSqGSIb3DQEBA" "QUAA4GNADCBiQKBgQC; k=rsa"'
+            rr = MagicMock()
+            rr.strings = (
+                b"v=DKIM1; t=y; p=MIGfMA0GCSqGSIb3DQEBA",
+                b"QUAA4GNADCBiQKBgQC; k=rsa",
             )
-            mock_resolve.return_value = [mock_answer]
+            answer = MagicMock()
+            answer.rrset = [rr]
+            answer.__iter__ = lambda self: iter([rr])
+            answer.__len__ = lambda self: 1
+            mock_resolve.return_value = answer
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "insecure"
@@ -1000,11 +1030,9 @@ class TestSPFSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = (
-                '"v=spf1 include:other.com include:_spf.example.com -all"'
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:other.com include:_spf.example.com -all"
             )
-            mock_resolve.return_value = [mock_answer]
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
@@ -1019,9 +1047,9 @@ class TestSPFSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=spf1 include:_spf.example.com ~all"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com ~all"
+            )
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
@@ -1036,11 +1064,9 @@ class TestSPFSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = (
-                '"v=spf1 include:_spf.example.com include:extra.com -all"'
+            mock_resolve.return_value = _txt_answer(
+                "v=spf1 include:_spf.example.com include:extra.com -all"
             )
-            mock_resolve.return_value = [mock_answer]
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
@@ -1055,9 +1081,7 @@ class TestSPFSemanticComparison:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=spf1 include:other.com -all"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=spf1 include:other.com -all")
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "incorrect"
@@ -1088,18 +1112,12 @@ class TestSPFRecursiveCheck:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_spf_main = MagicMock()
-            mock_spf_main.to_text.return_value = (
-                '"v=spf1 include:_spf.messages.org -all"'
-            )
-            mock_spf_include = MagicMock()
-            mock_spf_include.to_text.return_value = '"v=spf1 ip4:1.2.3.4 -all"'
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [mock_spf_main]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 if name == "_spf.messages.org":
-                    return [mock_spf_include]
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
                 return []
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1120,12 +1138,10 @@ class TestSPFRecursiveCheck:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_spf_main = MagicMock()
-            mock_spf_main.to_text.return_value = '"v=spf1 include:_spf.other.com -all"'
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [mock_spf_main]
+                    return _txt_answer("v=spf1 include:_spf.other.com -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1143,9 +1159,7 @@ class TestSPFRecursiveCheck:
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_answer = MagicMock()
-            mock_answer.to_text.return_value = '"v=spf1 ip4:1.2.3.4 -all"'
-            mock_resolve.return_value = [mock_answer]
+            mock_resolve.return_value = _txt_answer("v=spf1 ip4:1.2.3.4 -all")
 
             result = check_single_record(maildomain, expected_record)
 
@@ -1168,29 +1182,13 @@ class TestSPFRecursiveCheck:
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
                     # Found: includes _spf.messages.org (not _spf2 directly)
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 # Level 1: _spf.messages.org includes _spf2.messages.org
                 if name == "_spf.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf2.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf2.messages.org -all")
                 # Level 2: _spf2.messages.org has actual IPs
                 if name == "_spf2.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
-                        )
-                    ]
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1214,34 +1212,16 @@ class TestSPFRecursiveCheck:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:a.messages.org include:b.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer(
+                        "v=spf1 include:a.messages.org include:b.messages.org -all"
+                    )
                 resolved_order.append(name)
                 if name == "a.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:child-a.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:child-a.messages.org -all")
                 if name == "b.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:2.3.4.5 -all"')
-                        )
-                    ]
+                    return _txt_answer("v=spf1 ip4:2.3.4.5 -all")
                 if name == "child-a.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
-                        )
-                    ]
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1256,42 +1236,60 @@ class TestSPFRecursiveCheck:
             ]
 
     def test_spf_10_lookup_limit(self, maildomain_factory, settings):
-        """RFC 7208: max 10 DNS lookups total. Hitting the limit = invalid."""
+        """RFC 7208: max 10 DNS lookups for mechanisms. Chain of exactly 10
+        includes succeeds, 11th triggers the limit."""
         settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
         maildomain = maildomain_factory(name="example.com")
-        # Expected include is deep — unreachable within 10 lookups
+
+        # Chain of 10: _spf1 -> _spf2 -> ... -> _spf10 (= target)
+        # Should succeed: exactly 10 lookups.
         expected_record = {
             "type": "TXT",
             "target": "",
-            "value": "v=spf1 include:_spf-final.messages.org -all",
+            "value": "v=spf1 include:_spf10.messages.org -all",
         }
-        lookup_count = {"n": 0}
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf1.messages.org -all"'
-                            )
+                    return _txt_answer("v=spf1 include:_spf1.messages.org -all")
+                for i in range(1, 10):
+                    if name == f"_spf{i}.messages.org":
+                        return _txt_answer(
+                            f"v=spf1 include:_spf{i + 1}.messages.org -all"
                         )
-                    ]
-                # Each include points to the next, creating a long chain
-                lookup_count["n"] += 1
-                level = lookup_count["n"]
-                return [
-                    MagicMock(
-                        to_text=MagicMock(
-                            return_value=f'"v=spf1 include:_spf{level + 1}.messages.org -all"'
-                        )
-                    )
-                ]
+                if name == "_spf10.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
             result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
 
+        # Chain of 11: needs 11 lookups, should hit the limit.
+        expected_record_11 = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf11.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect_11(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer("v=spf1 include:_spf1.messages.org -all")
+                for i in range(1, 11):
+                    if name == f"_spf{i}.messages.org":
+                        return _txt_answer(
+                            f"v=spf1 include:_spf{i + 1}.messages.org -all"
+                        )
+                if name == "_spf11.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect_11
+            result = check_single_record(maildomain, expected_record_11)
             assert result["status"] == "invalid"
 
     def test_spf_dns_error_means_not_found(self, maildomain_factory, settings):
@@ -1308,13 +1306,7 @@ class TestSPFRecursiveCheck:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 # Include target fails to resolve
                 raise NXDOMAIN()
 
@@ -1337,23 +1329,13 @@ class TestSPFRecursiveCheck:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 if name == "_spf.messages.org":
                     # Two SPF records — customer duplicated the record
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
-                        ),
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:5.6.7.8 -all"')
-                        ),
-                    ]
+                    return _txt_answer(
+                        "v=spf1 ip4:1.2.3.4 -all",
+                        "v=spf1 ip4:5.6.7.8 -all",
+                    )
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1383,19 +1365,9 @@ class TestCheckSPFStatus:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 if name == "_spf.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
-                        )
-                    ]
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1427,13 +1399,7 @@ class TestCheckSPFStatus:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1452,19 +1418,9 @@ class TestCheckSPFStatus:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 if name == "_spf.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
-                        )
-                    ]
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1490,19 +1446,9 @@ class TestCheckSPFStatus:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 if name == "_spf.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
-                        )
-                    ]
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1519,6 +1465,50 @@ class TestCheckSPFStatus:
             assert mock_resolve.call_count > first_call_count
 
     @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_transient_dns_error_not_cached(self, maildomain_factory):
+        """DNS timeout should return False but NOT cache the result."""
+        maildomain = maildomain_factory(name="example.com")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            # First call: DNS timeout (transient error)
+            mock_resolve.side_effect = Timeout()
+            assert check_spf_status(maildomain) is False
+
+            # Second call: DNS works now — should NOT use cache
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
+                if name == "_spf.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            assert check_spf_status(maildomain) is True
+
+    @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_definitive_failure_is_cached(self, maildomain_factory):
+        """A definitive SPF misconfiguration (missing record) should be cached."""
+        maildomain = maildomain_factory(name="example.com")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            # NXDOMAIN is a definitive failure (status=missing, not error)
+            mock_resolve.side_effect = NXDOMAIN()
+            assert check_spf_status(maildomain) is False
+            first_call_count = mock_resolve.call_count
+
+            # Second call should use cache — no additional DNS queries
+            assert check_spf_status(maildomain) is False
+            assert mock_resolve.call_count == first_call_count
+
+    @override_settings(
         MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
         '"value":"v=spf1 ip4:1.2.3.4 -all"}]',
     )
@@ -1527,9 +1517,7 @@ class TestCheckSPFStatus:
         maildomain = maildomain_factory(name="example.com")
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            mock_resolve.return_value = [
-                MagicMock(to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"'))
-            ]
+            mock_resolve.return_value = _txt_answer("v=spf1 ip4:1.2.3.4 -all")
             assert check_spf_status(maildomain) is True
 
     def test_spf_non_technical_domain_includes_still_traversed(
@@ -1550,27 +1538,15 @@ class TestCheckSPFStatus:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.other.com include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer(
+                        "v=spf1 include:_spf.other.com include:_spf.messages.org -all"
+                    )
                 resolved_names.append(name)
                 if name == "_spf.other.com":
                     # Non-technical include resolves fine, has no children
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:9.9.9.9 -all"')
-                        )
-                    ]
+                    return _txt_answer("v=spf1 ip4:9.9.9.9 -all")
                 if name == "_spf.messages.org":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
-                        )
-                    ]
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect
@@ -1613,18 +1589,10 @@ class TestCheckSPFStatus:
 
             def resolve_side_effect(name, _record_type):
                 if name == "example.com":
-                    return [
-                        MagicMock(
-                            to_text=MagicMock(
-                                return_value='"v=spf1 include:_spf.messages.org -all"'
-                            )
-                        )
-                    ]
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
                 if name == "_spf.messages.org":
                     # TXT record exists but is not SPF
-                    return [
-                        MagicMock(to_text=MagicMock(return_value='"not an spf record"'))
-                    ]
+                    return _txt_answer("not an spf record")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -31,16 +31,10 @@ def _txt_rr(value):
 
 
 def _txt_answer(*values):
-    """Create a mock dns.resolver answer for TXT records.
-
-    Returns an object that works with both iteration and .rrset access.
-    Each value becomes a separate TXT record in the rrset.
-    """
+    """Create a mock dns.resolver answer for TXT records."""
     rrs = [_txt_rr(v) for v in values]
     answer = MagicMock()
     answer.rrset = rrs
-    answer.__iter__ = lambda self: iter(rrs)
-    answer.__len__ = lambda self: len(rrs)
     return answer
 
 

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -279,10 +279,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
                     if record_type == "TXT" and name == "_spf.example.com":
                         return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
 
-                    if (
-                        record_type == "TXT"
-                        and name == "_dmarc.example.com"
-                        or name == "_dmarc_stripped.example.com"
+                    if record_type == "TXT" and name in (
+                        "_dmarc.example.com",
+                        "_dmarc_stripped.example.com",
                     ):
                         return _txt_answer("v=DMARC1; p=reject; adkim=s; aspf=s;")
 
@@ -978,8 +977,6 @@ class TestDKIMSemanticComparison:
             )
             answer = MagicMock()
             answer.rrset = [rr]
-            answer.__iter__ = lambda self: iter([rr])
-            answer.__len__ = lambda self: 1
             mock_resolve.return_value = answer
 
             result = check_single_record(maildomain, expected_record)
@@ -1003,8 +1000,6 @@ class TestDKIMSemanticComparison:
             )
             answer = MagicMock()
             answer.rrset = [rr]
-            answer.__iter__ = lambda self: iter([rr])
-            answer.__len__ = lambda self: 1
             mock_resolve.return_value = answer
 
             result = check_single_record(maildomain, expected_record)

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -1164,7 +1164,6 @@ class TestSPFRecursiveCheck:
             result = check_single_record(maildomain, expected_record)
 
             assert result["status"] == "correct"
-            assert result["status"] == "correct"
 
     def test_spf_real_recursion_two_levels(self, maildomain_factory, settings):
         """BFS follows found chain to reach expected technical include 2 levels deep."""

--- a/src/backend/core/tests/mda/test_outbound.py
+++ b/src/backend/core/tests/mda/test_outbound.py
@@ -1110,6 +1110,173 @@ class TestSendMessageDKIMVerification:
         assert mock_deliver_inbound.called
 
 
+@pytest.mark.django_db
+class TestSendMessageSPFCheck:
+    """Test SPF check in send_message."""
+
+    @override_settings(MESSAGES_SPF_CHECK_OUTGOING=True)
+    @patch("core.services.dns.check.dns.resolver.resolve")
+    @patch("core.mda.outbound.send_outbound_message")
+    def test_spf_check_failure_marks_for_retry(
+        self, mock_send_outbound, mock_dns_resolve, mailbox_sender
+    ):
+        """When SPF check fails, external recipients are marked for retry."""
+        thread = factories.ThreadFactory()
+        factories.ThreadAccessFactory(
+            mailbox=mailbox_sender,
+            thread=thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+        sender_contact = factories.ContactFactory(mailbox=mailbox_sender)
+        message = factories.MessageFactory(
+            thread=thread,
+            sender=sender_contact,
+            is_draft=False,
+            is_sender=True,
+            subject="Test SPF",
+        )
+
+        raw_mime = (
+            f"From: {sender_contact.email}\r\n"
+            "To: external@other.com\r\n"
+            "Subject: Test\r\n\r\nBody\r\n"
+        ).encode()
+        blob = mailbox_sender.create_blob(
+            content=raw_mime, content_type="message/rfc822"
+        )
+        message.blob = blob
+        message.save()
+
+        external_contact = factories.ContactFactory(
+            mailbox=mailbox_sender, email="external@other.com"
+        )
+        recipient = factories.MessageRecipientFactory(
+            message=message,
+            contact=external_contact,
+            type=models.MessageRecipientTypeChoices.TO,
+        )
+
+        # DNS returns no SPF record → check_spf_status returns False
+        mock_dns_resolve.side_effect = dns.resolver.NXDOMAIN()
+
+        outbound.send_message(message)
+
+        assert not mock_send_outbound.called
+        recipient.refresh_from_db()
+        assert recipient.delivery_status == enums.MessageDeliveryStatusChoices.RETRY
+        assert "SPF check failed" in recipient.delivery_message
+
+    @override_settings(
+        MESSAGES_SPF_CHECK_OUTGOING=True,
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 ip4:1.2.3.4 -all"}]',
+    )
+    @patch("core.services.dns.check.dns.resolver.resolve")
+    @patch("core.mda.outbound.send_outbound_message")
+    def test_spf_check_success_sends_message(
+        self, mock_send_outbound, mock_dns_resolve, mailbox_sender
+    ):
+        """When SPF check passes, message is sent normally."""
+        thread = factories.ThreadFactory()
+        factories.ThreadAccessFactory(
+            mailbox=mailbox_sender,
+            thread=thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+        sender_contact = factories.ContactFactory(mailbox=mailbox_sender)
+        message = factories.MessageFactory(
+            thread=thread,
+            sender=sender_contact,
+            is_draft=False,
+            is_sender=True,
+            subject="Test SPF",
+        )
+
+        raw_mime = (
+            f"From: {sender_contact.email}\r\n"
+            "To: external@other.com\r\n"
+            "Subject: Test\r\n\r\nBody\r\n"
+        ).encode()
+        blob = mailbox_sender.create_blob(
+            content=raw_mime, content_type="message/rfc822"
+        )
+        message.blob = blob
+        message.save()
+
+        external_contact = factories.ContactFactory(
+            mailbox=mailbox_sender, email="external@other.com"
+        )
+        factories.MessageRecipientFactory(
+            message=message,
+            contact=external_contact,
+            type=models.MessageRecipientTypeChoices.TO,
+        )
+
+        def resolve_side_effect(name, record_type):
+            if name == mailbox_sender.domain.name:
+                return [
+                    MagicMock(
+                        to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
+                    )
+                ]
+            raise dns.resolver.NXDOMAIN()
+
+        mock_dns_resolve.side_effect = resolve_side_effect
+        mock_send_outbound.return_value = {"external@other.com": {"delivered": True}}
+
+        outbound.send_message(message)
+
+        assert mock_send_outbound.called
+
+    @patch("core.mda.outbound.send_outbound_message")
+    def test_spf_check_skipped_when_disabled(self, mock_send_outbound, mailbox_sender):
+        """When MESSAGES_SPF_CHECK_OUTGOING is False (default), no SPF check."""
+        thread = factories.ThreadFactory()
+        factories.ThreadAccessFactory(
+            mailbox=mailbox_sender,
+            thread=thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+        sender_contact = factories.ContactFactory(mailbox=mailbox_sender)
+        message = factories.MessageFactory(
+            thread=thread,
+            sender=sender_contact,
+            is_draft=False,
+            is_sender=True,
+            subject="Test SPF",
+        )
+
+        raw_mime = (
+            f"From: {sender_contact.email}\r\n"
+            "To: external@other.com\r\n"
+            "Subject: Test\r\n\r\nBody\r\n"
+        ).encode()
+        blob = mailbox_sender.create_blob(
+            content=raw_mime, content_type="message/rfc822"
+        )
+        message.blob = blob
+        message.save()
+
+        external_contact = factories.ContactFactory(
+            mailbox=mailbox_sender, email="external@other.com"
+        )
+        factories.MessageRecipientFactory(
+            message=message,
+            contact=external_contact,
+            type=models.MessageRecipientTypeChoices.TO,
+        )
+
+        mock_send_outbound.return_value = {"external@other.com": {"delivered": True}}
+
+        # No DNS mock needed — SPF check should not run
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            outbound.send_message(message)
+            # check_spf_status should not have been called
+            assert not mock_resolve.called
+
+        assert mock_send_outbound.called
+
+
 # 1x1 red pixel PNG, small enough to be used in tests
 TINY_PNG_B64 = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4"

--- a/src/backend/core/tests/mda/test_outbound.py
+++ b/src/backend/core/tests/mda/test_outbound.py
@@ -1155,6 +1155,10 @@ def _create_spf_test_message(mailbox_sender):
 class TestSendMessageSPFCheck:
     """Test SPF check in send_message."""
 
+    def setup_method(self):
+        """Clear SPF cache so each test hits the mocked DNS resolver."""
+        cache.clear()
+
     @override_settings(MESSAGES_SPF_CHECK_OUTGOING=True)
     @patch("core.services.dns.check.dns.resolver.resolve")
     @patch("core.mda.outbound.send_outbound_message")

--- a/src/backend/core/tests/mda/test_outbound.py
+++ b/src/backend/core/tests/mda/test_outbound.py
@@ -1110,6 +1110,47 @@ class TestSendMessageDKIMVerification:
         assert mock_deliver_inbound.called
 
 
+def _create_spf_test_message(mailbox_sender):
+    """Create the common objects needed by SPF check tests.
+
+    Returns (message, sender_contact, external_contact, recipient, thread).
+    """
+    thread = factories.ThreadFactory()
+    factories.ThreadAccessFactory(
+        mailbox=mailbox_sender,
+        thread=thread,
+        role=enums.ThreadAccessRoleChoices.EDITOR,
+    )
+    sender_contact = factories.ContactFactory(mailbox=mailbox_sender)
+    message = factories.MessageFactory(
+        thread=thread,
+        sender=sender_contact,
+        is_draft=False,
+        is_sender=True,
+        subject="Test SPF",
+    )
+
+    raw_mime = (
+        f"From: {sender_contact.email}\r\n"
+        "To: external@other.com\r\n"
+        "Subject: Test\r\n\r\nBody\r\n"
+    ).encode()
+    blob = mailbox_sender.create_blob(content=raw_mime, content_type="message/rfc822")
+    message.blob = blob
+    message.save()
+
+    external_contact = factories.ContactFactory(
+        mailbox=mailbox_sender, email="external@other.com"
+    )
+    recipient = factories.MessageRecipientFactory(
+        message=message,
+        contact=external_contact,
+        type=models.MessageRecipientTypeChoices.TO,
+    )
+
+    return message, sender_contact, external_contact, recipient, thread
+
+
 @pytest.mark.django_db
 class TestSendMessageSPFCheck:
     """Test SPF check in send_message."""
@@ -1121,40 +1162,7 @@ class TestSendMessageSPFCheck:
         self, mock_send_outbound, mock_dns_resolve, mailbox_sender
     ):
         """When SPF check fails, external recipients are marked for retry."""
-        thread = factories.ThreadFactory()
-        factories.ThreadAccessFactory(
-            mailbox=mailbox_sender,
-            thread=thread,
-            role=enums.ThreadAccessRoleChoices.EDITOR,
-        )
-        sender_contact = factories.ContactFactory(mailbox=mailbox_sender)
-        message = factories.MessageFactory(
-            thread=thread,
-            sender=sender_contact,
-            is_draft=False,
-            is_sender=True,
-            subject="Test SPF",
-        )
-
-        raw_mime = (
-            f"From: {sender_contact.email}\r\n"
-            "To: external@other.com\r\n"
-            "Subject: Test\r\n\r\nBody\r\n"
-        ).encode()
-        blob = mailbox_sender.create_blob(
-            content=raw_mime, content_type="message/rfc822"
-        )
-        message.blob = blob
-        message.save()
-
-        external_contact = factories.ContactFactory(
-            mailbox=mailbox_sender, email="external@other.com"
-        )
-        recipient = factories.MessageRecipientFactory(
-            message=message,
-            contact=external_contact,
-            type=models.MessageRecipientTypeChoices.TO,
-        )
+        message, _, _, recipient, _ = _create_spf_test_message(mailbox_sender)
 
         # DNS returns no SPF record → check_spf_status returns False
         mock_dns_resolve.side_effect = dns.resolver.NXDOMAIN()
@@ -1177,40 +1185,7 @@ class TestSendMessageSPFCheck:
         self, mock_send_outbound, mock_dns_resolve, mailbox_sender
     ):
         """When SPF check passes, message is sent normally."""
-        thread = factories.ThreadFactory()
-        factories.ThreadAccessFactory(
-            mailbox=mailbox_sender,
-            thread=thread,
-            role=enums.ThreadAccessRoleChoices.EDITOR,
-        )
-        sender_contact = factories.ContactFactory(mailbox=mailbox_sender)
-        message = factories.MessageFactory(
-            thread=thread,
-            sender=sender_contact,
-            is_draft=False,
-            is_sender=True,
-            subject="Test SPF",
-        )
-
-        raw_mime = (
-            f"From: {sender_contact.email}\r\n"
-            "To: external@other.com\r\n"
-            "Subject: Test\r\n\r\nBody\r\n"
-        ).encode()
-        blob = mailbox_sender.create_blob(
-            content=raw_mime, content_type="message/rfc822"
-        )
-        message.blob = blob
-        message.save()
-
-        external_contact = factories.ContactFactory(
-            mailbox=mailbox_sender, email="external@other.com"
-        )
-        factories.MessageRecipientFactory(
-            message=message,
-            contact=external_contact,
-            type=models.MessageRecipientTypeChoices.TO,
-        )
+        message, _, _, _, _ = _create_spf_test_message(mailbox_sender)
 
         def resolve_side_effect(name, record_type):
             if name == mailbox_sender.domain.name:
@@ -1231,40 +1206,7 @@ class TestSendMessageSPFCheck:
     @patch("core.mda.outbound.send_outbound_message")
     def test_spf_check_skipped_when_disabled(self, mock_send_outbound, mailbox_sender):
         """When MESSAGES_SPF_CHECK_OUTGOING is False (default), no SPF check."""
-        thread = factories.ThreadFactory()
-        factories.ThreadAccessFactory(
-            mailbox=mailbox_sender,
-            thread=thread,
-            role=enums.ThreadAccessRoleChoices.EDITOR,
-        )
-        sender_contact = factories.ContactFactory(mailbox=mailbox_sender)
-        message = factories.MessageFactory(
-            thread=thread,
-            sender=sender_contact,
-            is_draft=False,
-            is_sender=True,
-            subject="Test SPF",
-        )
-
-        raw_mime = (
-            f"From: {sender_contact.email}\r\n"
-            "To: external@other.com\r\n"
-            "Subject: Test\r\n\r\nBody\r\n"
-        ).encode()
-        blob = mailbox_sender.create_blob(
-            content=raw_mime, content_type="message/rfc822"
-        )
-        message.blob = blob
-        message.save()
-
-        external_contact = factories.ContactFactory(
-            mailbox=mailbox_sender, email="external@other.com"
-        )
-        factories.MessageRecipientFactory(
-            message=message,
-            contact=external_contact,
-            type=models.MessageRecipientTypeChoices.TO,
-        )
+        message, _, _, _, _ = _create_spf_test_message(mailbox_sender)
 
         mock_send_outbound.return_value = {"external@other.com": {"delivered": True}}
 

--- a/src/backend/core/tests/mda/test_outbound.py
+++ b/src/backend/core/tests/mda/test_outbound.py
@@ -1214,11 +1214,11 @@ class TestSendMessageSPFCheck:
 
         def resolve_side_effect(name, record_type):
             if name == mailbox_sender.domain.name:
-                return [
-                    MagicMock(
-                        to_text=MagicMock(return_value='"v=spf1 ip4:1.2.3.4 -all"')
-                    )
-                ]
+                rr = MagicMock()
+                rr.strings = (b"v=spf1 ip4:1.2.3.4 -all",)
+                answer = MagicMock()
+                answer.rrset = [rr]
+                return answer
             raise dns.resolver.NXDOMAIN()
 
         mock_dns_resolve.side_effect = resolve_side_effect

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -392,6 +392,13 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # Block outgoing messages when SPF includes are not correctly set up
+    MESSAGES_SPF_CHECK_OUTGOING = values.BooleanValue(
+        default=False,
+        environ_name="MESSAGES_SPF_CHECK_OUTGOING",
+        environ_prefix=None,
+    )
+
     # Technical domain for DNS records (MX, SPF, DKIM hosting)
     MESSAGES_TECHNICAL_DOMAIN = values.Value(
         "localhost", environ_name="MESSAGES_TECHNICAL_DOMAIN", environ_prefix=None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional outgoing SPF validation that can block or mark external deliveries when sender SPF fails.
  * SPF cache invalidation so DNS rechecks are used immediately after DNS validation.

* **Improvements**
  * More robust SPF evaluation including recursive include resolution, improved TXT handling, duplicate/limit detection, and clearer result statuses.

* **Tests**
  * Expanded SPF/DNS/DKIM tests covering recursion, lookup limits, TXT formats, caching and invalidation, and outbound delivery behavior.

* **Chores**
  * Added configuration flag to enable outgoing SPF validation (disabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->