### PR TITLE
🌐(frontend) force default language

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -243,6 +243,7 @@ _Those settings are deprecated and will be removed in the future._
 | `NEXT_PUBLIC_API_ORIGIN` | `http://localhost:8901` | Frontend API origin | Dev |
 | `NEXT_PUBLIC_LANGUAGES` | `[["en-US","English"],["fr-FR","Français"],["nl-NL","Nederlands"]]` | Languages available for frontend | Optional |
 | `NEXT_PUBLIC_DEFAULT_LANGUAGE` | `en-US` | Default language for frontend | Optional |
+| `NEXT_PUBLIC_FORCED_DEFAULT_LANGUAGE` | `false` | When `true`, the default language fallback is `NEXT_PUBLIC_DEFAULT_LANGUAGE` instead of the browser language. | Optional |
 | `NEXT_PUBLIC_THEME_CONFIG` | `{theme: "white-label"}` | Theme configuration for frontend | Optional |
 | `NEXT_PUBLIC_FEEDBACK_WIDGET_API_URL` || Feedback widget API URL | Optional |
 | `NEXT_PUBLIC_FEEDBACK_WIDGET_PATH` || Feedback widget path | Optional |

--- a/src/frontend/src/features/i18n/conf.ts
+++ b/src/frontend/src/features/i18n/conf.ts
@@ -20,3 +20,4 @@ export const LANGUAGES = getLanguagesFromEnv();
 export const LANGUAGES_ALLOWED = LANGUAGES.map((language: [string, string]) => language[0]);
 export const LANGUAGE_LOCAL_STORAGE = APP_STORAGE_PREFIX + 'language';
 export const BASE_LANGUAGE = process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE || LANGUAGES_ALLOWED[0];
+export const IS_LANGUAGE_FORCED = process.env.NEXT_PUBLIC_FORCED_DEFAULT_LANGUAGE === 'true';

--- a/src/frontend/src/features/i18n/utils.ts
+++ b/src/frontend/src/features/i18n/utils.ts
@@ -1,5 +1,6 @@
 import {
   BASE_LANGUAGE,
+  IS_LANGUAGE_FORCED,
   LANGUAGES_ALLOWED,
   LANGUAGE_LOCAL_STORAGE,
 } from './conf';
@@ -9,8 +10,9 @@ export const getLanguage = () => {
     return BASE_LANGUAGE;
   }
 
+  const storedLanguage = localStorage.getItem(LANGUAGE_LOCAL_STORAGE);
   const languageStore =
-    localStorage.getItem(LANGUAGE_LOCAL_STORAGE) || navigator?.language;
+    storedLanguage || (IS_LANGUAGE_FORCED ? BASE_LANGUAGE : navigator?.language);
 
   return LANGUAGES_ALLOWED.includes(languageStore) ? languageStore : BASE_LANGUAGE;
 };


### PR DESCRIPTION
## Purpose

Currently, when user has not its language set into local storage, we retrieve
the default language through the navigator language. In some instance, we would
like to enforce the default language. So we add a new env var `NEXT_PUBLIC_FORCED_DEFAULT_LANGUAGE`, if this one is set to `true`, we skip
the navigator.language and use the `NEXT_PUBLIC_DEFAULT_LANGUAGE` as default
