### PR TITLE
✨(inbound) add configurable inbound auth backends

### DIFF
--- a/src/backend/core/api/viewsets/inbound/mta.py
+++ b/src/backend/core/api/viewsets/inbound/mta.py
@@ -17,7 +17,7 @@ from rest_framework.response import Response
 
 from core import models
 from core.mda.inbound import check_local_recipients, deliver_inbound_message
-from core.mda.rfc5322 import EmailParseError, parse_email_message
+from core.mda.rfc5322 import EmailParseError, parse_email_message, remove_mime_headers
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +159,11 @@ class InboundMTAViewSet(viewsets.GenericViewSet):
             len(raw_data),
             mta_metadata["original_recipients"],  # Log all intended recipients
         )
+
+        # Drop any sender-supplied X-StMsg-* headers so only values we prepend
+        # further down the pipeline (sender-auth verdict, widget-referer, ...)
+        # are visible to storage and the frontend.
+        raw_data = remove_mime_headers(raw_data, prefixes=["x-stmsg-"])
 
         def sanitize_header(header: str) -> str:
             return header.replace("\r", "").replace("\n", "")[0:255]

--- a/src/backend/core/api/viewsets/thread_access.py
+++ b/src/backend/core/api/viewsets/thread_access.py
@@ -68,19 +68,23 @@ class ThreadAccessViewSet(
 
     @transaction.atomic
     def perform_destroy(self, instance):
-        """Prevent deletion of the last editor access on a thread."""
+        """Prevent deletion of the last editor access on a thread.
+
+        Locks every editor row for the thread (including the one being
+        deleted) with FOR UPDATE in id order so concurrent deletions acquire
+        locks in the same sequence and cannot deadlock.
+        """
         if instance.role == enums.ThreadAccessRoleChoices.EDITOR:
-            # Evaluate the queryset to actually acquire FOR UPDATE locks;
-            # .count() generates SELECT COUNT(*) which drops FOR UPDATE.
             editor_ids = list(
                 models.ThreadAccess.objects.select_for_update()
                 .filter(
                     thread=instance.thread,
                     role=enums.ThreadAccessRoleChoices.EDITOR,
                 )
+                .order_by("id")
                 .values_list("id", flat=True)
             )
-            if len(editor_ids) <= 1:
+            if editor_ids == [instance.id]:
                 raise ValidationError(
                     "Cannot delete the last editor access of a thread."
                 )

--- a/src/backend/core/mda/inbound_auth.py
+++ b/src/backend/core/mda/inbound_auth.py
@@ -1,0 +1,182 @@
+"""Inbound sender authentication checks (DKIM / DMARC).
+
+The check is binary: if the message doesn't clear sender authentication, the
+caller prepends `X-StMsg-Sender-Auth: none` so the frontend surfaces an
+"unverified sender" warning.
+
+Rules applied for every backend:
+  - DKIM must be present AND pass.
+  - If DMARC is present, it must pass.
+
+The backend is picked by ``SPAM_CONFIG["inbound_auth"]``:
+  - ``"native"``: verify DKIM locally (crypto + DNS). DMARC is not yet
+    implemented for native, so only the DKIM rule applies.
+  - ``"rspamd"``: read DKIM / DMARC symbols from the rspamd /checkv2 result
+    (reused from the spam check, or fetched on demand by the caller).
+  - ``"authentication-results"``: parse ``dkim=`` / ``dmarc=`` entries from the
+    ``Authentication-Results`` header set by a trusted upstream relay. The
+    header slice respects ``SPAM_CONFIG["trusted_relays"]`` so forged headers
+    from untrusted hops are ignored.
+  - missing / ``None``: disabled, always returns False.
+
+Backend failures (DNS lookup blowing up, rspamd unreachable, no AR header from
+any trusted relay) are treated as "cannot verify" and flag the message — we
+never claim a sender is verified without positive evidence.
+"""
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from core.mda.signing import verify_message_dkim
+
+logger = logging.getLogger(__name__)
+
+
+_PASS = "pass"
+_FAIL = "fail"
+_NONE = "none"  # explicitly no signature / policy
+
+
+# Rspamd symbol names -> outcome, per check type.
+# https://rspamd.com/doc/modules/dkim.html / dmarc
+_RSPAMD_SYMBOLS: Dict[str, Dict[str, str]] = {
+    "dkim": {
+        "R_DKIM_ALLOW": _PASS,
+        "R_DKIM_REJECT": _FAIL,
+        "R_DKIM_PERMFAIL": _FAIL,
+        "R_DKIM_TEMPFAIL": _FAIL,
+        "DKIM_INVALID": _FAIL,
+        "R_DKIM_NA": _NONE,
+        "DKIM_NA": _NONE,
+    },
+    "dmarc": {
+        "DMARC_POLICY_ALLOW": _PASS,
+        "DMARC_POLICY_REJECT": _FAIL,
+        "DMARC_POLICY_QUARANTINE": _FAIL,
+        "DMARC_BAD_POLICY": _FAIL,
+        "DMARC_NA": _NONE,
+    },
+}
+
+
+# Matches `dkim=pass`, `dmarc=fail`, etc. in an Authentication-Results header.
+_AR_METHOD_RE = re.compile(
+    r"\b(?P<method>dkim|dmarc)\s*=\s*(?P<result>[a-zA-Z]+)",
+    re.IGNORECASE,
+)
+
+_AR_PASS = {"pass"}
+_AR_FAIL = {"fail", "softfail", "permerror", "temperror", "policy"}
+_AR_NONE = {"none", "neutral"}
+
+
+def _rspamd_outcome(
+    check: str, rspamd_result: Optional[Dict[str, Any]]
+) -> Optional[str]:
+    if not rspamd_result:
+        return None
+    symbols = rspamd_result.get("symbols") or {}
+    if not isinstance(symbols, dict):
+        return None
+    mapping = _RSPAMD_SYMBOLS.get(check, {})
+    outcome: Optional[str] = None
+    for symbol, result in mapping.items():
+        if symbol not in symbols:
+            continue
+        # fail dominates pass dominates none.
+        if result == _FAIL:
+            return _FAIL
+        if result == _PASS:
+            outcome = _PASS
+        elif outcome is None:
+            outcome = result
+    return outcome
+
+
+def _authentication_results_values(
+    parsed_email: Dict[str, Any], trusted_relays: int
+) -> List[str]:
+    """Collect Authentication-Results header values from trusted header blocks.
+
+    Block 0 is what we (or our MTA) prepended; blocks 1..N are upstream relays
+    (most recent first). Anything past ``trusted_relays`` is ignored.
+    """
+    blocks = parsed_email.get("headers_blocks") or []
+    blocks_to_check = trusted_relays + 1
+    values: List[str] = []
+    for block in blocks[:blocks_to_check]:
+        ar = block.get("authentication-results")
+        if not ar:
+            continue
+        if isinstance(ar, list):
+            values.extend(str(v) for v in ar)
+        else:
+            values.append(str(ar))
+    return values
+
+
+def _ar_outcome(check: str, ar_values: List[str]) -> Optional[str]:
+    if not ar_values:
+        return None
+    found = False
+    outcome: Optional[str] = None
+    for value in ar_values:
+        for match in _AR_METHOD_RE.finditer(value):
+            if match.group("method").lower() != check:
+                continue
+            found = True
+            result = match.group("result").lower()
+            if result in _AR_FAIL:
+                return _FAIL
+            if result in _AR_PASS:
+                outcome = _PASS
+            elif result in _AR_NONE and outcome is None:
+                outcome = _NONE
+    return outcome if found else None
+
+
+def _native_dkim_outcome(raw_data: bytes) -> Optional[str]:
+    try:
+        return _PASS if verify_message_dkim(raw_data) else _FAIL
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.warning("Native DKIM verification errored: %s", e)
+        return None
+
+
+def check_inbound_authentication(
+    raw_data: bytes,
+    parsed_email: Dict[str, Any],
+    spam_config: Dict[str, Any],
+    rspamd_result: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return True when the message should be flagged as unverified.
+
+    See module docstring for the rule set and supported backends.
+    """
+    mode = (spam_config.get("inbound_auth") or "").strip().lower() or None
+    if not mode:
+        return False
+
+    if mode == "native":
+        dkim = _native_dkim_outcome(raw_data)
+        dmarc: Optional[str] = None
+    elif mode == "rspamd":
+        dkim = _rspamd_outcome("dkim", rspamd_result)
+        dmarc = _rspamd_outcome("dmarc", rspamd_result)
+    elif mode == "authentication-results":
+        trusted_relays = int(spam_config.get("trusted_relays", 1))
+        ar_values = _authentication_results_values(parsed_email, trusted_relays)
+        dkim = _ar_outcome("dkim", ar_values)
+        dmarc = _ar_outcome("dmarc", ar_values)
+    else:
+        logger.warning("Unknown inbound_auth mode: %s", mode)
+        return False
+
+    logger.info("Inbound auth: mode=%s dkim=%s dmarc=%s", mode, dkim, dmarc)
+
+    if dkim != _PASS:
+        return True
+    if dmarc == _FAIL:
+        return True
+    return False

--- a/src/backend/core/mda/inbound_auth.py
+++ b/src/backend/core/mda/inbound_auth.py
@@ -39,7 +39,7 @@ from core.mda.signing import verify_message_dkim
 logger = logging.getLogger(__name__)
 
 
-_PASS = "pass"
+_PASS = "pass"  # noqa: S105 (auth-result token, not a password)
 _FAIL = "fail"
 _NONE = "none"  # explicitly no signature / policy
 
@@ -66,15 +66,35 @@ _RSPAMD_SYMBOLS: Dict[str, Dict[str, str]] = {
 }
 
 
-# Matches `dkim=pass`, `dmarc=fail`, etc. in an Authentication-Results header.
+# Matches `dkim=pass`, `dmarc=fail`, etc. in an Authentication-Results header
+# value, after CFWS comments and quoted strings have been scrubbed. The leading
+# (^|(?<=[\s;])) requires the method token to start at the beginning of the
+# value or right after whitespace/`;` — RFC 8601's only legitimate token
+# separators — so labels like `x-dkim=fail` or `arc.dkim=pass` are not
+# mistaken for a bare `dkim=` token.
 _AR_METHOD_RE = re.compile(
-    r"\b(?P<method>dkim|dmarc)\s*=\s*(?P<result>[a-zA-Z]+)",
+    r"(?:^|(?<=[\s;]))(?P<method>dkim|dmarc)\s*=\s*(?P<result>[a-zA-Z]+)",
     re.IGNORECASE,
 )
 
 _AR_PASS = {"pass"}
 _AR_FAIL = {"fail", "softfail", "permerror", "temperror", "policy"}
 _AR_NONE = {"none", "neutral"}
+
+
+# Aggressive scrubbers run before the method/result regex so attacker-controlled
+# free text inside a comment or quoted string can't masquerade as a real token.
+# An unmatched opener consumes through end-of-string (the trailing close is
+# optional in the pattern), which is the safe direction: prefer dropping
+# suspicious bytes over honouring them.
+_AR_COMMENT_RE = re.compile(r"\([^)]*\)?")
+_AR_QUOTED_STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"?')
+
+
+def _scrub_ar_value(value: str) -> str:
+    """Erase RFC 5322 comments and quoted-string contents from an AR value."""
+    value = _AR_COMMENT_RE.sub(" ", value)
+    return _AR_QUOTED_STRING_RE.sub(" ", value)
 
 
 def _rspamd_outcome(
@@ -128,7 +148,8 @@ def _ar_outcome(check: str, ar_values: List[str]) -> Optional[str]:
     found = False
     outcome: Optional[str] = None
     for value in ar_values:
-        for match in _AR_METHOD_RE.finditer(value):
+        scrubbed = _scrub_ar_value(value)
+        for match in _AR_METHOD_RE.finditer(scrubbed):
             if match.group("method").lower() != check:
                 continue
             found = True
@@ -154,6 +175,16 @@ VERDICT_UNVERIFIED = "none"
 VERDICT_FORGED = "fail"
 
 
+def get_inbound_auth_mode(spam_config: Dict[str, Any]) -> str:
+    """Return the normalized ``inbound_auth`` mode from a spam config.
+
+    Empty or missing values become an empty string. Callers can treat the
+    result with ``if not mode`` as "disabled" and compare directly against
+    the supported mode names.
+    """
+    return (spam_config.get("inbound_auth") or "").strip().lower()
+
+
 def check_inbound_authentication(
     raw_data: bytes,
     parsed_email: Dict[str, Any],
@@ -164,7 +195,7 @@ def check_inbound_authentication(
 
     See module docstring for the rule set and supported backends.
     """
-    mode = (spam_config.get("inbound_auth") or "").strip().lower() or None
+    mode = get_inbound_auth_mode(spam_config)
     if not mode:
         return None
 

--- a/src/backend/core/mda/inbound_auth.py
+++ b/src/backend/core/mda/inbound_auth.py
@@ -1,12 +1,17 @@
 """Inbound sender authentication checks (DKIM / DMARC).
 
-The check is binary: if the message doesn't clear sender authentication, the
-caller prepends `X-StMsg-Sender-Auth: none` so the frontend surfaces an
-"unverified sender" warning.
+Returns the verdict the caller should stamp as ``X-StMsg-Sender-Auth``:
+  - ``None``: verified, do not add the header.
+  - ``"none"``: cannot verify (missing DKIM, backend unreachable, no AR
+    header from a trusted relay). Frontend shows a yellow "unverified" hint.
+  - ``"fail"``: explicit forgery signal (DMARC fail). Frontend shows a red
+    "likely forged" warning — stronger than "none" because the sender's own
+    domain disavows the message.
 
 Rules applied for every backend:
-  - DKIM must be present AND pass.
-  - If DMARC is present, it must pass.
+  - DKIM must be present AND pass (else ``"none"``).
+  - If DMARC is present and fails, return ``"fail"`` — even if DKIM passes.
+  - If DMARC is absent or passes, DKIM alone decides.
 
 The backend is picked by ``SPAM_CONFIG["inbound_auth"]``:
   - ``"native"``: verify DKIM locally (crypto + DNS). DMARC is not yet
@@ -17,11 +22,12 @@ The backend is picked by ``SPAM_CONFIG["inbound_auth"]``:
     ``Authentication-Results`` header set by a trusted upstream relay. The
     header slice respects ``SPAM_CONFIG["trusted_relays"]`` so forged headers
     from untrusted hops are ignored.
-  - missing / ``None``: disabled, always returns False.
+  - missing / ``None``: disabled, always returns ``None``.
 
 Backend failures (DNS lookup blowing up, rspamd unreachable, no AR header from
-any trusted relay) are treated as "cannot verify" and flag the message — we
-never claim a sender is verified without positive evidence.
+any trusted relay) collapse to ``"none"`` — we never claim a sender is
+verified without positive evidence, but we also don't claim forgery without
+an explicit DMARC fail.
 """
 
 import logging
@@ -144,19 +150,23 @@ def _native_dkim_outcome(raw_data: bytes) -> Optional[str]:
         return None
 
 
+VERDICT_UNVERIFIED = "none"
+VERDICT_FORGED = "fail"
+
+
 def check_inbound_authentication(
     raw_data: bytes,
     parsed_email: Dict[str, Any],
     spam_config: Dict[str, Any],
     rspamd_result: Optional[Dict[str, Any]] = None,
-) -> bool:
-    """Return True when the message should be flagged as unverified.
+) -> Optional[str]:
+    """Return the ``X-StMsg-Sender-Auth`` verdict for this message.
 
     See module docstring for the rule set and supported backends.
     """
     mode = (spam_config.get("inbound_auth") or "").strip().lower() or None
     if not mode:
-        return False
+        return None
 
     if mode == "native":
         dkim = _native_dkim_outcome(raw_data)
@@ -171,12 +181,14 @@ def check_inbound_authentication(
         dmarc = _ar_outcome("dmarc", ar_values)
     else:
         logger.warning("Unknown inbound_auth mode: %s", mode)
-        return False
+        return None
 
     logger.info("Inbound auth: mode=%s dkim=%s dmarc=%s", mode, dkim, dmarc)
 
-    if dkim != _PASS:
-        return True
+    # DMARC fail is an explicit disavowal by the sender's domain — stronger
+    # signal than a missing DKIM, so it wins regardless of DKIM's state.
     if dmarc == _FAIL:
-        return True
-    return False
+        return VERDICT_FORGED
+    if dkim != _PASS:
+        return VERDICT_UNVERIFIED
+    return None

--- a/src/backend/core/mda/inbound_tasks.py
+++ b/src/backend/core/mda/inbound_tasks.py
@@ -13,7 +13,10 @@ import requests
 from celery.utils.log import get_task_logger
 
 from core import models
-from core.mda.inbound_auth import check_inbound_authentication
+from core.mda.inbound_auth import (
+    check_inbound_authentication,
+    get_inbound_auth_mode,
+)
 from core.mda.inbound_create import _create_message_from_inbound
 from core.mda.rfc5322 import parse_email_message
 
@@ -22,9 +25,7 @@ from messages.celery_app import app as celery_app
 logger = get_task_logger(__name__)
 
 
-def _is_selfcheck_message(
-    parsed_email: Dict[str, Any], recipient_email: str
-) -> bool:
+def _is_selfcheck_message(parsed_email: Dict[str, Any], recipient_email: str) -> bool:
     """Return True when this message is the self-check probe.
 
     Match is strict on both envelope ends: the From address must equal
@@ -275,22 +276,28 @@ def process_inbound_message_task(self, inbound_message_id: str):
         # Run inbound authentication checks (DKIM / DMARC). The verdict, if
         # any, is stamped as X-StMsg-Sender-Auth so the frontend can render
         # "unverified" (none) or "likely forged" (fail) warnings.
-        inbound_auth_mode = (spam_config.get("inbound_auth") or "").strip().lower()
-        if rspamd_result is None and inbound_auth_mode == "rspamd":
+        if rspamd_result is None and get_inbound_auth_mode(spam_config) == "rspamd":
             _, _, rspamd_result = _check_spam_with_rspamd(raw_data_bytes, spam_config)
         auth_verdict = check_inbound_authentication(
             raw_data_bytes, parsed_email, spam_config, rspamd_result
         )
         if auth_verdict:
-            raw_data_bytes = (
+            prepended = (
                 f"X-StMsg-Sender-Auth: {auth_verdict}\r\n".encode("ascii")
                 + raw_data_bytes
             )
             try:
-                parsed_email = parse_email_message(raw_data_bytes)
+                parsed_email = parse_email_message(prepended)
+                raw_data_bytes = prepended
             except Exception as e:  # pylint: disable=broad-exception-caught
+                # Keep raw_data_bytes / parsed_email in lockstep: if the
+                # re-parse breaks, store the original bytes so the blob stays
+                # parseable for display (subject/body/recipients). The
+                # sender-auth banner is sacrificed in this rare case.
                 logger.warning(
-                    "Failed to re-parse email after prepending auth header: %s", e
+                    "Failed to re-parse email after prepending auth header, "
+                    "dropping the prepend: %s",
+                    e,
                 )
 
         # Create the message using the extracted function

--- a/src/backend/core/mda/inbound_tasks.py
+++ b/src/backend/core/mda/inbound_tasks.py
@@ -272,18 +272,19 @@ def process_inbound_message_task(self, inbound_message_id: str):
                         spam_check_error,
                     )
 
-        # Run inbound authentication checks (DKIM / DMARC). A failure prepends
-        # X-StMsg-Sender-Auth: none so the frontend renders the "unverified
-        # sender" warning.
+        # Run inbound authentication checks (DKIM / DMARC). The verdict, if
+        # any, is stamped as X-StMsg-Sender-Auth so the frontend can render
+        # "unverified" (none) or "likely forged" (fail) warnings.
         inbound_auth_mode = (spam_config.get("inbound_auth") or "").strip().lower()
         if rspamd_result is None and inbound_auth_mode == "rspamd":
             _, _, rspamd_result = _check_spam_with_rspamd(raw_data_bytes, spam_config)
-        auth_failed = check_inbound_authentication(
+        auth_verdict = check_inbound_authentication(
             raw_data_bytes, parsed_email, spam_config, rspamd_result
         )
-        if auth_failed:
+        if auth_verdict:
             raw_data_bytes = (
-                b"X-StMsg-Sender-Auth: none\r\n" + raw_data_bytes
+                f"X-StMsg-Sender-Auth: {auth_verdict}\r\n".encode("ascii")
+                + raw_data_bytes
             )
             try:
                 parsed_email = parse_email_message(raw_data_bytes)

--- a/src/backend/core/mda/inbound_tasks.py
+++ b/src/backend/core/mda/inbound_tasks.py
@@ -5,6 +5,7 @@
 import re
 from typing import Any, Dict, Optional, Tuple
 
+from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -12,12 +13,34 @@ import requests
 from celery.utils.log import get_task_logger
 
 from core import models
+from core.mda.inbound_auth import check_inbound_authentication
 from core.mda.inbound_create import _create_message_from_inbound
 from core.mda.rfc5322 import parse_email_message
 
 from messages.celery_app import app as celery_app
 
 logger = get_task_logger(__name__)
+
+
+def _is_selfcheck_message(
+    parsed_email: Dict[str, Any], recipient_email: str
+) -> bool:
+    """Return True when this message is the self-check probe.
+
+    Match is strict on both envelope ends: the From address must equal
+    MESSAGES_SELFCHECK_FROM and the recipient must equal MESSAGES_SELFCHECK_TO.
+    """
+    selfcheck_from = (settings.MESSAGES_SELFCHECK_FROM or "").strip().lower()
+    selfcheck_to = (settings.MESSAGES_SELFCHECK_TO or "").strip().lower()
+
+    if not selfcheck_from or not selfcheck_to:
+        return False
+
+    from_email = ((parsed_email.get("from") or {}).get("email") or "").strip().lower()
+    if from_email != selfcheck_from:
+        return False
+
+    return (recipient_email or "").strip().lower() == selfcheck_to
 
 
 def _check_spam_with_hardcoded_rules(
@@ -108,7 +131,7 @@ def _check_spam_with_hardcoded_rules(
 
 def _check_spam_with_rspamd(
     raw_data: bytes, spam_config: Dict[str, Any]
-) -> Tuple[bool, Optional[str]]:
+) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
     """Check if a message is spam using rspamd.
 
     Args:
@@ -116,14 +139,16 @@ def _check_spam_with_rspamd(
         spam_config: Spam configuration
 
     Returns:
-        Tuple of (is_spam, error_message). error_message is None on success.
+        Tuple of (is_spam, error_message, rspamd_result). error_message is None on
+        success. rspamd_result is the full parsed JSON response when available, so
+        other inspectors (e.g. inbound auth) can reuse symbols without re-querying.
     """
 
     spam_url = spam_config.get("rspamd_url")
     if not spam_url:
         # If rspamd is not configured, treat all messages as not spam
         logger.debug("SPAM_CONFIG.rspamd_url not configured, skipping spam check")
-        return False, None
+        return False, None, None
 
     try:
         headers = {"Content-Type": "message/rfc822"}
@@ -156,15 +181,15 @@ def _check_spam_with_rspamd(
             is_spam,
         )
 
-        return is_spam, None
+        return is_spam, None, result
 
     except requests.exceptions.RequestException as e:
         logger.exception("Error checking spam with rspamd: %s", e)
         # On error, treat as not spam to avoid blocking legitimate messages
-        return False, str(e)
+        return False, str(e), None
     except Exception as e:
         logger.exception("Unexpected error checking spam with rspamd: %s", e)
-        return False, str(e)
+        return False, str(e), None
 
 
 @celery_app.task(bind=True)
@@ -225,19 +250,46 @@ def process_inbound_message_task(self, inbound_message_id: str):
         # Get spam config from maildomain (includes global settings + domain-specific overrides)
         spam_config = mailbox.domain.get_spam_config()
 
-        # If we have hardcoded rules, check them sequentially
-        is_spam = _check_spam_with_hardcoded_rules(parsed_email, spam_config)
-
-        # If no rules matched, check with rspamd
-        if is_spam is None:
-            is_spam, spam_check_error = _check_spam_with_rspamd(
-                raw_data_bytes, spam_config
+        rspamd_result: Optional[Dict[str, Any]] = None
+        if _is_selfcheck_message(parsed_email, recipient_email):
+            logger.debug(
+                "Bypassing spam checks for selfcheck message %s", inbound_message_id
             )
-            if spam_check_error:
+            is_spam = False
+        else:
+            # If we have hardcoded rules, check them sequentially
+            is_spam = _check_spam_with_hardcoded_rules(parsed_email, spam_config)
+
+            # If no rules matched, check with rspamd
+            if is_spam is None:
+                is_spam, spam_check_error, rspamd_result = _check_spam_with_rspamd(
+                    raw_data_bytes, spam_config
+                )
+                if spam_check_error:
+                    logger.warning(
+                        "Spam check error for inbound message %s: %s (treating as not spam)",
+                        inbound_message_id,
+                        spam_check_error,
+                    )
+
+        # Run inbound authentication checks (DKIM / DMARC). A failure prepends
+        # X-StMsg-Sender-Auth: none so the frontend renders the "unverified
+        # sender" warning.
+        inbound_auth_mode = (spam_config.get("inbound_auth") or "").strip().lower()
+        if rspamd_result is None and inbound_auth_mode == "rspamd":
+            _, _, rspamd_result = _check_spam_with_rspamd(raw_data_bytes, spam_config)
+        auth_failed = check_inbound_authentication(
+            raw_data_bytes, parsed_email, spam_config, rspamd_result
+        )
+        if auth_failed:
+            raw_data_bytes = (
+                b"X-StMsg-Sender-Auth: none\r\n" + raw_data_bytes
+            )
+            try:
+                parsed_email = parse_email_message(raw_data_bytes)
+            except Exception as e:  # pylint: disable=broad-exception-caught
                 logger.warning(
-                    "Spam check error for inbound message %s: %s (treating as not spam)",
-                    inbound_message_id,
-                    spam_check_error,
+                    "Failed to re-parse email after prepending auth header: %s", e
                 )
 
         # Create the message using the extracted function

--- a/src/backend/core/mda/rfc5322/__init__.py
+++ b/src/backend/core/mda/rfc5322/__init__.py
@@ -21,7 +21,11 @@ from .parser import (
     parse_email_addresses,
     parse_email_message,
 )
-from .utils import extract_base64_images_from_html, extract_base64_images_from_text
+from .utils import (
+    extract_base64_images_from_html,
+    extract_base64_images_from_text,
+    remove_mime_headers,
+)
 
 __all__ = [
     # Parser functions
@@ -41,4 +45,5 @@ __all__ = [
     # Utility functions
     "extract_base64_images_from_html",
     "extract_base64_images_from_text",
+    "remove_mime_headers",
 ]

--- a/src/backend/core/mda/rfc5322/utils.py
+++ b/src/backend/core/mda/rfc5322/utils.py
@@ -121,6 +121,65 @@ def extract_base64_images_from_text(
     return stripped_text, images
 
 
+def remove_mime_headers(
+    raw_email: bytes,
+    *,
+    prefixes: typing.Iterable[str] = (),
+    names: typing.Iterable[str] = (),
+) -> bytes:
+    """Remove headers from the head section of a raw MIME message.
+
+    A header is dropped when its name (case-insensitive, ASCII) either equals
+    one of *names* or starts with one of *prefixes*. RFC 5322 §2.2.3 folded
+    continuation lines (lines beginning with SP or HTAB) are dropped along
+    with the header they continue.
+
+    Operates on the head as raw bytes split at the first blank line; the
+    body and the bytes of every retained header are left byte-identical.
+    DKIM body hashing is unaffected, and signed headers we keep are not
+    refolded or re-encoded.
+
+    Returns the input unchanged when nothing matched.
+    """
+    name_set = {n.lower().encode("ascii") for n in names}
+    prefix_tuple = tuple(p.lower().encode("ascii") for p in prefixes)
+    if not name_set and not prefix_tuple:
+        return raw_email
+
+    split = raw_email.find(b"\r\n\r\n")
+    if split < 0:
+        split = raw_email.find(b"\n\n")
+    if split < 0:
+        head, body = raw_email, b""
+    else:
+        head, body = raw_email[:split], raw_email[split:]
+
+    out: list[bytes] = []
+    dropping = False
+    for line in head.splitlines(keepends=True):
+        if line[:1] in (b" ", b"\t"):
+            if not dropping:
+                out.append(line)
+            continue
+        name, sep, _ = line.partition(b":")
+        if not sep:
+            # Malformed line — preserve and stop any in-progress drop.
+            dropping = False
+            out.append(line)
+            continue
+        name_lc = name.lower()
+        if name_lc in name_set or (prefix_tuple and name_lc.startswith(prefix_tuple)):
+            dropping = True
+            continue
+        dropping = False
+        out.append(line)
+
+    cleaned = b"".join(out)
+    if cleaned == head:
+        return raw_email
+    return cleaned + body
+
+
 def extract_base64_images_from_html(
     html: str,
     known_images: dict[str, str] | None = None,

--- a/src/backend/core/tests/mda/test_inbound_auth.py
+++ b/src/backend/core/tests/mda/test_inbound_auth.py
@@ -1,0 +1,440 @@
+"""Tests for inbound sender authentication checks (DKIM / DMARC)."""
+
+from unittest.mock import Mock, patch
+
+from django.test import override_settings
+
+import pytest
+
+from core import factories, models
+from core.mda.inbound_auth import check_inbound_authentication
+from core.mda.inbound_tasks import process_inbound_message_task
+from core.mda.rfc5322 import parse_email_message
+
+
+RAW_EMAIL = (
+    b"From: sender@example.com\r\n"
+    b"To: rcpt@example.com\r\n"
+    b"Subject: Test\r\n"
+    b"Message-ID: <abc@example.com>\r\n"
+    b"\r\n"
+    b"Body\r\n"
+)
+
+
+class TestCheckInboundAuthenticationDisabled:
+    """When inbound_auth is absent or empty the check is a no-op."""
+
+    def test_missing_key_returns_false(self):
+        assert check_inbound_authentication(RAW_EMAIL, {}, {}) is False
+
+    def test_none_value_returns_false(self):
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": None})
+            is False
+        )
+
+    def test_empty_string_returns_false(self):
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": ""})
+            is False
+        )
+
+    def test_unknown_mode_returns_false(self):
+        """An unrecognised mode is treated as disabled (with a log warning)."""
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": "wat"})
+            is False
+        )
+
+
+class TestCheckInboundAuthenticationNative:
+    """Native mode verifies DKIM locally and ignores DMARC."""
+
+    @patch("core.mda.inbound_auth.verify_message_dkim")
+    def test_dkim_pass(self, mock_verify):
+        mock_verify.return_value = True
+        config = {"inbound_auth": "native"}
+        assert check_inbound_authentication(RAW_EMAIL, {}, config) is False
+
+    @patch("core.mda.inbound_auth.verify_message_dkim")
+    def test_dkim_fail(self, mock_verify):
+        mock_verify.return_value = False
+        config = {"inbound_auth": "native"}
+        assert check_inbound_authentication(RAW_EMAIL, {}, config) is True
+
+    @patch("core.mda.inbound_auth.verify_message_dkim")
+    def test_dkim_error_flags(self, mock_verify):
+        """Transient errors -> can't verify -> flag (fail-closed)."""
+        mock_verify.side_effect = RuntimeError("dns broken")
+        config = {"inbound_auth": "native"}
+        assert check_inbound_authentication(RAW_EMAIL, {}, config) is True
+
+    @patch("core.mda.inbound_auth.verify_message_dkim")
+    def test_dmarc_header_ignored(self, mock_verify):
+        """Native doesn't look at DMARC; passing DKIM alone is enough."""
+        mock_verify.return_value = True
+        parsed = {
+            "headers_blocks": [
+                {"authentication-results": ["mx; dmarc=fail"]}
+            ]
+        }
+        config = {"inbound_auth": "native"}
+        assert check_inbound_authentication(RAW_EMAIL, parsed, config) is False
+
+    @patch("core.mda.inbound_auth.verify_message_dkim")
+    def test_dmarc_rspamd_ignored(self, mock_verify):
+        """Native ignores any rspamd_result that was passed in."""
+        mock_verify.return_value = True
+        rspamd = {"symbols": {"DMARC_POLICY_REJECT": {"score": 5}}}
+        config = {"inbound_auth": "native"}
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is False
+        )
+
+
+class TestCheckInboundAuthenticationRspamd:
+    """Rspamd mode reads DKIM/DMARC symbols from the /checkv2 response."""
+
+    def test_dkim_pass_no_dmarc(self):
+        config = {"inbound_auth": "rspamd"}
+        rspamd = {"symbols": {"R_DKIM_ALLOW": {"score": 0.1}}}
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is False
+        )
+
+    def test_dkim_pass_dmarc_pass(self):
+        config = {"inbound_auth": "rspamd"}
+        rspamd = {
+            "symbols": {
+                "R_DKIM_ALLOW": {"score": 0.1},
+                "DMARC_POLICY_ALLOW": {"score": 0.1},
+            }
+        }
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is False
+        )
+
+    def test_dkim_pass_dmarc_fail(self):
+        config = {"inbound_auth": "rspamd"}
+        rspamd = {
+            "symbols": {
+                "R_DKIM_ALLOW": {"score": 0.1},
+                "DMARC_POLICY_REJECT": {"score": 5},
+            }
+        }
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+        )
+
+    def test_dkim_pass_dmarc_quarantine(self):
+        config = {"inbound_auth": "rspamd"}
+        rspamd = {
+            "symbols": {
+                "R_DKIM_ALLOW": {"score": 0.1},
+                "DMARC_POLICY_QUARANTINE": {"score": 2},
+            }
+        }
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+        )
+
+    def test_dkim_pass_dmarc_na(self):
+        """DMARC_NA = no published policy -> no DMARC requirement -> accept."""
+        config = {"inbound_auth": "rspamd"}
+        rspamd = {
+            "symbols": {
+                "R_DKIM_ALLOW": {"score": 0.1},
+                "DMARC_NA": {"score": 0},
+            }
+        }
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is False
+        )
+
+    def test_dkim_fail(self):
+        config = {"inbound_auth": "rspamd"}
+        rspamd = {"symbols": {"R_DKIM_REJECT": {"score": 5}}}
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+        )
+
+    def test_dkim_missing(self):
+        """DKIM_NA means no DKIM-Signature header -> flag."""
+        config = {"inbound_auth": "rspamd"}
+        rspamd = {"symbols": {"DKIM_NA": {"score": 0}}}
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+        )
+
+    def test_dkim_fail_dominates_pass(self):
+        """Two DKIM symbols in one response: fail wins."""
+        config = {"inbound_auth": "rspamd"}
+        rspamd = {
+            "symbols": {
+                "R_DKIM_ALLOW": {"score": 0.1},
+                "R_DKIM_REJECT": {"score": 5},
+            }
+        }
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+        )
+
+    def test_no_rspamd_result_flags(self):
+        """Backend unavailable -> can't verify -> flag."""
+        config = {"inbound_auth": "rspamd"}
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, None) is True
+        )
+
+    def test_rspamd_result_without_symbols_flags(self):
+        """Response missing `symbols` key -> no evidence -> flag."""
+        config = {"inbound_auth": "rspamd"}
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, {}) is True
+        )
+
+
+class TestCheckInboundAuthenticationResults:
+    """`authentication-results` mode parses an upstream relay's AR header."""
+
+    @staticmethod
+    def _parsed(ar_values, trust_blocks=1):
+        blocks = []
+        for i in range(trust_blocks):
+            block = {}
+            if i < len(ar_values) and ar_values[i] is not None:
+                block["authentication-results"] = ar_values[i]
+            blocks.append(block)
+        return {"headers_blocks": blocks}
+
+    def test_dkim_pass_no_dmarc(self):
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed([["mx.example.net; dkim=pass"]])
+        assert check_inbound_authentication(b"", parsed, config) is False
+
+    def test_dkim_pass_dmarc_pass(self):
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed(
+            [["mx.example.net; dkim=pass; dmarc=pass"]]
+        )
+        assert check_inbound_authentication(b"", parsed, config) is False
+
+    def test_dkim_pass_dmarc_fail(self):
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed(
+            [["mx.example.net; dkim=pass; dmarc=fail"]]
+        )
+        assert check_inbound_authentication(b"", parsed, config) is True
+
+    def test_dkim_pass_dmarc_none(self):
+        """dmarc=none -> no policy -> don't require DMARC pass."""
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed(
+            [["mx.example.net; dkim=pass; dmarc=none"]]
+        )
+        assert check_inbound_authentication(b"", parsed, config) is False
+
+    def test_dkim_fail(self):
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed([["mx.example.net; dkim=fail"]])
+        assert check_inbound_authentication(b"", parsed, config) is True
+
+    def test_dkim_softfail_is_fail(self):
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed([["mx; dkim=softfail"]])
+        assert check_inbound_authentication(b"", parsed, config) is True
+
+    def test_dkim_none_is_flag(self):
+        """dkim=none (no signature) is not a pass -> flag."""
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed([["mx; dkim=none"]])
+        assert check_inbound_authentication(b"", parsed, config) is True
+
+    def test_header_absent_flags(self):
+        """No AR header anywhere -> can't verify -> flag."""
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = {"headers_blocks": [{}]}
+        assert check_inbound_authentication(b"", parsed, config) is True
+
+    def test_no_dkim_entry_flags(self):
+        """AR present but no dkim= entry -> unknown -> flag."""
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed([["mx; spf=pass"]])
+        assert check_inbound_authentication(b"", parsed, config) is True
+
+    def test_untrusted_block_ignored(self):
+        """trusted_relays=0 -> only block 0 (our MTA) is trusted."""
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 0}
+        parsed = {
+            "headers_blocks": [
+                {},  # block 0: no AR from us
+                {"authentication-results": ["mx; dkim=pass"]},  # untrusted
+            ]
+        }
+        assert check_inbound_authentication(b"", parsed, config) is True
+
+    def test_trusted_block_used(self):
+        """Default trusted_relays=1 -> block 1 is trusted."""
+        config = {"inbound_auth": "authentication-results"}
+        parsed = {
+            "headers_blocks": [
+                {},
+                {"authentication-results": ["mx; dkim=pass"]},
+            ]
+        }
+        assert check_inbound_authentication(b"", parsed, config) is False
+
+    def test_dkim_fail_dominates_pass_across_values(self):
+        """Multiple AR values in one block: fail wins over pass."""
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = self._parsed(
+            [["mx1; dkim=pass", "mx2; dkim=fail"]]
+        )
+        assert check_inbound_authentication(b"", parsed, config) is True
+
+    def test_single_string_ar_value(self):
+        """AR header may be a bare string (single occurrence) rather than list."""
+        config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+        parsed = {
+            "headers_blocks": [
+                {"authentication-results": "mx; dkim=pass"}
+            ]
+        }
+        assert check_inbound_authentication(b"", parsed, config) is False
+
+
+@pytest.mark.django_db
+class TestProcessInboundMessageAuthIntegration:
+    """End-to-end: a failing auth check prepends X-StMsg-Sender-Auth: none."""
+
+    @override_settings(SPAM_CONFIG={"inbound_auth": "native"})
+    @patch("core.mda.inbound_tasks.check_inbound_authentication")
+    @patch("core.mda.inbound_tasks._create_message_from_inbound")
+    def test_failed_auth_injects_header(
+        self, mock_create_message, mock_auth_check
+    ):
+        mailbox = factories.MailboxFactory()
+        inbound_message = models.InboundMessage.objects.create(
+            mailbox=mailbox,
+            raw_data=RAW_EMAIL,
+        )
+        mock_auth_check.return_value = True
+        mock_create_message.return_value = True
+
+        with patch.object(process_inbound_message_task, "update_state", Mock()):
+            process_inbound_message_task.run(str(inbound_message.id))
+
+        assert mock_create_message.called
+        call_kwargs = mock_create_message.call_args[1]
+        assert call_kwargs["raw_data"].startswith(b"X-StMsg-Sender-Auth: none\r\n")
+        parsed = call_kwargs["parsed_email"]
+        assert parsed["headers"].get("x-stmsg-sender-auth") == "none"
+
+    @override_settings(SPAM_CONFIG={"inbound_auth": "native"})
+    @patch("core.mda.inbound_tasks.check_inbound_authentication")
+    @patch("core.mda.inbound_tasks._create_message_from_inbound")
+    def test_passing_auth_does_not_inject_header(
+        self, mock_create_message, mock_auth_check
+    ):
+        mailbox = factories.MailboxFactory()
+        inbound_message = models.InboundMessage.objects.create(
+            mailbox=mailbox,
+            raw_data=RAW_EMAIL,
+        )
+        mock_auth_check.return_value = False
+        mock_create_message.return_value = True
+
+        with patch.object(process_inbound_message_task, "update_state", Mock()):
+            process_inbound_message_task.run(str(inbound_message.id))
+
+        call_kwargs = mock_create_message.call_args[1]
+        assert not call_kwargs["raw_data"].startswith(b"X-StMsg-Sender-Auth")
+
+    @override_settings(
+        SPAM_CONFIG={
+            "rspamd_url": "http://rspamd:8010/_api",
+            "inbound_auth": "rspamd",
+        }
+    )
+    @patch("core.mda.inbound_tasks.requests.post")
+    @patch("core.mda.inbound_tasks._create_message_from_inbound")
+    def test_rspamd_response_reused_by_auth_check(
+        self, mock_create_message, mock_post
+    ):
+        """Single rspamd call feeds both spam and auth."""
+        mailbox = factories.MailboxFactory()
+        inbound_message = models.InboundMessage.objects.create(
+            mailbox=mailbox,
+            raw_data=RAW_EMAIL,
+        )
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "action": "no action",
+            "score": 1.0,
+            "required_score": 15.0,
+            "symbols": {"R_DKIM_REJECT": {"score": 5}},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+        mock_create_message.return_value = True
+
+        with patch.object(process_inbound_message_task, "update_state", Mock()):
+            process_inbound_message_task.run(str(inbound_message.id))
+
+        assert mock_post.call_count == 1
+        call_kwargs = mock_create_message.call_args[1]
+        assert call_kwargs["raw_data"].startswith(b"X-StMsg-Sender-Auth: none\r\n")
+
+    @override_settings(
+        SPAM_CONFIG={
+            "rspamd_url": "http://rspamd:8010/_api",
+            "inbound_auth": "rspamd",
+            "rules": [{"header_match": "X-Spam:yes", "action": "ham"}],
+        }
+    )
+    @patch("core.mda.inbound_tasks.requests.post")
+    @patch("core.mda.inbound_tasks._create_message_from_inbound")
+    def test_rspamd_fetched_on_demand_when_spam_skipped_rspamd(
+        self, mock_create_message, mock_post
+    ):
+        """Hardcoded spam rule short-circuits spam; rspamd still fetched for auth."""
+        mailbox = factories.MailboxFactory()
+        raw = b"X-Spam: yes\r\n" + RAW_EMAIL
+        inbound_message = models.InboundMessage.objects.create(
+            mailbox=mailbox,
+            raw_data=raw,
+        )
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "action": "no action",
+            "score": 1.0,
+            "required_score": 15.0,
+            "symbols": {"R_DKIM_ALLOW": {"score": 0.1}},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+        mock_create_message.return_value = True
+
+        with patch.object(process_inbound_message_task, "update_state", Mock()):
+            process_inbound_message_task.run(str(inbound_message.id))
+
+        assert mock_post.call_count == 1
+        call_kwargs = mock_create_message.call_args[1]
+        assert not call_kwargs["raw_data"].startswith(b"X-StMsg-Sender-Auth")
+
+    def test_maildomain_override(self):
+        """custom_settings.SPAM_CONFIG overrides the global default."""
+        maildomain = factories.MailDomainFactory(
+            custom_settings={
+                "SPAM_CONFIG": {"inbound_auth": "rspamd"},
+            }
+        )
+        config = maildomain.get_spam_config()
+        assert config.get("inbound_auth") == "rspamd"
+
+    def test_header_injection_propagates_to_stmsg(self):
+        """After prepending, the parser exposes the header via x-stmsg-*."""
+        tagged = b"X-StMsg-Sender-Auth: none\r\n" + RAW_EMAIL
+        parsed = parse_email_message(tagged)
+        assert parsed["headers"].get("x-stmsg-sender-auth") == "none"

--- a/src/backend/core/tests/mda/test_inbound_auth.py
+++ b/src/backend/core/tests/mda/test_inbound_auth.py
@@ -1,5 +1,7 @@
 """Tests for inbound sender authentication checks (DKIM / DMARC)."""
 
+# pylint: disable=missing-function-docstring,too-many-public-methods
+
 from unittest.mock import Mock, patch
 
 from django.test import override_settings
@@ -14,7 +16,6 @@ from core.mda.inbound_auth import (
 )
 from core.mda.inbound_tasks import process_inbound_message_task
 from core.mda.rfc5322 import parse_email_message
-
 
 RAW_EMAIL = (
     b"From: sender@example.com\r\n"
@@ -34,21 +35,16 @@ class TestCheckInboundAuthenticationDisabled:
 
     def test_none_value_returns_none(self):
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": None})
-            is None
+            check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": None}) is None
         )
 
     def test_empty_string_returns_none(self):
-        assert (
-            check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": ""})
-            is None
-        )
+        assert check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": ""}) is None
 
     def test_unknown_mode_returns_none(self):
         """An unrecognised mode is treated as disabled (with a log warning)."""
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": "wat"})
-            is None
+            check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": "wat"}) is None
         )
 
 
@@ -65,30 +61,20 @@ class TestCheckInboundAuthenticationNative:
     def test_dkim_fail(self, mock_verify):
         mock_verify.return_value = False
         config = {"inbound_auth": "native"}
-        assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config)
-            == VERDICT_UNVERIFIED
-        )
+        assert check_inbound_authentication(RAW_EMAIL, {}, config) == VERDICT_UNVERIFIED
 
     @patch("core.mda.inbound_auth.verify_message_dkim")
     def test_dkim_error_unverified(self, mock_verify):
         """Transient errors -> cannot verify -> "none" (not forgery)."""
         mock_verify.side_effect = RuntimeError("dns broken")
         config = {"inbound_auth": "native"}
-        assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config)
-            == VERDICT_UNVERIFIED
-        )
+        assert check_inbound_authentication(RAW_EMAIL, {}, config) == VERDICT_UNVERIFIED
 
     @patch("core.mda.inbound_auth.verify_message_dkim")
     def test_dmarc_header_ignored(self, mock_verify):
         """Native doesn't look at DMARC; passing DKIM alone is enough."""
         mock_verify.return_value = True
-        parsed = {
-            "headers_blocks": [
-                {"authentication-results": ["mx; dmarc=fail"]}
-            ]
-        }
+        parsed = {"headers_blocks": [{"authentication-results": ["mx; dmarc=fail"]}]}
         config = {"inbound_auth": "native"}
         assert check_inbound_authentication(RAW_EMAIL, parsed, config) is None
 
@@ -98,9 +84,7 @@ class TestCheckInboundAuthenticationNative:
         mock_verify.return_value = True
         rspamd = {"symbols": {"DMARC_POLICY_REJECT": {"score": 5}}}
         config = {"inbound_auth": "native"}
-        assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
-        )
+        assert check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
 
 
 class TestCheckInboundAuthenticationRspamd:
@@ -109,9 +93,7 @@ class TestCheckInboundAuthenticationRspamd:
     def test_dkim_pass_no_dmarc(self):
         config = {"inbound_auth": "rspamd"}
         rspamd = {"symbols": {"R_DKIM_ALLOW": {"score": 0.1}}}
-        assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
-        )
+        assert check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
 
     def test_dkim_pass_dmarc_pass(self):
         config = {"inbound_auth": "rspamd"}
@@ -121,9 +103,7 @@ class TestCheckInboundAuthenticationRspamd:
                 "DMARC_POLICY_ALLOW": {"score": 0.1},
             }
         }
-        assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
-        )
+        assert check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
 
     def test_dkim_pass_dmarc_fail_forged(self):
         """DMARC fail on a message that otherwise has DKIM -> 'fail' (forgery)."""
@@ -162,9 +142,7 @@ class TestCheckInboundAuthenticationRspamd:
                 "DMARC_NA": {"score": 0},
             }
         }
-        assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
-        )
+        assert check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
 
     def test_dkim_fail(self):
         config = {"inbound_auth": "rspamd"}
@@ -248,70 +226,47 @@ class TestCheckInboundAuthenticationResults:
 
     def test_dkim_pass_dmarc_pass(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
-        parsed = self._parsed(
-            [["mx.example.net; dkim=pass; dmarc=pass"]]
-        )
+        parsed = self._parsed([["mx.example.net; dkim=pass; dmarc=pass"]])
         assert check_inbound_authentication(b"", parsed, config) is None
 
     def test_dkim_pass_dmarc_fail_forged(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
-        parsed = self._parsed(
-            [["mx.example.net; dkim=pass; dmarc=fail"]]
-        )
-        assert (
-            check_inbound_authentication(b"", parsed, config) == VERDICT_FORGED
-        )
+        parsed = self._parsed([["mx.example.net; dkim=pass; dmarc=fail"]])
+        assert check_inbound_authentication(b"", parsed, config) == VERDICT_FORGED
 
     def test_dkim_pass_dmarc_none(self):
         """dmarc=none -> no policy -> don't require DMARC pass."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
-        parsed = self._parsed(
-            [["mx.example.net; dkim=pass; dmarc=none"]]
-        )
+        parsed = self._parsed([["mx.example.net; dkim=pass; dmarc=none"]])
         assert check_inbound_authentication(b"", parsed, config) is None
 
     def test_dkim_fail(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx.example.net; dkim=fail"]])
-        assert (
-            check_inbound_authentication(b"", parsed, config)
-            == VERDICT_UNVERIFIED
-        )
+        assert check_inbound_authentication(b"", parsed, config) == VERDICT_UNVERIFIED
 
     def test_dkim_softfail_is_fail(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx; dkim=softfail"]])
-        assert (
-            check_inbound_authentication(b"", parsed, config)
-            == VERDICT_UNVERIFIED
-        )
+        assert check_inbound_authentication(b"", parsed, config) == VERDICT_UNVERIFIED
 
     def test_dkim_none_is_unverified(self):
         """dkim=none (no signature) is not a pass -> 'none'."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx; dkim=none"]])
-        assert (
-            check_inbound_authentication(b"", parsed, config)
-            == VERDICT_UNVERIFIED
-        )
+        assert check_inbound_authentication(b"", parsed, config) == VERDICT_UNVERIFIED
 
     def test_header_absent_unverified(self):
         """No AR header anywhere -> can't verify -> 'none'."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = {"headers_blocks": [{}]}
-        assert (
-            check_inbound_authentication(b"", parsed, config)
-            == VERDICT_UNVERIFIED
-        )
+        assert check_inbound_authentication(b"", parsed, config) == VERDICT_UNVERIFIED
 
     def test_no_dkim_entry_unverified(self):
         """AR present but no dkim= entry -> unknown -> 'none'."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx; spf=pass"]])
-        assert (
-            check_inbound_authentication(b"", parsed, config)
-            == VERDICT_UNVERIFIED
-        )
+        assert check_inbound_authentication(b"", parsed, config) == VERDICT_UNVERIFIED
 
     def test_untrusted_block_ignored(self):
         """trusted_relays=0 -> only block 0 (our MTA) is trusted."""
@@ -322,10 +277,7 @@ class TestCheckInboundAuthenticationResults:
                 {"authentication-results": ["mx; dkim=pass"]},  # untrusted
             ]
         }
-        assert (
-            check_inbound_authentication(b"", parsed, config)
-            == VERDICT_UNVERIFIED
-        )
+        assert check_inbound_authentication(b"", parsed, config) == VERDICT_UNVERIFIED
 
     def test_trusted_block_used(self):
         """Default trusted_relays=1 -> block 1 is trusted."""
@@ -341,23 +293,205 @@ class TestCheckInboundAuthenticationResults:
     def test_dkim_fail_dominates_pass_across_values(self):
         """Multiple AR values in one block: fail wins -> 'none'."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
-        parsed = self._parsed(
-            [["mx1; dkim=pass", "mx2; dkim=fail"]]
-        )
-        assert (
-            check_inbound_authentication(b"", parsed, config)
-            == VERDICT_UNVERIFIED
-        )
+        parsed = self._parsed([["mx1; dkim=pass", "mx2; dkim=fail"]])
+        assert check_inbound_authentication(b"", parsed, config) == VERDICT_UNVERIFIED
 
     def test_single_string_ar_value(self):
         """AR header may be a bare string (single occurrence) rather than list."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
-        parsed = {
-            "headers_blocks": [
-                {"authentication-results": "mx; dkim=pass"}
-            ]
-        }
+        parsed = {"headers_blocks": [{"authentication-results": "mx; dkim=pass"}]}
         assert check_inbound_authentication(b"", parsed, config) is None
+
+
+class TestCheckInboundAuthenticationResultsScrubbing:
+    """`dkim=`/`dmarc=` literals inside CFWS comments or quoted strings must
+    NOT be honoured — they're attacker-controlled free text."""
+
+    CONFIG = {"inbound_auth": "authentication-results", "trusted_relays": 1}
+
+    @staticmethod
+    def _parsed(ar_value):
+        return {"headers_blocks": [{"authentication-results": [ar_value]}]}
+
+    # --- Comments (parens) ---------------------------------------------
+
+    def test_comment_dkim_pass_does_not_satisfy(self):
+        """`(dkim=pass)` inside a comment is text, not a token."""
+        parsed = self._parsed("mx; spf=fail (dkim=pass attack)")
+        # No real dkim= → unverified.
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_comment_after_real_token_does_not_override(self):
+        """Real `dkim=fail` outside a comment still wins."""
+        parsed = self._parsed("mx; dkim=fail (reason: dkim=pass spoof)")
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_comment_dmarc_fail_does_not_force_forged(self):
+        """`(dmarc=fail)` inside a comment shouldn't escalate to 'fail'."""
+        parsed = self._parsed("mx; dkim=pass (note: dmarc=fail in some other domain)")
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) is None
+
+    def test_nested_comments_scrubbed(self):
+        """RFC 5322 comments may nest; the whole nested span is scrubbed."""
+        parsed = self._parsed("mx; spf=pass (outer (dkim=pass) trailing) ")
+        # No real dkim= token outside the comment.
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_real_token_after_comment_still_matched(self):
+        """A genuine token following a comment must still be parsed."""
+        parsed = self._parsed("mx (received from upstream); dkim=pass")
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) is None
+
+    # --- Quoted strings ------------------------------------------------
+
+    def test_quoted_dkim_pass_does_not_satisfy(self):
+        """`dkim=pass` inside a quoted string is just opaque text."""
+        parsed = self._parsed('mx; spf=pass smtp.mailfrom="bob (dkim=pass)"')
+        # spf is not in our rule set; no real dkim= → unverified.
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_quoted_string_with_escapes_scrubbed(self):
+        """Backslash-escaped quotes inside a quoted string don't end it."""
+        parsed = self._parsed('mx; spf=pass smtp.mailfrom="a\\"dkim=pass\\"b"')
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_real_token_after_quoted_string_still_matched(self):
+        """A real token after a quoted reason is still seen."""
+        parsed = self._parsed('mx; spf=fail smtp.mailfrom="weird value"; dkim=pass')
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) is None
+
+    # --- Mixed ---------------------------------------------------------
+
+    def test_quoted_inside_comment_scrubbed(self):
+        parsed = self._parsed('mx (a "dkim=pass" b); dkim=fail')
+        # Real token is dkim=fail.
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_unterminated_comment_does_not_explode(self):
+        """Malformed (unterminated) CFWS shouldn't crash the parser.
+
+        Real `dkim=pass` appears before the unterminated comment, so it's
+        still seen as a verified token; the comment swallows the rest of the
+        string but that has no other tokens to lose.
+        """
+        parsed = self._parsed("mx; dkim=pass (unterminated comment")
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) is None
+
+    def test_unterminated_comment_swallows_real_token(self):
+        """If the real token is INSIDE an unterminated comment, it's lost."""
+        parsed = self._parsed("mx; spf=pass (comment that never closes dkim=pass")
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_unterminated_quote_does_not_explode(self):
+        parsed = self._parsed('mx; dkim=pass "unterminated')
+        # Real dkim=pass token comes BEFORE the unterminated quote.
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) is None
+
+    # --- Token boundary --------------------------------------------------
+
+    def test_prefixed_label_not_matched(self):
+        """`x-dkim=fail` is its own label, not a bare `dkim=` token."""
+        parsed = self._parsed("mx; x-dkim=fail")
+        # No real dkim token → unverified.
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_dotted_label_not_matched(self):
+        """`arc.dkim=pass` is also a different label."""
+        parsed = self._parsed("mx; arc.dkim=pass")
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_underscore_label_not_matched(self):
+        parsed = self._parsed("mx; foo_dkim=pass")
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_label_with_real_token_after_separator(self):
+        """A spurious label first, then a real bare `dkim=`."""
+        parsed = self._parsed("mx; x-dkim=fail; dkim=pass")
+        # x-dkim=fail must not pollute; real dkim=pass wins → verified.
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) is None
+
+    def test_real_token_at_start_of_value(self):
+        """No leading separator — start-of-string still matches."""
+        parsed = self._parsed("dkim=pass")
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) is None
+
+    def test_realworld_multiline_ar_header_all_pass(self):
+        """A real Authentication-Results header (anonymized): dkim+spf+dmarc all pass.
+
+        Includes folded continuation lines, parenthesized comments containing
+        `domain of "..."` quoted strings with `=` signs, `header.b="..."`
+        quoted DKIM signatures, and `(policy=quarantine)` comments — all
+        prone to spoofing the simple regex if scrubbing isn't applied.
+        """
+        ar = (
+            "mx.example-relay.net;\r\n"
+            '    dkim=pass header.d=newsletter.example.com header.s=s1 header.b="aB/cDeFg";\r\n'
+            "    spf=pass (mx.example-relay.net: domain of "
+            '"bounces+12345-abcd-recipient=example.org@bounce.newsletter.example.com" '
+            "designates 192.0.2.10 as permitted sender) "
+            'smtp.mailfrom="bounces+12345-abcd-recipient=example.org@bounce.newsletter.example.com";\r\n'
+            "    dmarc=pass (policy=quarantine) header.from=example.com"
+        )
+        parsed = self._parsed(ar)
+        # dkim=pass real, dmarc=pass real → verified.
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) is None
+
+    def test_realworld_ar_header_dmarc_fail_still_detected(self):
+        """Same shape as above but dmarc fails — must surface as forgery."""
+        ar = (
+            "mx.example-relay.net;\r\n"
+            '    dkim=pass header.d=newsletter.example.com header.s=s1 header.b="aB/cDeFg";\r\n'
+            "    spf=pass (mx.example-relay.net: domain of "
+            '"bounces+12345@bounce.example.com" designates 192.0.2.10 as permitted sender) '
+            'smtp.mailfrom="bounces+12345@bounce.example.com";\r\n'
+            "    dmarc=fail (policy=reject) header.from=example.com"
+        )
+        parsed = self._parsed(ar)
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_FORGED
+
+    def test_realworld_ar_header_dkim_fail(self):
+        """Real-world shape with dkim=fail → unverified."""
+        ar = (
+            "mx.example-relay.net;\r\n"
+            '    dkim=fail header.d=newsletter.example.com header.s=s1 header.b="aB/cDeFg";\r\n'
+            "    spf=pass (mx.example-relay.net: domain of "
+            '"bounces+12345@bounce.example.com" designates 192.0.2.10 as permitted sender) '
+            'smtp.mailfrom="bounces+12345@bounce.example.com";\r\n'
+            "    dmarc=pass (policy=quarantine) header.from=example.com"
+        )
+        parsed = self._parsed(ar)
+        assert (
+            check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_UNVERIFIED
+        )
+
+    def test_dkim_pass_inside_comment_then_dmarc_fail_real(self):
+        """Combination: comment fakes dkim=pass; real dmarc=fail wins as 'fail'."""
+        parsed = self._parsed("mx; spf=pass (dkim=pass spoof); dmarc=fail")
+        # No real dkim= token; dmarc=fail real → 'fail' verdict.
+        # But our rules say: dkim must pass for verified; dmarc=fail forces
+        # 'fail' regardless. Since dkim isn't pass, but dmarc=fail dominates
+        # → return VERDICT_FORGED.
+        assert check_inbound_authentication(b"", parsed, self.CONFIG) == VERDICT_FORGED
 
 
 @pytest.mark.django_db
@@ -437,9 +571,7 @@ class TestProcessInboundMessageAuthIntegration:
     )
     @patch("core.mda.inbound_tasks.requests.post")
     @patch("core.mda.inbound_tasks._create_message_from_inbound")
-    def test_rspamd_response_reused_by_auth_check(
-        self, mock_create_message, mock_post
-    ):
+    def test_rspamd_response_reused_by_auth_check(self, mock_create_message, mock_post):
         """Single rspamd call feeds both spam and auth."""
         mailbox = factories.MailboxFactory()
         inbound_message = models.InboundMessage.objects.create(
@@ -552,3 +684,41 @@ class TestProcessInboundMessageAuthIntegration:
         tagged = b"X-StMsg-Sender-Auth: fail\r\n" + RAW_EMAIL
         parsed = parse_email_message(tagged)
         assert parsed["headers"].get("x-stmsg-sender-auth") == "fail"
+
+    @override_settings(SPAM_CONFIG={"inbound_auth": "native"})
+    @patch("core.mda.inbound_tasks.parse_email_message")
+    @patch("core.mda.inbound_tasks.check_inbound_authentication")
+    @patch("core.mda.inbound_tasks._create_message_from_inbound")
+    def test_reparse_failure_after_prepend_keeps_views_in_sync(
+        self, mock_create_message, mock_auth_check, mock_parse
+    ):
+        """If re-parsing the prepended bytes blows up, the prepend is dropped.
+
+        Otherwise raw_data (with the new header) and parsed_email (without it)
+        diverge, and `Message.get_parsed_data()` later returns {} for the
+        whole message because the same bytes fail to parse at display time.
+        """
+        # First call: initial parse succeeds. Second: re-parse after prepend fails.
+        original_parsed = {
+            "headers": {"from": "a@b"},
+            "headers_blocks": [{}],
+            "from": {"email": "a@b"},
+        }
+        mock_parse.side_effect = [original_parsed, RuntimeError("flanker exploded")]
+        mock_auth_check.return_value = VERDICT_UNVERIFIED
+        mock_create_message.return_value = True
+
+        mailbox = factories.MailboxFactory()
+        inbound_message = models.InboundMessage.objects.create(
+            mailbox=mailbox,
+            raw_data=RAW_EMAIL,
+        )
+
+        with patch.object(process_inbound_message_task, "update_state", Mock()):
+            process_inbound_message_task.run(str(inbound_message.id))
+
+        call_kwargs = mock_create_message.call_args[1]
+        # Prepend was reverted: raw_data is the original bytes.
+        assert call_kwargs["raw_data"] == RAW_EMAIL
+        # parsed_email is the original parse, also without the header.
+        assert call_kwargs["parsed_email"] is original_parsed

--- a/src/backend/core/tests/mda/test_inbound_auth.py
+++ b/src/backend/core/tests/mda/test_inbound_auth.py
@@ -7,7 +7,11 @@ from django.test import override_settings
 import pytest
 
 from core import factories, models
-from core.mda.inbound_auth import check_inbound_authentication
+from core.mda.inbound_auth import (
+    VERDICT_FORGED,
+    VERDICT_UNVERIFIED,
+    check_inbound_authentication,
+)
 from core.mda.inbound_tasks import process_inbound_message_task
 from core.mda.rfc5322 import parse_email_message
 
@@ -25,26 +29,26 @@ RAW_EMAIL = (
 class TestCheckInboundAuthenticationDisabled:
     """When inbound_auth is absent or empty the check is a no-op."""
 
-    def test_missing_key_returns_false(self):
-        assert check_inbound_authentication(RAW_EMAIL, {}, {}) is False
+    def test_missing_key_returns_none(self):
+        assert check_inbound_authentication(RAW_EMAIL, {}, {}) is None
 
-    def test_none_value_returns_false(self):
+    def test_none_value_returns_none(self):
         assert (
             check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": None})
-            is False
+            is None
         )
 
-    def test_empty_string_returns_false(self):
+    def test_empty_string_returns_none(self):
         assert (
             check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": ""})
-            is False
+            is None
         )
 
-    def test_unknown_mode_returns_false(self):
+    def test_unknown_mode_returns_none(self):
         """An unrecognised mode is treated as disabled (with a log warning)."""
         assert (
             check_inbound_authentication(RAW_EMAIL, {}, {"inbound_auth": "wat"})
-            is False
+            is None
         )
 
 
@@ -55,20 +59,26 @@ class TestCheckInboundAuthenticationNative:
     def test_dkim_pass(self, mock_verify):
         mock_verify.return_value = True
         config = {"inbound_auth": "native"}
-        assert check_inbound_authentication(RAW_EMAIL, {}, config) is False
+        assert check_inbound_authentication(RAW_EMAIL, {}, config) is None
 
     @patch("core.mda.inbound_auth.verify_message_dkim")
     def test_dkim_fail(self, mock_verify):
         mock_verify.return_value = False
         config = {"inbound_auth": "native"}
-        assert check_inbound_authentication(RAW_EMAIL, {}, config) is True
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config)
+            == VERDICT_UNVERIFIED
+        )
 
     @patch("core.mda.inbound_auth.verify_message_dkim")
-    def test_dkim_error_flags(self, mock_verify):
-        """Transient errors -> can't verify -> flag (fail-closed)."""
+    def test_dkim_error_unverified(self, mock_verify):
+        """Transient errors -> cannot verify -> "none" (not forgery)."""
         mock_verify.side_effect = RuntimeError("dns broken")
         config = {"inbound_auth": "native"}
-        assert check_inbound_authentication(RAW_EMAIL, {}, config) is True
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config)
+            == VERDICT_UNVERIFIED
+        )
 
     @patch("core.mda.inbound_auth.verify_message_dkim")
     def test_dmarc_header_ignored(self, mock_verify):
@@ -80,7 +90,7 @@ class TestCheckInboundAuthenticationNative:
             ]
         }
         config = {"inbound_auth": "native"}
-        assert check_inbound_authentication(RAW_EMAIL, parsed, config) is False
+        assert check_inbound_authentication(RAW_EMAIL, parsed, config) is None
 
     @patch("core.mda.inbound_auth.verify_message_dkim")
     def test_dmarc_rspamd_ignored(self, mock_verify):
@@ -89,7 +99,7 @@ class TestCheckInboundAuthenticationNative:
         rspamd = {"symbols": {"DMARC_POLICY_REJECT": {"score": 5}}}
         config = {"inbound_auth": "native"}
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is False
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
         )
 
 
@@ -100,7 +110,7 @@ class TestCheckInboundAuthenticationRspamd:
         config = {"inbound_auth": "rspamd"}
         rspamd = {"symbols": {"R_DKIM_ALLOW": {"score": 0.1}}}
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is False
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
         )
 
     def test_dkim_pass_dmarc_pass(self):
@@ -112,10 +122,11 @@ class TestCheckInboundAuthenticationRspamd:
             }
         }
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is False
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
         )
 
-    def test_dkim_pass_dmarc_fail(self):
+    def test_dkim_pass_dmarc_fail_forged(self):
+        """DMARC fail on a message that otherwise has DKIM -> 'fail' (forgery)."""
         config = {"inbound_auth": "rspamd"}
         rspamd = {
             "symbols": {
@@ -124,10 +135,12 @@ class TestCheckInboundAuthenticationRspamd:
             }
         }
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd)
+            == VERDICT_FORGED
         )
 
-    def test_dkim_pass_dmarc_quarantine(self):
+    def test_dkim_pass_dmarc_quarantine_forged(self):
+        """DMARC quarantine is a fail-equivalent signal -> 'fail'."""
         config = {"inbound_auth": "rspamd"}
         rspamd = {
             "symbols": {
@@ -136,7 +149,8 @@ class TestCheckInboundAuthenticationRspamd:
             }
         }
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd)
+            == VERDICT_FORGED
         )
 
     def test_dkim_pass_dmarc_na(self):
@@ -149,26 +163,28 @@ class TestCheckInboundAuthenticationRspamd:
             }
         }
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is False
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is None
         )
 
     def test_dkim_fail(self):
         config = {"inbound_auth": "rspamd"}
         rspamd = {"symbols": {"R_DKIM_REJECT": {"score": 5}}}
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd)
+            == VERDICT_UNVERIFIED
         )
 
     def test_dkim_missing(self):
-        """DKIM_NA means no DKIM-Signature header -> flag."""
+        """DKIM_NA means no DKIM-Signature header -> 'none'."""
         config = {"inbound_auth": "rspamd"}
         rspamd = {"symbols": {"DKIM_NA": {"score": 0}}}
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd)
+            == VERDICT_UNVERIFIED
         )
 
     def test_dkim_fail_dominates_pass(self):
-        """Two DKIM symbols in one response: fail wins."""
+        """Two DKIM symbols in one response: fail wins -> 'none'."""
         config = {"inbound_auth": "rspamd"}
         rspamd = {
             "symbols": {
@@ -177,21 +193,38 @@ class TestCheckInboundAuthenticationRspamd:
             }
         }
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd) is True
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd)
+            == VERDICT_UNVERIFIED
         )
 
-    def test_no_rspamd_result_flags(self):
-        """Backend unavailable -> can't verify -> flag."""
+    def test_dkim_fail_and_dmarc_fail_is_forged(self):
+        """DMARC fail is stronger than DKIM fail -> 'fail'."""
         config = {"inbound_auth": "rspamd"}
+        rspamd = {
+            "symbols": {
+                "R_DKIM_REJECT": {"score": 5},
+                "DMARC_POLICY_REJECT": {"score": 5},
+            }
+        }
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, None) is True
+            check_inbound_authentication(RAW_EMAIL, {}, config, rspamd)
+            == VERDICT_FORGED
         )
 
-    def test_rspamd_result_without_symbols_flags(self):
-        """Response missing `symbols` key -> no evidence -> flag."""
+    def test_no_rspamd_result_unverified(self):
+        """Backend unavailable -> can't verify -> 'none' (not 'fail')."""
         config = {"inbound_auth": "rspamd"}
         assert (
-            check_inbound_authentication(RAW_EMAIL, {}, config, {}) is True
+            check_inbound_authentication(RAW_EMAIL, {}, config, None)
+            == VERDICT_UNVERIFIED
+        )
+
+    def test_rspamd_result_without_symbols_unverified(self):
+        """Response missing `symbols` key -> no evidence -> 'none'."""
+        config = {"inbound_auth": "rspamd"}
+        assert (
+            check_inbound_authentication(RAW_EMAIL, {}, config, {})
+            == VERDICT_UNVERIFIED
         )
 
 
@@ -211,21 +244,23 @@ class TestCheckInboundAuthenticationResults:
     def test_dkim_pass_no_dmarc(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx.example.net; dkim=pass"]])
-        assert check_inbound_authentication(b"", parsed, config) is False
+        assert check_inbound_authentication(b"", parsed, config) is None
 
     def test_dkim_pass_dmarc_pass(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed(
             [["mx.example.net; dkim=pass; dmarc=pass"]]
         )
-        assert check_inbound_authentication(b"", parsed, config) is False
+        assert check_inbound_authentication(b"", parsed, config) is None
 
-    def test_dkim_pass_dmarc_fail(self):
+    def test_dkim_pass_dmarc_fail_forged(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed(
             [["mx.example.net; dkim=pass; dmarc=fail"]]
         )
-        assert check_inbound_authentication(b"", parsed, config) is True
+        assert (
+            check_inbound_authentication(b"", parsed, config) == VERDICT_FORGED
+        )
 
     def test_dkim_pass_dmarc_none(self):
         """dmarc=none -> no policy -> don't require DMARC pass."""
@@ -233,35 +268,50 @@ class TestCheckInboundAuthenticationResults:
         parsed = self._parsed(
             [["mx.example.net; dkim=pass; dmarc=none"]]
         )
-        assert check_inbound_authentication(b"", parsed, config) is False
+        assert check_inbound_authentication(b"", parsed, config) is None
 
     def test_dkim_fail(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx.example.net; dkim=fail"]])
-        assert check_inbound_authentication(b"", parsed, config) is True
+        assert (
+            check_inbound_authentication(b"", parsed, config)
+            == VERDICT_UNVERIFIED
+        )
 
     def test_dkim_softfail_is_fail(self):
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx; dkim=softfail"]])
-        assert check_inbound_authentication(b"", parsed, config) is True
+        assert (
+            check_inbound_authentication(b"", parsed, config)
+            == VERDICT_UNVERIFIED
+        )
 
-    def test_dkim_none_is_flag(self):
-        """dkim=none (no signature) is not a pass -> flag."""
+    def test_dkim_none_is_unverified(self):
+        """dkim=none (no signature) is not a pass -> 'none'."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx; dkim=none"]])
-        assert check_inbound_authentication(b"", parsed, config) is True
+        assert (
+            check_inbound_authentication(b"", parsed, config)
+            == VERDICT_UNVERIFIED
+        )
 
-    def test_header_absent_flags(self):
-        """No AR header anywhere -> can't verify -> flag."""
+    def test_header_absent_unverified(self):
+        """No AR header anywhere -> can't verify -> 'none'."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = {"headers_blocks": [{}]}
-        assert check_inbound_authentication(b"", parsed, config) is True
+        assert (
+            check_inbound_authentication(b"", parsed, config)
+            == VERDICT_UNVERIFIED
+        )
 
-    def test_no_dkim_entry_flags(self):
-        """AR present but no dkim= entry -> unknown -> flag."""
+    def test_no_dkim_entry_unverified(self):
+        """AR present but no dkim= entry -> unknown -> 'none'."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed([["mx; spf=pass"]])
-        assert check_inbound_authentication(b"", parsed, config) is True
+        assert (
+            check_inbound_authentication(b"", parsed, config)
+            == VERDICT_UNVERIFIED
+        )
 
     def test_untrusted_block_ignored(self):
         """trusted_relays=0 -> only block 0 (our MTA) is trusted."""
@@ -272,7 +322,10 @@ class TestCheckInboundAuthenticationResults:
                 {"authentication-results": ["mx; dkim=pass"]},  # untrusted
             ]
         }
-        assert check_inbound_authentication(b"", parsed, config) is True
+        assert (
+            check_inbound_authentication(b"", parsed, config)
+            == VERDICT_UNVERIFIED
+        )
 
     def test_trusted_block_used(self):
         """Default trusted_relays=1 -> block 1 is trusted."""
@@ -283,15 +336,18 @@ class TestCheckInboundAuthenticationResults:
                 {"authentication-results": ["mx; dkim=pass"]},
             ]
         }
-        assert check_inbound_authentication(b"", parsed, config) is False
+        assert check_inbound_authentication(b"", parsed, config) is None
 
     def test_dkim_fail_dominates_pass_across_values(self):
-        """Multiple AR values in one block: fail wins over pass."""
+        """Multiple AR values in one block: fail wins -> 'none'."""
         config = {"inbound_auth": "authentication-results", "trusted_relays": 1}
         parsed = self._parsed(
             [["mx1; dkim=pass", "mx2; dkim=fail"]]
         )
-        assert check_inbound_authentication(b"", parsed, config) is True
+        assert (
+            check_inbound_authentication(b"", parsed, config)
+            == VERDICT_UNVERIFIED
+        )
 
     def test_single_string_ar_value(self):
         """AR header may be a bare string (single occurrence) rather than list."""
@@ -301,17 +357,17 @@ class TestCheckInboundAuthenticationResults:
                 {"authentication-results": "mx; dkim=pass"}
             ]
         }
-        assert check_inbound_authentication(b"", parsed, config) is False
+        assert check_inbound_authentication(b"", parsed, config) is None
 
 
 @pytest.mark.django_db
 class TestProcessInboundMessageAuthIntegration:
-    """End-to-end: a failing auth check prepends X-StMsg-Sender-Auth: none."""
+    """End-to-end: a verdict prepends X-StMsg-Sender-Auth with its value."""
 
     @override_settings(SPAM_CONFIG={"inbound_auth": "native"})
     @patch("core.mda.inbound_tasks.check_inbound_authentication")
     @patch("core.mda.inbound_tasks._create_message_from_inbound")
-    def test_failed_auth_injects_header(
+    def test_unverified_verdict_injects_none_header(
         self, mock_create_message, mock_auth_check
     ):
         mailbox = factories.MailboxFactory()
@@ -319,7 +375,7 @@ class TestProcessInboundMessageAuthIntegration:
             mailbox=mailbox,
             raw_data=RAW_EMAIL,
         )
-        mock_auth_check.return_value = True
+        mock_auth_check.return_value = VERDICT_UNVERIFIED
         mock_create_message.return_value = True
 
         with patch.object(process_inbound_message_task, "update_state", Mock()):
@@ -331,10 +387,10 @@ class TestProcessInboundMessageAuthIntegration:
         parsed = call_kwargs["parsed_email"]
         assert parsed["headers"].get("x-stmsg-sender-auth") == "none"
 
-    @override_settings(SPAM_CONFIG={"inbound_auth": "native"})
+    @override_settings(SPAM_CONFIG={"inbound_auth": "rspamd"})
     @patch("core.mda.inbound_tasks.check_inbound_authentication")
     @patch("core.mda.inbound_tasks._create_message_from_inbound")
-    def test_passing_auth_does_not_inject_header(
+    def test_forged_verdict_injects_fail_header(
         self, mock_create_message, mock_auth_check
     ):
         mailbox = factories.MailboxFactory()
@@ -342,7 +398,29 @@ class TestProcessInboundMessageAuthIntegration:
             mailbox=mailbox,
             raw_data=RAW_EMAIL,
         )
-        mock_auth_check.return_value = False
+        mock_auth_check.return_value = VERDICT_FORGED
+        mock_create_message.return_value = True
+
+        with patch.object(process_inbound_message_task, "update_state", Mock()):
+            process_inbound_message_task.run(str(inbound_message.id))
+
+        call_kwargs = mock_create_message.call_args[1]
+        assert call_kwargs["raw_data"].startswith(b"X-StMsg-Sender-Auth: fail\r\n")
+        parsed = call_kwargs["parsed_email"]
+        assert parsed["headers"].get("x-stmsg-sender-auth") == "fail"
+
+    @override_settings(SPAM_CONFIG={"inbound_auth": "native"})
+    @patch("core.mda.inbound_tasks.check_inbound_authentication")
+    @patch("core.mda.inbound_tasks._create_message_from_inbound")
+    def test_verified_does_not_inject_header(
+        self, mock_create_message, mock_auth_check
+    ):
+        mailbox = factories.MailboxFactory()
+        inbound_message = models.InboundMessage.objects.create(
+            mailbox=mailbox,
+            raw_data=RAW_EMAIL,
+        )
+        mock_auth_check.return_value = None
         mock_create_message.return_value = True
 
         with patch.object(process_inbound_message_task, "update_state", Mock()):
@@ -385,6 +463,42 @@ class TestProcessInboundMessageAuthIntegration:
         assert mock_post.call_count == 1
         call_kwargs = mock_create_message.call_args[1]
         assert call_kwargs["raw_data"].startswith(b"X-StMsg-Sender-Auth: none\r\n")
+
+    @override_settings(
+        SPAM_CONFIG={
+            "rspamd_url": "http://rspamd:8010/_api",
+            "inbound_auth": "rspamd",
+        }
+    )
+    @patch("core.mda.inbound_tasks.requests.post")
+    @patch("core.mda.inbound_tasks._create_message_from_inbound")
+    def test_dmarc_fail_injects_fail_header_end_to_end(
+        self, mock_create_message, mock_post
+    ):
+        mailbox = factories.MailboxFactory()
+        inbound_message = models.InboundMessage.objects.create(
+            mailbox=mailbox,
+            raw_data=RAW_EMAIL,
+        )
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "action": "no action",
+            "score": 1.0,
+            "required_score": 15.0,
+            "symbols": {
+                "R_DKIM_ALLOW": {"score": 0.1},
+                "DMARC_POLICY_REJECT": {"score": 5},
+            },
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+        mock_create_message.return_value = True
+
+        with patch.object(process_inbound_message_task, "update_state", Mock()):
+            process_inbound_message_task.run(str(inbound_message.id))
+
+        call_kwargs = mock_create_message.call_args[1]
+        assert call_kwargs["raw_data"].startswith(b"X-StMsg-Sender-Auth: fail\r\n")
 
     @override_settings(
         SPAM_CONFIG={
@@ -435,6 +549,6 @@ class TestProcessInboundMessageAuthIntegration:
 
     def test_header_injection_propagates_to_stmsg(self):
         """After prepending, the parser exposes the header via x-stmsg-*."""
-        tagged = b"X-StMsg-Sender-Auth: none\r\n" + RAW_EMAIL
+        tagged = b"X-StMsg-Sender-Auth: fail\r\n" + RAW_EMAIL
         parsed = parse_email_message(tagged)
-        assert parsed["headers"].get("x-stmsg-sender-auth") == "none"
+        assert parsed["headers"].get("x-stmsg-sender-auth") == "fail"

--- a/src/backend/core/tests/mda/test_rfc5322_utils.py
+++ b/src/backend/core/tests/mda/test_rfc5322_utils.py
@@ -1,11 +1,14 @@
 """Tests for core.mda.rfc5322.utils — base64 image extraction utilities."""
 
+# pylint: disable=missing-function-docstring,too-many-public-methods
+
 import base64
 import re
 
 from core.mda.rfc5322.utils import (
     extract_base64_images_from_html,
     extract_base64_images_from_text,
+    remove_mime_headers,
 )
 
 # A tiny valid 1x1 red PNG (68 bytes)
@@ -261,3 +264,194 @@ class TestDeduplication:
         cid = images[0]["cid"]
         assert f"![a](cid:{cid})" in result
         assert f"![b](cid:{cid})" in result
+
+
+class TestRemoveMimeHeaders:
+    """Tests for remove_mime_headers()."""
+
+    BASE_HEAD = (
+        b"Received: from mta.example.com (mta.example.com [10.0.0.1])\r\n"
+        b"\tby relay.example.com with SMTP id abc123\r\n"
+        b"From: sender@example.com\r\n"
+        b"To: rcpt@example.com\r\n"
+        b"Subject: Hi\r\n"
+    )
+    BODY = b"\r\n\r\nThis is the body.\r\n"
+
+    # --- Empty filters --------------------------------------------------
+
+    def test_no_filters_returns_input_unchanged(self):
+        raw = self.BASE_HEAD + self.BODY
+        assert remove_mime_headers(raw) is raw
+
+    def test_empty_iterables_return_input_unchanged(self):
+        raw = self.BASE_HEAD + self.BODY
+        assert remove_mime_headers(raw, prefixes=[], names=[]) is raw
+
+    def test_no_match_returns_input_unchanged(self):
+        raw = self.BASE_HEAD + self.BODY
+        out = remove_mime_headers(raw, prefixes=["x-no-such-"], names=["x-also-no"])
+        assert out is raw
+
+    # --- Exact name matching --------------------------------------------
+
+    def test_exact_name_match(self):
+        raw = b"From: a@b\r\nX-Custom: value\r\nSubject: hi\r\n" + self.BODY
+        out = remove_mime_headers(raw, names=["X-Custom"])
+        assert b"X-Custom" not in out
+        assert b"From: a@b" in out
+        assert b"Subject: hi" in out
+
+    def test_exact_name_case_insensitive(self):
+        raw = b"X-CuStOm: value\r\nFrom: a@b\r\n" + self.BODY
+        out = remove_mime_headers(raw, names=["x-custom"])
+        assert b"X-CuStOm" not in out
+
+    def test_exact_name_does_not_match_prefix(self):
+        """names=['x-foo'] must not strip 'x-foo-bar'."""
+        raw = b"X-Foo-Bar: keep\r\nX-Foo: drop\r\n" + self.BODY
+        out = remove_mime_headers(raw, names=["x-foo"])
+        assert b"X-Foo-Bar: keep" in out
+        assert b"\r\nX-Foo:" not in b"\r\n" + out
+        assert b"X-Foo: drop" not in out
+
+    def test_multiple_exact_names(self):
+        raw = b"X-A: 1\r\nX-B: 2\r\nX-C: 3\r\n" + self.BODY
+        out = remove_mime_headers(raw, names=["X-A", "X-C"])
+        assert b"X-A:" not in out
+        assert b"X-C:" not in out
+        assert b"X-B: 2" in out
+
+    # --- Prefix matching -------------------------------------------------
+
+    def test_prefix_match(self):
+        raw = (
+            b"X-StMsg-Sender-Auth: pass\r\n"
+            b"X-StMsg-Widget-Referer: evil.com\r\n"
+            b"From: a@b\r\n" + self.BODY
+        )
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert b"X-StMsg-" not in out
+        assert b"From: a@b" in out
+
+    def test_prefix_case_insensitive(self):
+        raw = b"x-STmsg-Foo: drop\r\nFrom: a@b\r\n" + self.BODY
+        out = remove_mime_headers(raw, prefixes=["X-StMsg-"])
+        assert b"x-STmsg-Foo" not in out
+
+    def test_multiple_prefixes(self):
+        raw = b"X-Spam-Score: 5\r\nX-StMsg-Foo: 1\r\nX-Other: keep\r\n" + self.BODY
+        out = remove_mime_headers(raw, prefixes=["x-spam-", "x-stmsg-"])
+        assert b"X-Spam-Score" not in out
+        assert b"X-StMsg-Foo" not in out
+        assert b"X-Other: keep" in out
+
+    def test_prefix_does_not_match_unrelated_name(self):
+        raw = b"Subject: x-stmsg-not-a-header\r\n" + self.BODY
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert out is raw
+
+    # --- Combined filters ------------------------------------------------
+
+    def test_prefixes_and_names_combined(self):
+        raw = b"X-StMsg-Foo: 1\r\nDKIM-Signature: v=1; ...\r\nFrom: a@b\r\n" + self.BODY
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"], names=["DKIM-Signature"])
+        assert b"X-StMsg-Foo" not in out
+        assert b"DKIM-Signature" not in out
+        assert b"From: a@b" in out
+
+    # --- Folding (RFC 5322 §2.2.3) --------------------------------------
+
+    def test_folded_target_header_dropped_completely(self):
+        raw = (
+            b"X-StMsg-Widget-Referer: http://evil.com/\r\n"
+            b" /some/very/long/path\r\n"
+            b"\t?that_continues=yes\r\n"
+            b"From: a@b\r\n" + self.BODY
+        )
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert b"evil.com" not in out
+        assert b"some/very/long/path" not in out
+        assert b"that_continues" not in out
+        assert b"From: a@b" in out
+
+    def test_folded_unrelated_header_preserved(self):
+        raw = (
+            b"Subject: a very long\r\n"
+            b" subject line with\r\n"
+            b"\tmultiple folds\r\n"
+            b"X-StMsg-Sender-Auth: pass\r\n" + self.BODY
+        )
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert b"a very long" in out
+        assert b" subject line with" in out
+        assert b"\tmultiple folds" in out
+        assert b"X-StMsg-Sender-Auth" not in out
+
+    def test_continuation_after_drop_then_real_header(self):
+        """A real header following a dropped folded header is preserved."""
+        raw = b"X-StMsg-Foo: a\r\n continued\r\nReal-Header: kept\r\n" + self.BODY
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert b"X-StMsg-Foo" not in out
+        assert b"continued" not in out
+        assert b"Real-Header: kept" in out
+
+    # --- Line endings ---------------------------------------------------
+
+    def test_lf_only_line_endings(self):
+        raw = b"X-StMsg-Sender-Auth: pass\nFrom: a@b\n\nbody"
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert b"X-StMsg-Sender-Auth" not in out
+        assert b"From: a@b" in out
+        assert out.endswith(b"\n\nbody")
+
+    # --- Body / boundary semantics --------------------------------------
+
+    def test_body_left_byte_identical(self):
+        body = b"\r\n\r\nLine1\r\nX-StMsg-Foo: looks like a header but it's body\r\n"
+        raw = b"From: a@b\r\nX-StMsg-Foo: bar\r\n" + body
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert out.endswith(body)
+        head = out.split(b"\r\n\r\n", 1)[0]
+        assert b"X-StMsg-" not in head
+
+    def test_retained_headers_byte_identical(self):
+        raw = self.BASE_HEAD + b"X-StMsg-Sender-Auth: pass\r\n" + self.BODY
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        # Each retained header line must appear unchanged in the output.
+        for line in self.BASE_HEAD.splitlines(keepends=True):
+            assert line in out
+
+    def test_no_body_separator(self):
+        raw = b"X-StMsg-Sender-Auth: pass\r\nFrom: a@b\r\n"
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert b"X-StMsg-Sender-Auth" not in out
+        assert b"From: a@b" in out
+
+    def test_empty_input(self):
+        assert remove_mime_headers(b"", prefixes=["x-stmsg-"]) == b""
+
+    # --- Malformed input -------------------------------------------------
+
+    def test_malformed_line_without_colon_preserved(self):
+        raw = (
+            b"From: a@b\r\n"
+            b"some-malformed-line-no-colon\r\n"
+            b"X-StMsg-Sender-Auth: pass\r\n" + self.BODY
+        )
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert b"some-malformed-line-no-colon" in out
+        assert b"X-StMsg-Sender-Auth" not in out
+
+    def test_malformed_line_resets_drop_state(self):
+        """A non-continuation line clears any in-progress drop, even if malformed."""
+        raw = (
+            b"X-StMsg-Foo: a\r\n"
+            b"malformed-without-colon\r\n"
+            b" indented-after-malformed\r\n" + self.BODY
+        )
+        out = remove_mime_headers(raw, prefixes=["x-stmsg-"])
+        assert b"X-StMsg-Foo" not in out
+        assert b"malformed-without-colon" in out
+        # The indented line is a "continuation" of the malformed line — kept.
+        assert b" indented-after-malformed" in out

--- a/src/backend/core/tests/mda/test_spam_processing.py
+++ b/src/backend/core/tests/mda/test_spam_processing.py
@@ -102,10 +102,11 @@ class TestRspamdSpamCheck:
         mock_post.return_value = mock_response
 
         raw_data = b"Spam email content"
-        is_spam, error = _check_spam_with_rspamd(raw_data, spam_config)
+        is_spam, error, rspamd_result = _check_spam_with_rspamd(raw_data, spam_config)
 
         assert is_spam is True
         assert error is None
+        assert rspamd_result is not None
         mock_post.assert_called_once()
         call_args = mock_post.call_args
         assert call_args[0][0] == "http://rspamd:8010/_api/checkv2"
@@ -126,7 +127,7 @@ class TestRspamdSpamCheck:
         mock_post.return_value = mock_response
 
         raw_data = b"Legitimate email content"
-        is_spam, error = _check_spam_with_rspamd(raw_data, spam_config)
+        is_spam, error, _rspamd_result = _check_spam_with_rspamd(raw_data, spam_config)
 
         assert is_spam is False
         assert error is None
@@ -164,10 +165,11 @@ class TestRspamdSpamCheck:
         """Test that spam check is skipped when rspamd is not configured."""
         spam_config = {}
         raw_data = b"Email content"
-        is_spam, error = _check_spam_with_rspamd(raw_data, spam_config)
+        is_spam, error, rspamd_result = _check_spam_with_rspamd(raw_data, spam_config)
 
         assert is_spam is False
         assert error is None
+        assert rspamd_result is None
 
     @override_settings(SPAM_CONFIG={"rspamd_url": "http://rspamd:8010/_api"})
     @patch("core.mda.inbound_tasks.requests.post")
@@ -177,11 +179,12 @@ class TestRspamdSpamCheck:
         mock_post.side_effect = requests.exceptions.RequestException("Connection error")
 
         raw_data = b"Email content"
-        is_spam, error = _check_spam_with_rspamd(raw_data, spam_config)
+        is_spam, error, rspamd_result = _check_spam_with_rspamd(raw_data, spam_config)
 
         # On error, treat as not spam to avoid blocking legitimate messages
         assert is_spam is False
         assert error is not None
+        assert rspamd_result is None
 
     @override_settings(
         SPAM_CONFIG={
@@ -709,7 +712,7 @@ class TestProcessInboundMessageTask:
             raw_data=raw_data,
         )
 
-        mock_check_spam.return_value = (True, None)  # is_spam=True
+        mock_check_spam.return_value = (True, None, None)  # is_spam=True
         mock_create_message.return_value = True
 
         # Call the bound task directly using .run() method
@@ -742,7 +745,7 @@ class TestProcessInboundMessageTask:
             raw_data=raw_data,
         )
 
-        mock_check_spam.return_value = (False, None)  # is_spam=False
+        mock_check_spam.return_value = (False, None, None)  # is_spam=False
         mock_create_message.return_value = True
 
         # Call the bound task directly using .run() method
@@ -771,7 +774,7 @@ class TestProcessInboundMessageTask:
             raw_data=raw_data,
         )
 
-        mock_check_spam.return_value = (False, None)
+        mock_check_spam.return_value = (False, None, None)
         mock_create_message.return_value = False  # Creation failed
 
         # Call the bound task directly using .run() method

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -283,7 +283,16 @@ class Base(Configuration):
 
     # Spam filtering settings
 
-    # Default spam configuration for all mail domains, overrideable per mail domain in custom_settings
+    # Default spam configuration for all mail domains, overrideable per mail
+    # domain in custom_settings. Recognised keys include:
+    #   rspamd_url / rspamd_auth : rspamd /checkv2 endpoint + optional auth header
+    #   trusted_relays           : int, how many upstream Received blocks to trust
+    #                              for header-based rules (default 1)
+    #   rules                    : list of hardcoded header-match spam rules
+    #   inbound_auth             : sender authentication backend — one of
+    #                              "native", "rspamd", "authentication-results",
+    #                              or None/absent to disable. See
+    #                              core.mda.inbound_auth for semantics.
     SPAM_CONFIG = values.DictValue({}, environ_name="SPAM_CONFIG", environ_prefix=None)
 
     # MTA settings

--- a/src/frontend/public/locales/common/en-US.json
+++ b/src/frontend/public/locales/common/en-US.json
@@ -602,6 +602,7 @@
   "These tags will be automatically applied to every incoming message from the widget.": "These tags will be automatically applied to every incoming message from the widget.",
   "This action cannot be undone and the user will need the new password to access its mailbox.": "This action cannot be undone and the user will need the new password to access its mailbox.",
   "This contact's identity could not be verified. Proceed with caution.": "This contact's identity could not be verified. Proceed with caution.",
+  "This message failed sender authentication and is likely a forgery. Do not trust it.": "This message failed sender authentication and is likely a forgery. Do not trust it.",
   "This description will be used by the AI to automatically assign this label to your messages.": "This description will be used by the AI to automatically assign this label to your messages.",
   "This email prefix is not allowed for personal mailboxes. Please choose a different prefix.": "This email prefix is not allowed for personal mailboxes. Please choose a different prefix.",
   "This event has been cancelled": "This event has been cancelled",

--- a/src/frontend/public/locales/common/fr-FR.json
+++ b/src/frontend/public/locales/common/fr-FR.json
@@ -663,6 +663,7 @@
   "These tags will be automatically applied to every incoming message from the widget.": "Ces libellés seront automatiquement appliqués à chaque message entrant provenant du widget.",
   "This action cannot be undone and the user will need the new password to access its mailbox.": "Cette action est irréversible et l'utilisateur aura besoin du nouveau mot de passe pour accéder à sa boîte aux lettres.",
   "This contact's identity could not be verified. Proceed with caution.": "L'identité de ce contact n'a pas pu être vérifiée. Faites attention.",
+  "This message failed sender authentication and is likely a forgery. Do not trust it.": "L'authentification de l'expéditeur a échoué pour ce message, qui est probablement frauduleux. Ne lui faites pas confiance.",
   "This description will be used by the AI to automatically assign this label to your messages.": "Cette description sera utilisée par l'IA pour assigner automatiquement cette étiquette à vos messages.",
   "This email prefix is not allowed for personal mailboxes. Please choose a different prefix.": "Ce préfixe d'adresse n'est pas autorisé pour les boîtes aux lettres personnelles. Veuillez choisir un autre préfixe.",
   "This event has been cancelled": "Cet événement a été annulé",

--- a/src/frontend/public/locales/common/nl-NL.json
+++ b/src/frontend/public/locales/common/nl-NL.json
@@ -466,6 +466,7 @@
   "These tags will be automatically applied to every incoming message from the widget.": "Deze tags worden automatisch toegepast op elk inkomend bericht vanuit de widget.",
   "This action cannot be undone and the user will need the new password to access its mailbox.": "Deze actie kan niet ongedaan worden gemaakt en de gebruiker heeft het nieuwe wachtwoord nodig om toegang te krijgen tot de mailbox.",
   "This contact's identity could not be verified. Proceed with caution.": "De identiteit van deze contactpersoon kon niet worden geverifieerd. Wees voorzichtig.",
+  "This message failed sender authentication and is likely a forgery. Do not trust it.": "Dit bericht heeft de afzenderauthenticatie niet doorstaan en is waarschijnlijk vervalst. Vertrouw het niet.",
   "This description will be used by the AI to automatically assign this label to your messages.": "Deze beschrijving wordt gebruikt door de AI om dit label automatisch aan je berichten toe te wijzen.",
   "This email prefix is not allowed for personal mailboxes. Please choose a different prefix.": "Dit emailvoorvoegsel is niet toegestaan voor persoonlijke mailboxen. Kies een andere voorvoegsel.",
   "This event has been cancelled": "Deze afspraak is geannuleerd",

--- a/src/frontend/public/locales/common/ru-RU.json
+++ b/src/frontend/public/locales/common/ru-RU.json
@@ -538,6 +538,7 @@
   "These tags will be automatically applied to every incoming message from the widget.": "Эти теги будут автоматически применяться к каждому входящему сообщению из виджета.",
   "This action cannot be undone and the user will need the new password to access its mailbox.": "Это действие не может быть отменено, и пользователю потребуется новый пароль для доступа к его почтовому ящику.",
   "This contact's identity could not be verified. Proceed with caution.": "Невозможно проверить личность этого контакта. Будьте осторожны.",
+  "This message failed sender authentication and is likely a forgery. Do not trust it.": "Это сообщение не прошло аутентификацию отправителя и, вероятно, является подделкой. Не доверяйте ему.",
   "This description will be used by the AI to automatically assign this label to your messages.": "Это описание будет использоваться ИИ для автоматического присвоения ярлыка вашим сообщениям.",
   "This email prefix is not allowed for personal mailboxes. Please choose a different prefix.": "Этот префикс электронной почты не допускается для личных почтовых ящиков. Пожалуйста, выберите другой префикс.",
   "This event has been cancelled": "Это событие отменено",

--- a/src/frontend/public/locales/common/uk-UA.json
+++ b/src/frontend/public/locales/common/uk-UA.json
@@ -538,6 +538,7 @@
   "These tags will be automatically applied to every incoming message from the widget.": "Ці теги будуть автоматично застосовуватися до кожного вхідного повідомлення з віджету.",
   "This action cannot be undone and the user will need the new password to access its mailbox.": "Цю дію не можна скасувати, користувачеві потрібен новий пароль для доступу до поштової скриньки.",
   "This contact's identity could not be verified. Proceed with caution.": "Не вдалося перевірити особистість цього контакту. Будьте обачні.",
+  "This message failed sender authentication and is likely a forgery. Do not trust it.": "Це повідомлення не пройшло перевірку відправника та, ймовірно, є підробкою. Не довіряйте йому.",
   "This description will be used by the AI to automatically assign this label to your messages.": "Цей опис буде використовуватися ШІ для автоматичного призначення міток вашим повідомленням.",
   "This email prefix is not allowed for personal mailboxes. Please choose a different prefix.": "Цей префікс електронної пошти не дозволено для особистих поштових скриньок. Будь ласка, оберіть інший префікс.",
   "This event has been cancelled": "Цю подію скасовано",

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-header.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-header.tsx
@@ -34,8 +34,12 @@ const ThreadMessageHeader = ({
     // to users who have full edit rights on the thread.
     const canEditThread = useAbility(Abilities.CAN_EDIT_THREAD, selectedThread ?? null);
 
-    // Derived state specific to header
-    const isSuspiciousSender = Boolean(message.stmsg_headers?.['sender-auth'] === 'none');
+    // Derived state specific to header. 'none' = we couldn't verify the sender
+    // (missing DKIM, no upstream auth data); 'fail' = explicit DMARC disavowal
+    // from the sender's domain, i.e. almost certainly a forgery.
+    const senderAuth = message.stmsg_headers?.['sender-auth'];
+    const isUnverifiedSender = senderAuth === 'none';
+    const isForgedSender = senderAuth === 'fail';
 
     const isUserSender = useMemo(() => {
         if (!message.is_sender) return false;
@@ -144,7 +148,14 @@ const ThreadMessageHeader = ({
                     </Banner>
                 )}
                 <div className="thread-message__header-rows" style={{ marginBottom: 'var(--c--globals--spacings--sm)' }}>
-                    {isSuspiciousSender && (
+                    {isForgedSender && (
+                        <Banner type="error" compact fullWidth>
+                            <div className="thread-message__header-banner__content">
+                                <p>{t("This message failed sender authentication and is likely a forgery. Do not trust it.")}</p>
+                            </div>
+                        </Banner>
+                    )}
+                    {isUnverifiedSender && (
                         <Banner type="warning" compact fullWidth>
                             <div className="thread-message__header-banner__content">
                                 <p>{t("This contact's identity could not be verified. Proceed with caution.")}</p>
@@ -164,7 +175,7 @@ const ThreadMessageHeader = ({
                                     contact={message.sender}
                                     isUser={isUserSender}
                                     senderUserName={senderUserName}
-                                    status={isSuspiciousSender ? 'unverified' : undefined}
+                                    status={isForgedSender ? 'forged' : isUnverifiedSender ? 'unverified' : undefined}
                                     displayEmail
                                 />
                             </div>

--- a/src/frontend/src/features/ui/components/contact-chip/index.tsx
+++ b/src/frontend/src/features/ui/components/contact-chip/index.tsx
@@ -14,7 +14,7 @@ export type ContactChipDeliveryStatus = {
     timestamp: string | null;
     message: string | null;
 }
-type ContactChipSenderStatus = 'unverified';
+type ContactChipSenderStatus = 'unverified' | 'forged';
 
 export type ContactChipDeliveryAction = {
     label: string;
@@ -35,7 +35,7 @@ export const ContactChip = ({ contact, status, displayEmail = false, isUser = fa
     const popoverTriggerRef = useRef<HTMLButtonElement | null>(null);
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-    // Get delivery status info for popover (only if status is an object, not 'unverified')
+    // Get delivery status info for popover (only if status is an object, not a sender status)
     const deliveryStatusInfo = status instanceof Object ? status : undefined;
 
     const chipContent = (
@@ -43,6 +43,9 @@ export const ContactChip = ({ contact, status, displayEmail = false, isUser = fa
             <button type="button" ref={popoverTriggerRef} className="contact-chip__content" onClick={() => setIsPopoverOpen(open => !open)}>
                 {status === 'unverified' && (
                     <Icon name="warning" type={IconType.OUTLINED} size={IconSize.SMALL} className="contact-chip__icon contact-chip__icon--warning" />
+                )}
+                {status === 'forged' && (
+                    <Icon name="gpp_bad" type={IconType.FILLED} size={IconSize.SMALL} className="contact-chip__icon contact-chip__icon--error" />
                 )}
                 {status instanceof Object && status.status === 'undelivered' && (
                     <Icon name="error" type={IconType.FILLED} size={IconSize.SMALL} className="contact-chip__icon contact-chip__icon--error" />
@@ -79,6 +82,13 @@ export const ContactChip = ({ contact, status, displayEmail = false, isUser = fa
     if (status === 'unverified') {
         return (
             <Tooltip content={t("This contact's identity could not be verified. Proceed with caution.")}>
+                {chipContent}
+            </Tooltip>
+        );
+    }
+    if (status === 'forged') {
+        return (
+            <Tooltip content={t("This message failed sender authentication and is likely a forgery. Do not trust it.")}>
                 {chipContent}
             </Tooltip>
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sender authentication checks (DKIM/DMARC) with multiple modes (native, rspamd, authentication-results).
  * Message UI now shows a clear error banner for forged senders and a warning for unverified senders; contact chips display a forged state.
  * Auth verdicts are recorded so processing can annotate messages with sender-auth headers.

* **Tests**
  * Comprehensive unit and integration tests for authentication flows and message processing.

* **Documentation**
  * Clarified spam configuration comments and keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->