### PR TITLE
🐛(mda) quote error field and log socks proxy in outbound delivery

### DIFF
--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -479,7 +479,11 @@ def send_message(message: models.Message, force_mta_out: bool = False):
                     relay,
                     proxy_host or "nil",
                     status,
-                    (error or "nil").replace('"', '\\"'),
+                    (error or "nil")
+                    .replace("\\", "\\\\")
+                    .replace('"', '\\"')
+                    .replace("\n", "\\n")
+                    .replace("\r", "\\r"),
                 )
                 if delivered:
                     # TODO also update message.updated_at?

--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -462,18 +462,20 @@ def send_message(message: models.Message, force_mta_out: bool = False):
                 error: Optional[str] = None,
                 retry: Optional[bool] = False,
                 smtp_host: Optional[str] = None,
+                proxy_host: Optional[str] = None,
             ) -> None:
                 status = "delivered" if delivered else "failed"
                 relay = smtp_host if not internal else "internal"
 
                 logger.info(
-                    "module=core.mda.outbound.send_message message_id=%s to=%s from=%s relay=%s status=%s error=(%s)",
+                    'module=core.mda.outbound.send_message message_id=%s to=%s from=%s relay=%s socks=%s status=%s error="%s"',
                     message.id,
                     recipient_email,
                     message.sender.email,
                     relay,
+                    proxy_host or "nil",
                     status,
-                    error or "nil",
+                    (error or "nil").replace('"', '\\"'),
                 )
                 if delivered:
                     # TODO also update message.updated_at?
@@ -582,6 +584,7 @@ def send_message(message: models.Message, force_mta_out: bool = False):
                             status.get("error"),
                             status.get("retry", False),
                             status.get("smtp_host"),
+                            status.get("proxy_host"),
                         )
                 except Exception as e:  # pylint: disable=broad-exception-caught
                     logger.error(

--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -1,6 +1,7 @@
 """Handles outbound email delivery logic: composing and sending messages."""
 # pylint: disable=broad-exception-caught
 
+import json
 import logging
 from typing import Any, Optional
 
@@ -471,7 +472,7 @@ def send_message(message: models.Message, force_mta_out: bool = False):
                     (
                         "module=core.mda.outbound.send_message "
                         "message_id=%s to=%s from=%s "
-                        'relay=%s socks=%s status=%s error="%s"'
+                        "relay=%s socks=%s status=%s error=%s"
                     ),
                     message.id,
                     recipient_email,
@@ -479,11 +480,7 @@ def send_message(message: models.Message, force_mta_out: bool = False):
                     relay,
                     proxy_host or "nil",
                     status,
-                    (error or "nil")
-                    .replace("\\", "\\\\")
-                    .replace('"', '\\"')
-                    .replace("\n", "\\n")
-                    .replace("\r", "\\r"),
+                    json.dumps(error or "nil"),
                 )
                 if delivered:
                     # TODO also update message.updated_at?

--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -468,7 +468,11 @@ def send_message(message: models.Message, force_mta_out: bool = False):
                 relay = smtp_host if not internal else "internal"
 
                 logger.info(
-                    'module=core.mda.outbound.send_message message_id=%s to=%s from=%s relay=%s socks=%s status=%s error="%s"',
+                    (
+                        "module=core.mda.outbound.send_message "
+                        "message_id=%s to=%s from=%s "
+                        'relay=%s socks=%s status=%s error="%s"'
+                    ),
                     message.id,
                     recipient_email,
                     message.sender.email,

--- a/src/backend/core/mda/smtp.py
+++ b/src/backend/core/mda/smtp.py
@@ -135,6 +135,7 @@ def send_smtp_mail(
                 "error": error,
                 "retry": retry,
                 "smtp_host": smtp_host,
+                "proxy_host": proxy_host,
             }
             for email in recipient_emails
         }
@@ -275,6 +276,7 @@ def send_smtp_mail(
                 "error": f"Recipient refused: {code_msg[0]} {code_msg[1]}",  # (code, msg)
                 "retry": 400 <= code_msg[0] <= 499,
                 "smtp_host": smtp_host,
+                "proxy_host": proxy_host,
             }
         return statuses
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -291,7 +293,11 @@ def send_smtp_mail(
 
     for recipient_email in recipient_emails:
         if recipient_email not in recipient_errors:
-            statuses[recipient_email] = {"delivered": True, "smtp_host": smtp_host}
+            statuses[recipient_email] = {
+                "delivered": True,
+                "smtp_host": smtp_host,
+                "proxy_host": proxy_host,
+            }
         else:
             code_msg = recipient_errors[recipient_email]
             statuses[recipient_email] = {
@@ -299,6 +305,7 @@ def send_smtp_mail(
                 "error": f"Recipient refused: {code_msg[0]} {code_msg[1]}",  # (code, msg)
                 "retry": 400 <= code_msg[0] <= 499,
                 "smtp_host": smtp_host,
+                "proxy_host": proxy_host,
             }
 
     return statuses


### PR DESCRIPTION
## Purpose
- Fix error formatting in mda logs
- Add proxy host in error / succes log



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Per-recipient delivery statuses now include proxy host information so each recipient’s status carries associated proxy details.
  * Delivery logging updated to record explicit proxy/socks info and consistently escape error text for clearer, machine-parsable diagnostics.
  * Reporting standardized so proxy host is present across all SMTP delivery outcomes (delivered, failed, retry).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->