### PR TITLE
⬆️(frontend) update widget logic to latest version

### DIFF
--- a/src/frontend/src/features/ui/components/feedback-button/index.tsx
+++ b/src/frontend/src/features/ui/components/feedback-button/index.tsx
@@ -40,14 +40,14 @@ export const SurveyButton = ({ iconOnly = false, ...props }: SurveyButtonProps) 
     // Initialize the widget array if it doesn't exist
     if (typeof window !== "undefined" && widgetPath) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._stmsg_widget = (window as any)._stmsg_widget || [];
+      (window as any)._lasuite_widget = (window as any)._lasuite_widget || [];
 
       // Construct script URLs from the base path
       const feedbackScript = `${widgetPath}feedback.js`;
 
       // Push the widget configuration
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._stmsg_widget.push([
+      (window as any)._lasuite_widget.push([
         "feedback",
         "init",
         {

--- a/src/frontend/src/features/ui/components/feedback-widget/index.tsx
+++ b/src/frontend/src/features/ui/components/feedback-widget/index.tsx
@@ -30,15 +30,15 @@ export function FeedbackWidget({
     // Initialize the widget array if it doesn't exist
     if (typeof window !== "undefined" && widgetPath) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._stmsg_widget = (window as any)._stmsg_widget || [];
-      
+      (window as any)._lasuite_widget = (window as any)._lasuite_widget || [];
+
       // Construct script URLs from the base path
       const loaderScript = `${widgetPath}loader.js`;
       const feedbackScript = `${widgetPath}feedback.js`;
-      
+
       // Push the widget configuration
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._stmsg_widget.push([
+      (window as any)._lasuite_widget.push([
         "loader",
         "init",
         {

--- a/src/frontend/src/features/ui/components/lagaufre/index.tsx
+++ b/src/frontend/src/features/ui/components/lagaufre/index.tsx
@@ -20,7 +20,7 @@ export const LagaufreButton = () => {
     if (typeof window == "undefined" || !widgetPath || !apiUrl) return;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)._stmsg_widget = (window as any)._stmsg_widget || [];
+    (window as any)._lasuite_widget = (window as any)._lasuite_widget || [];
 
     // Construct script URLs from the base path
     const feedbackScript = `${widgetPath}lagaufre.js`;
@@ -48,7 +48,7 @@ export const LagaufreButton = () => {
 
     // Initialize the widget
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)._stmsg_widget.push([
+    (window as any)._lasuite_widget.push([
     "lagaufre",
     "init",
     {
@@ -68,7 +68,7 @@ export const LagaufreButton = () => {
     if (!isWidgetInitialized) return;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)._stmsg_widget.push([
+    (window as any)._lasuite_widget.push([
       "lagaufre",
       "toggle"
     ]);


### PR DESCRIPTION
## Purpose

The new widget loader consume `window._lasuite_widget` property to know which widget to load. The previous version was using `window._stmsg_header`.

/!\ Update NEXT_PUBLIC_LAGAUFRE_WIDGET_PATH and
NEXT_PUBLIC_FEEDBACK_WIDGET_PATH
to target the new widget version before deploying this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal widget initialization mechanism across multiple components to use a standardized global queue reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->