### PR TITLE
♻️(frontend) support legacy and new widget attribute

### DIFF
--- a/src/frontend/src/features/ui/components/feedback-button/index.tsx
+++ b/src/frontend/src/features/ui/components/feedback-button/index.tsx
@@ -3,6 +3,7 @@ import { Button, ButtonProps, Tooltip } from "@gouvfr-lasuite/cunningham-react"
 import { useTranslation } from "react-i18next"
 import { useAuth } from "@/features/auth";
 import { useState } from "react";
+import { WidgetHelper } from "@/features/utils/widget-helper";
 
 type SurveyButtonProps = ButtonProps & {
   /** Display only icon without label */
@@ -37,45 +38,27 @@ export const SurveyButton = ({ iconOnly = false, ...props }: SurveyButtonProps) 
   const closeLabel: string = t("Close the feedback widget");
 
   const showWidget = () => {
-    // Initialize the widget array if it doesn't exist
-    if (typeof window !== "undefined" && widgetPath) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._lasuite_widget = (window as any)._lasuite_widget || [];
+    if (typeof window === "undefined" || !widgetPath) return;
 
-      // Construct script URLs from the base path
-      const feedbackScript = `${widgetPath}feedback.js`;
+    WidgetHelper.pushCommand([
+      "feedback",
+      "init",
+      {
+        title,
+        api: apiUrl,
+        channel,
+        placeholder,
+        emailPlaceholder,
+        submitText,
+        successText,
+        successText2,
+        closeLabel,
+        // Add email parameter if user is logged in
+        ...(user?.email && { email: user.email }),
+      },
+    ]);
 
-      // Push the widget configuration
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._lasuite_widget.push([
-        "feedback",
-        "init",
-        {
-          title,
-          api: apiUrl,
-          channel,
-          placeholder,
-          emailPlaceholder,
-          submitText,
-          successText,
-          successText2,
-          closeLabel,
-          // Add email parameter if user is logged in
-          ...(user?.email && { email: user.email }),
-        },
-      ]);
-
-      // Load the loader script if not already loaded
-      if (!document.querySelector(`script[src="${feedbackScript}"]`)) {
-        const script = document.createElement("script");
-        script.async = true;
-        script.src = feedbackScript;
-        const firstScript = document.getElementsByTagName("script")[0];
-        if (firstScript && firstScript.parentNode) {
-          firstScript.parentNode.insertBefore(script, firstScript);
-        }
-      }
-    }
+    WidgetHelper.loadScript(`${widgetPath}feedback.js`);
   }
 
   const openHelpCenter = () => {

--- a/src/frontend/src/features/ui/components/feedback-widget/index.tsx
+++ b/src/frontend/src/features/ui/components/feedback-widget/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/features/auth";
+import { WidgetHelper } from "@/features/utils/widget-helper";
 
 interface FeedbackWidgetProps {
   widget?: string;
@@ -26,54 +27,34 @@ export function FeedbackWidget({
 
   useEffect(() => {
     if (!channel || !apiUrl || !widgetPath) return;
+    if (typeof window === "undefined") return;
 
-    // Initialize the widget array if it doesn't exist
-    if (typeof window !== "undefined" && widgetPath) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._lasuite_widget = (window as any)._lasuite_widget || [];
-
-      // Construct script URLs from the base path
-      const loaderScript = `${widgetPath}loader.js`;
-      const feedbackScript = `${widgetPath}feedback.js`;
-
-      // Push the widget configuration
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._lasuite_widget.push([
-        "loader",
-        "init",
-        {
-          params: {
-            title,
-            api: apiUrl,
-            channel,
-            placeholder,
-            emailPlaceholder,
-            submitText,
-            successText,
-            successText2,
-            closeLabel,
-            // Add email parameter if user is logged in
-            ...(user?.email && { email: user.email }),
-          },
-          script: feedbackScript,
-          widget,
-          label: title,
+    WidgetHelper.pushCommand([
+      "loader",
+      "init",
+      {
+        params: {
+          title,
+          api: apiUrl,
+          channel,
+          placeholder,
+          emailPlaceholder,
+          submitText,
+          successText,
+          successText2,
           closeLabel,
+          // Add email parameter if user is logged in
+          ...(user?.email && { email: user.email }),
         },
-      ]);
+        script: `${widgetPath}feedback.js`,
+        widget,
+        label: title,
+        closeLabel,
+      },
+    ]);
 
-      // Load the loader script if not already loaded
-      if (!document.querySelector(`script[src="${loaderScript}"]`)) {
-        const script = document.createElement("script");
-        script.async = true;
-        script.src = loaderScript;
-        const firstScript = document.getElementsByTagName("script")[0];
-        if (firstScript && firstScript.parentNode) {
-          firstScript.parentNode.insertBefore(script, firstScript);
-        }
-      }
-    }
-  }, [title, channel, apiUrl, widgetPath, widget, emailPlaceholder, submitText, successText, successText2, user?.email]);
+    WidgetHelper.loadScript(`${widgetPath}loader.js`);
+  }, [title, channel, apiUrl, widgetPath, widget, placeholder, emailPlaceholder, submitText, successText, successText2, closeLabel, user?.email]);
 
   // This component doesn't render anything visible
   // The widget is injected via the script

--- a/src/frontend/src/features/ui/components/lagaufre/index.tsx
+++ b/src/frontend/src/features/ui/components/lagaufre/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { useState, useEffect, useRef } from "react"
 import { Button, ButtonElement } from "@gouvfr-lasuite/cunningham-react";
+import { WidgetHelper } from "@/features/utils/widget-helper";
 
 /**
  * A button that opens the lagaufre widget
@@ -19,12 +20,6 @@ export const LagaufreButton = () => {
   useEffect(() => {
     if (typeof window == "undefined" || !widgetPath || !apiUrl) return;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)._lasuite_widget = (window as any)._lasuite_widget || [];
-
-    // Construct script URLs from the base path
-    const feedbackScript = `${widgetPath}lagaufre.js`;
-
     document.addEventListener("stmsg-widget-lagaufre-closed", () => {
         // Focus the button
         buttonRef.current?.focus();
@@ -35,30 +30,18 @@ export const LagaufreButton = () => {
         buttonRef.current?.setAttribute("aria-expanded", "true");
     });
 
-    // Load the loader script if not already loaded
-    if (!document.querySelector(`script[src="${feedbackScript}"]`)) {
-        const script = document.createElement("script");
-        script.async = true;
-        script.src = feedbackScript;
-        const firstScript = document.getElementsByTagName("script")[0];
-        if (firstScript && firstScript.parentNode) {
-            firstScript.parentNode.insertBefore(script, firstScript);
-        }
-    }
-
-    // Initialize the widget
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)._lasuite_widget.push([
-    "lagaufre",
-    "init",
-    {
+    WidgetHelper.loadScript(`${widgetPath}lagaufre.js`);
+    WidgetHelper.pushCommand([
+      "lagaufre",
+      "init",
+      {
         api: apiUrl,
         label,
         closeLabel,
-        position: 'fixed',
+        position: "fixed",
         top: 53,
-        right: 12
-    },
+        right: 12,
+      },
     ]);
 
     setIsWidgetInitialized(true);
@@ -66,12 +49,7 @@ export const LagaufreButton = () => {
 
   const toggleWidget = () => {
     if (!isWidgetInitialized) return;
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)._lasuite_widget.push([
-      "lagaufre",
-      "toggle"
-    ]);
+    WidgetHelper.pushCommand(["lagaufre", "toggle"]);
   }
 
   if (!widgetPath || !apiUrl) {

--- a/src/frontend/src/features/utils/widget-helper.ts
+++ b/src/frontend/src/features/utils/widget-helper.ts
@@ -1,0 +1,36 @@
+// Widget helper functions to share common logic
+
+declare global {
+  interface Window {
+    _lasuite_widget?: unknown[];
+    _stmsg_widget?: unknown[];
+  }
+}
+
+export class WidgetHelper {
+  // Both keys are populated so that legacy and current widget runtimes
+  // can consume the same command queue.
+  static #QUEUE_KEYS = ["_lasuite_widget", "_stmsg_widget"] as const;
+
+  static pushCommand(command: unknown[]) {
+    if (typeof window === "undefined") return;
+    for (const key of WidgetHelper.#QUEUE_KEYS) {
+      const queue = window[key] ?? [];
+      queue.push(command);
+      window[key] = queue;
+    }
+  }
+
+  static loadScript(scriptUrl: string) {
+    if (typeof window === "undefined") return;
+    if (document.querySelector(`script[src="${scriptUrl}"]`)) return;
+
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = scriptUrl;
+    const firstScript = document.getElementsByTagName("script")[0];
+    if (firstScript && firstScript.parentNode) {
+      firstScript.parentNode.insertBefore(script, firstScript);
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

The new widget loader consume `window._lasuite_widget` property to know which widget to load. The previous version was using `window._stmsg_header`. We refactor widget loading logic to support both version with ease.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated widget initialization logic across feedback and Lagaufre components through a new centralized utility module, improving code maintainability and consistency in widget script loading and command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->