### PR TITLE
🔒(backend) stop flagging inbound From=To mails as is_sender

### DIFF
--- a/src/backend/core/mda/inbound_create.py
+++ b/src/backend/core/mda/inbound_create.py
@@ -350,11 +350,7 @@ def _create_message_from_inbound(  # pylint: disable=too-many-arguments
         if subject and len(subject) > 255:
             subject = subject[:255]
 
-        is_sender = (
-            is_outbound
-            or (is_import and is_import_sender)
-            or (sender_email == recipient_email)
-        )
+        is_sender = is_outbound or (is_import and is_import_sender)
 
         message = models.Message.objects.create(
             thread=thread,

--- a/src/backend/core/mda/outbound.py
+++ b/src/backend/core/mda/outbound.py
@@ -456,11 +456,17 @@ def send_message(message: models.Message, force_mta_out: bool = False):
     This part is called asynchronously from the celery worker.
     """
 
-    # Refuse to send messages that are draft or not senders
+    # Refuse to send messages that are draft, not senders, or flagged spam.
+    # The spam guard is defence-in-depth: any code path that mints an
+    # is_sender=True message on a spam-flagged record (today none, but the
+    # invariant must hold for future paths) cannot exfiltrate it via the
+    # outbound pipeline.
     if message.is_draft:
         raise ValueError("Cannot send a draft message")
     if not message.is_sender:
         raise ValueError("Cannot send a message we are not sender of")
+    if message.is_spam:
+        raise ValueError("Cannot send a message flagged as spam")
 
     # Create a unique lock key for this message to prevent double sends
     lock_key = f"send_message_lock:{message.id}"

--- a/src/backend/core/mda/outbound_tasks.py
+++ b/src/backend/core/mda/outbound_tasks.py
@@ -134,11 +134,15 @@ def retry_messages_task(self, message_ids=None, force_mta_out=False, batch_size=
         dict: A dictionary with task status and results
     """
     # Get messages to process
-    # Bulk mode - find all messages with retryable recipients that are ready for retry
+    # Bulk mode - find all messages with retryable recipients that are ready
+    # for retry. is_spam=False is a defence-in-depth filter: should any code
+    # path mint an is_sender=True spam record, it must never re-enter the
+    # outbound pipeline.
     message_filter_q = (
         Q(
             is_draft=False,
             is_sender=True,
+            is_spam=False,
         )
         & (
             Q(recipients__delivery_status=MessageDeliveryStatusChoices.RETRY)

--- a/src/backend/core/services/importer/eml_tasks.py
+++ b/src/backend/core/services/importer/eml_tasks.py
@@ -91,6 +91,16 @@ def process_eml_file_task(self, file_key: str, recipient_id: str) -> Dict[str, A
 
         # Parse the email message
         parsed_email = parse_email_message(file_content)
+
+        # Treat the EML as a sent message when From matches the destination
+        # mailbox — the same heuristic IMAP uses against the account
+        # username. Without this flag, importing one's own sent mails would
+        # land them in the inbox view.
+        recipient_email = str(recipient)
+        sender_email = (parsed_email.get("from") or {}).get("email") or ""
+        # TODO: better heuristic to determine if the message is from the sender
+        is_import_sender = sender_email.lower() == recipient_email.lower()
+
         # Deliver the message. Deferrers batch OpenSearch indexing and
         # thread-stats updates into a single bulk task at context exit,
         # keeping behaviour consistent with the other import flows.
@@ -99,7 +109,11 @@ def process_eml_file_task(self, file_key: str, recipient_id: str) -> Dict[str, A
             ThreadStatsUpdateDeferrer.defer(),
         ):
             success = deliver_inbound_message(
-                str(recipient), parsed_email, file_content, is_import=True
+                recipient_email,
+                parsed_email,
+                file_content,
+                is_import=True,
+                is_import_sender=is_import_sender,
             )
 
         result = {

--- a/src/backend/core/services/importer/mbox_tasks.py
+++ b/src/backend/core/services/importer/mbox_tasks.py
@@ -307,11 +307,27 @@ def process_mbox_file_task(self, file_key: str, recipient_id: str) -> Dict[str, 
                             continue
 
                         parsed_email = parse_email_message(message_content)
+
+                        # Treat the message as a sent one when From matches
+                        # the destination mailbox — same heuristic as IMAP
+                        # and the EML import. Without this flag, importing
+                        # one's own sent mails would land them in the inbox
+                        # view.
+                        recipient_email = str(recipient)
+                        sender_email = (parsed_email.get("from") or {}).get(
+                            "email"
+                        ) or ""
+                        # TODO: better heuristic to determine if the message is from the sender
+                        is_import_sender = (
+                            sender_email.lower() == recipient_email.lower()
+                        )
+
                         if deliver_inbound_message(
-                            str(recipient),
+                            recipient_email,
                             parsed_email,
                             message_content,
                             is_import=True,
+                            is_import_sender=is_import_sender,
                         ):
                             success_count += 1
                         else:

--- a/src/backend/core/tests/mda/test_inbound_spoofed_sender.py
+++ b/src/backend/core/tests/mda/test_inbound_spoofed_sender.py
@@ -1,0 +1,239 @@
+# pylint: disable=redefined-outer-name
+"""Tests covering the spoofed-sender inbound bug.
+
+When an inbound MTA email arrives with ``From == To`` (a classic header
+forgery), the message must NOT be treated as a self-sent message. Marking it
+``is_sender=True`` makes it match the ``retry_messages_task`` filter
+(``is_sender=True`` AND ``delivery_status IN (RETRY, NULL)``), which would
+re-emit the spam — externally signed with our DKIM key if any external CC is
+present.
+
+Legitimate self-sends are protected by the ``mime_id`` dedup in
+``deliver_inbound_message``: the outbound copy already lives in the thread
+when ``send_message`` triggers the internal redelivery, so no second copy
+ever reaches ``_create_message_from_inbound``. The ``sender_email ==
+recipient_email`` shortcut is therefore dead code for the legitimate path
+and only fires for spoofed mails.
+"""
+
+from unittest.mock import patch
+
+from django.utils import timezone
+
+import pytest
+
+from core import enums, factories, models
+from core.mda.inbound import deliver_inbound_message
+from core.mda.inbound_tasks import process_inbound_message_task
+from core.mda.outbound_tasks import retry_messages_task
+
+
+def _build_spoofed_raw(victim_email: str) -> bytes:
+    """Build a minimal RFC 5322 message with From == To = victim."""
+    return (
+        f"From: {victim_email}\r\n"
+        f"To: {victim_email}\r\n"
+        "Subject: Spoofed self-sender\r\n"
+        "Message-ID: <spoof.1@example.com>\r\n"
+        "Date: Mon, 04 May 2026 09:00:00 +0000\r\n"
+        "\r\n"
+        "Spam body.\r\n"
+    ).encode()
+
+
+@pytest.fixture
+def victim_mailbox():
+    """Mailbox that receives the spoofed inbound."""
+    domain = factories.MailDomainFactory(name="victim.test")
+    return factories.MailboxFactory(local_part="alice", domain=domain)
+
+
+@pytest.mark.django_db
+class TestInboundSpoofedSender:
+    """Inbound delivery with ``From == To`` must not flag ``is_sender=True``."""
+
+    @patch("core.mda.inbound_tasks._check_spam_with_rspamd")
+    def test_inbound_spoofed_sender_not_marked_as_sender(
+        self, mock_rspamd, victim_mailbox
+    ):
+        """An MTA inbound spoofing From=To must NOT yield is_sender=True.
+
+        Reproduces the production incident: rspamd lets the message through
+        (``action: no action``), and our pipeline upgrades it to a self-sent
+        message because of the ``sender_email == recipient_email`` shortcut.
+        """
+        # Rspamd doesn't catch this kind of spoof in the current config.
+        mock_rspamd.return_value = (False, None, None)
+
+        recipient = str(victim_mailbox)
+        raw = _build_spoofed_raw(recipient)
+        parsed_email = {
+            "subject": "Spoofed self-sender",
+            "from": {"email": recipient},
+            "to": [{"email": recipient}],
+            "messageId": "spoof.1@example.com",
+            "date": timezone.now(),
+            "headers": {},
+            "headers_blocks": [],
+        }
+
+        # Bypass the Celery layer: deliver and process in-thread.
+        with patch("core.mda.inbound.process_inbound_message_task.delay") as mock_delay:
+            assert deliver_inbound_message(recipient, parsed_email, raw) is True
+
+        inbound = models.InboundMessage.objects.get(mailbox=victim_mailbox)
+        mock_delay.assert_called_once_with(str(inbound.id))
+
+        process_inbound_message_task.apply(args=[str(inbound.id)])
+
+        message = models.Message.objects.get(thread__accesses__mailbox=victim_mailbox)
+        assert message.is_sender is False, (
+            "Inbound MTA messages with spoofed From=To must not be flagged "
+            "as is_sender=True; otherwise retry_messages_task re-emits them."
+        )
+
+    @patch("core.mda.inbound_tasks._check_spam_with_rspamd")
+    @patch("core.mda.outbound_tasks.send_message")
+    def test_inbound_spoofed_sender_not_picked_up_by_retry(
+        self, mock_send_message, mock_rspamd, victim_mailbox
+    ):
+        """The retry task must skip messages built from a spoofed inbound.
+
+        This is the actionable harm: even if ``is_sender`` somehow leaks True,
+        the retry pipeline must not invoke ``send_message`` on it, because
+        that would DKIM-sign and re-emit the spam.
+        """
+        mock_rspamd.return_value = (False, None, None)
+
+        recipient = str(victim_mailbox)
+        raw = _build_spoofed_raw(recipient)
+        parsed_email = {
+            "subject": "Spoofed self-sender",
+            "from": {"email": recipient},
+            "to": [{"email": recipient}],
+            "messageId": "spoof.2@example.com",
+            "date": timezone.now(),
+            "headers": {},
+            "headers_blocks": [],
+        }
+
+        with patch("core.mda.inbound.process_inbound_message_task.delay"):
+            deliver_inbound_message(recipient, parsed_email, raw)
+
+        inbound = models.InboundMessage.objects.get(mailbox=victim_mailbox)
+        process_inbound_message_task.apply(args=[str(inbound.id)])
+
+        # Sanity: a recipient row exists with NULL delivery_status (the
+        # natural state for an inbound MessageRecipient).
+        message = models.Message.objects.get(thread__accesses__mailbox=victim_mailbox)
+        assert message.recipients.filter(delivery_status__isnull=True).exists()
+
+        # Run the periodic retry task. It must not pick the spoofed message.
+        result = retry_messages_task.apply(args=[]).get()
+
+        assert result["total_messages"] == 0, (
+            "retry_messages_task must not match an inbound spoofed message; "
+            f"got total_messages={result['total_messages']}"
+        )
+        mock_send_message.assert_not_called()
+
+    def test_inbound_spoofed_sender_legit_self_send_dedupes(self, victim_mailbox):
+        """A genuine self-send is dedupped, not re-created as is_sender=True.
+
+        The outbound message already lives in the thread before send_message
+        triggers the internal inbound redelivery; the mime_id dedup in
+        ``deliver_inbound_message`` short-circuits that redelivery so no
+        second copy gets minted. This is what protects legitimate
+        self-sends, NOT the ``sender_email == recipient_email`` shortcut in
+        ``_create_message_from_inbound`` — which only ever fires for
+        spoofed/anomalous mails and is the source of the bug.
+        """
+        recipient = str(victim_mailbox)
+        mime_id = "self.legit.1@example.com"
+
+        # Simulate the outbound message persisted by prepare_outbound_message.
+        thread = factories.ThreadFactory()
+        factories.ThreadAccessFactory(
+            mailbox=victim_mailbox,
+            thread=thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+        outbound = factories.MessageFactory(
+            thread=thread,
+            mime_id=mime_id,
+            is_draft=False,
+            is_sender=True,
+            subject="Genuine self-send",
+        )
+
+        parsed_email = {
+            "subject": "Genuine self-send",
+            "from": {"email": recipient},
+            "to": [{"email": recipient}],
+            "messageId": mime_id,
+            "date": timezone.now(),
+            "headers": {},
+            "headers_blocks": [],
+        }
+
+        assert (
+            deliver_inbound_message(
+                recipient, parsed_email, b"raw", skip_inbound_queue=True
+            )
+            is True
+        )
+
+        # Dedup short-circuits: only the original outbound message exists.
+        messages = models.Message.objects.filter(
+            thread__accesses__mailbox=victim_mailbox
+        )
+        assert messages.count() == 1
+        assert messages.first().id == outbound.id
+
+    def test_inbound_spoofed_sender_import_path_never_picked_up_by_retry(
+        self, victim_mailbox
+    ):
+        """An imported From=To message must not be picked up by retry.
+
+        Imports legitimately mint is_sender=True (via the EML/mbox/IMAP/PST
+        is_import_sender heuristic). The protection against the retry path
+        is structural: imported recipients always carry
+        ``delivery_status=SENT``, so the retry filter
+        ``delivery_status IN (RETRY, NULL)`` excludes them by construction.
+        """
+        recipient = str(victim_mailbox)
+        raw = _build_spoofed_raw(recipient)
+        parsed_email = {
+            "subject": "Imported self-send",
+            "from": {"email": recipient},
+            "to": [{"email": recipient}],
+            "messageId": "import.self.1@example.com",
+            "date": timezone.now(),
+            "headers": {},
+            "headers_blocks": [],
+        }
+
+        assert (
+            deliver_inbound_message(
+                recipient,
+                parsed_email,
+                raw,
+                is_import=True,
+                is_import_sender=True,
+            )
+            is True
+        )
+
+        message = models.Message.objects.get(thread__accesses__mailbox=victim_mailbox)
+        assert message.is_sender is True
+        # Every recipient row carries delivery_status=SENT, the structural
+        # guarantee that imports never enter the retry pipeline.
+        assert (
+            message.recipients.filter(
+                delivery_status=enums.MessageDeliveryStatusChoices.SENT
+            ).count()
+            == message.recipients.count()
+        )
+
+        result = retry_messages_task.apply(args=[]).get()
+        assert result["total_messages"] == 0

--- a/src/backend/core/tests/mda/test_outbound.py
+++ b/src/backend/core/tests/mda/test_outbound.py
@@ -451,6 +451,14 @@ class TestSendOutboundMessage:
             == 1
         )
 
+    def test_outbound_send_refuses_spam_flagged_message(self, draft_message):
+        """``send_message`` must refuse to emit a spam-flagged record."""
+        draft_message.is_spam = True
+        draft_message.save(update_fields=["is_spam"])
+
+        with pytest.raises(ValueError, match="flagged as spam"):
+            outbound.send_message(draft_message)
+
 
 class TestSendMessageRedisLock(TransactionTestCase):
     """Unit tests for the Redis lock functionality in send_message function."""

--- a/src/backend/core/tests/mda/test_retry.py
+++ b/src/backend/core/tests/mda/test_retry.py
@@ -642,3 +642,32 @@ class TestRetryMessagesTask:
         assert mock_update_state.call_count == 4
         # Verify it's significantly less than total messages
         assert mock_update_state.call_count < result["total_messages"]
+
+    @patch("core.mda.outbound_tasks.send_message")
+    def test_retry_excludes_spam_flagged_messages(
+        self, mock_send_message, mailbox_sender, thread
+    ):
+        """Spam-flagged messages must never be picked up by the retry filter."""
+        sender_contact = factories.ContactFactory(mailbox=mailbox_sender)
+        message = factories.MessageFactory(
+            thread=thread,
+            sender=sender_contact,
+            is_draft=False,
+            is_sender=True,
+            is_spam=True,
+            subject="Spam-flagged retry candidate",
+        )
+        recipient_contact = factories.ContactFactory(
+            mailbox=mailbox_sender, email="external@example.com"
+        )
+        factories.MessageRecipientFactory(
+            message=message,
+            contact=recipient_contact,
+            type=models.MessageRecipientTypeChoices.TO,
+            delivery_status=None,
+        )
+
+        result = retry_messages_task.apply(args=[]).get()
+
+        assert result["total_messages"] == 0
+        mock_send_message.assert_not_called()


### PR DESCRIPTION
## Purpose

A spoofed inbound with From == To was being marked is_sender=True via the
`sender_email == recipient_email` shortcut in
_create_message_from_inbound.
Because MessageRecipient rows from the inbound path carry no delivery_status, those messages matched retry_messages_task's (is_sender=True AND delivery_status IN (RETRY, NULL)) filter and went through send_message on every 5-min beat — DKIM-signing and re-emitting the spam to every recipient on the envelope, externals included.

Legitimate self-sends are unaffected: send_message's internal redelivery hits the mime_id dedup in deliver_inbound_message before reaching _create_message_from_inbound, so the shortcut was already dead code on the legitimate path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inbound messages where sender equals recipient are no longer treated as sent by you; these won’t be reprocessed or incorrectly retried.
  * Imported messages preserve correct sender attribution so imports marked as sender behave appropriately without causing retry loops.
  * Self-sent emails remain deduplicated so only the original sent message appears.

* **New Features**
  * Messages flagged as spam are blocked from being sent or retried.

* **Tests**
  * New tests cover spoofed-sender, spam-blocking, retry, and import behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->