### PR TITLE
🔒(backend) respect keycloak password policy when generating passwords

### DIFF
--- a/src/backend/core/services/identity/keycloak.py
+++ b/src/backend/core/services/identity/keycloak.py
@@ -307,25 +307,29 @@ def resync_all_mailboxes_to_keycloak():
 
 
 def generate_password(length=12):
-    """Generate a secure random password with at least one uppercase, one lowercase, and one digit."""
-    if length < 3:
+    """
+    Generate a secure random password with at least one uppercase, one lowercase, one digit, and one special character.
+    """
+    if length < 12:
         raise ValueError(
-            "Password length must be at least 3 to satisfy all requirements."
+            "Password length must be at least 12 to satisfy all requirements."
         )
 
     _upper = "ABCDEFGHJKLMNPQRTUVWXYZ"
     _lower = "abcdefghijkmnopqrstuvwxyz"
     _digits = "2346789"
+    _special = "!@#$%&*?"
 
     # Ensure at least one of each required character type
     password_chars = [
         secrets.choice(_upper),
         secrets.choice(_lower),
         secrets.choice(_digits),
+        secrets.choice(_special),
     ]
     # Fill the rest of the password length with random choices
     password_chars += [
-        secrets.choice(_upper + _lower + _digits) for _ in range(length - 3)
+        secrets.choice(_upper + _lower + _digits + _special) for _ in range(length - 4)
     ]
     # Shuffle to avoid predictable positions
     secrets.SystemRandom().shuffle(password_chars)


### PR DESCRIPTION
## Purpose

Description...


## Proposal

Description...

- [] item 1...
- [] item 2...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Minimum password length requirement increased to 12 characters
  * Passwords now must include special characters in addition to letters and numbers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->