### PR TITLE
🐛(frontend) initialize thread event input on open

### DIFF
--- a/src/backend/core/tests/api/test_messages_import.py
+++ b/src/backend/core/tests/api/test_messages_import.py
@@ -2,7 +2,6 @@
 # pylint: disable=redefined-outer-name, unused-argument, no-value-for-parameter, too-many-lines
 
 import datetime
-import socket
 from unittest.mock import patch
 
 from django.core.files.storage import storages
@@ -27,14 +26,14 @@ def _mock_ssrf_dns():
 
     The IMAP endpoint validates the server hostname via
     ``core.services.ssrf.validate_hostname``; tests use unresolvable fixtures
-    like ``imap.example.com`` so we return a public IP to reach the mocked
-    IMAP task code.
+    like ``imap.example.com`` so we bypass validation to reach the mocked IMAP
+    task code. We patch the symbol imported into
+    ``core.services.importer.imap`` rather than ``socket.getaddrinfo``, which
+    would also break real DNS lookups (e.g. boto3 reaching the S3 bucket).
     """
     with patch(
-        "core.services.ssrf.socket.getaddrinfo",
-        return_value=[
-            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
-        ],
+        "core.services.importer.imap.validate_hostname",
+        return_value=["93.184.216.34"],
     ):
         yield
 

--- a/src/backend/core/tests/importer/conftest.py
+++ b/src/backend/core/tests/importer/conftest.py
@@ -1,6 +1,5 @@
 """Shared fixtures for importer tests."""
 
-import socket
 from unittest import mock
 
 import pytest
@@ -11,14 +10,14 @@ def _mock_ssrf_dns():
     """Short-circuit SSRF DNS validation for IMAP tests.
 
     The IMAP import path validates the server hostname via
-    ``core.services.ssrf.validate_hostname`` which calls ``socket.getaddrinfo``.
-    Test fixtures use unresolvable hostnames like ``imap.example.com``, so we
-    return a valid public IP here to let tests reach the mocked IMAP code.
+    ``core.services.ssrf.validate_hostname``. Test fixtures use unresolvable
+    hostnames like ``imap.example.com``, so we bypass validation here to let
+    tests reach the mocked IMAP code. We patch the symbol imported into
+    ``core.services.importer.imap`` rather than ``socket.getaddrinfo``, which
+    would also break real DNS lookups (e.g. boto3 reaching the S3 bucket).
     """
     with mock.patch(
-        "core.services.ssrf.socket.getaddrinfo",
-        return_value=[
-            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
-        ],
+        "core.services.importer.imap.validate_hostname",
+        return_value=["93.184.216.34"],
     ):
         yield

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -1239,6 +1239,8 @@ class Test(Base):
     # Add a test encryption key for django-fernet-encrypted-fields
     SALT_KEY = ["test-salt-for-development-only"]
 
+    FEATURE_MAILBOX_ADMIN_CHANNELS = ["api_key", "widget"]
+
     SCHEMA_CUSTOM_ATTRIBUTES_USER = {}
     SCHEMA_CUSTOM_ATTRIBUTES_MAILDOMAIN = {}
 

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-event-input/use-im-input-visibility.ts
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-event-input/use-im-input-visibility.ts
@@ -56,14 +56,20 @@ export const useIMInputVisibility = ({
         const el = containerRef.current;
         if (!el) return;
 
+        const updateNearBottom = () => {
+            const distanceFromBottom =
+                el.scrollHeight - el.scrollTop - el.clientHeight;
+            setIsNearBottom(distanceFromBottom <= NEAR_BOTTOM_THRESHOLD);
+        };
+
+        updateNearBottom();
+
         const handleScroll = () => {
             if (rafRef.current !== null) return;
             rafRef.current = requestAnimationFrame(() => {
                 rafRef.current = null;
                 const scrollTop = el.scrollTop;
-                const distanceFromBottom =
-                    el.scrollHeight - scrollTop - el.clientHeight;
-                setIsNearBottom(distanceFromBottom <= NEAR_BOTTOM_THRESHOLD);
+                updateNearBottom();
 
                 // Detect fast downward scroll
                 const prevScrollTop = lastScrollTopRef.current;


### PR DESCRIPTION
## Purpose

Currently, the logic to show/hide thread-event-input was only processed into a scroll handler and by default the thread-event-input was hiddden. So in thread view with only few messages, we expect to display the thread
event input, but it is not. Now we call the near bottom check at mount to
display the input if it is relevant when a thread is opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal scroll position tracking logic for message input to improve code maintainability while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->