### PR TITLE
🐛(flanker) fix email parsing edge cases with UTF8

### DIFF
--- a/src/backend/core/tests/mda/test_rfc5322_composer.py
+++ b/src/backend/core/tests/mda/test_rfc5322_composer.py
@@ -282,6 +282,105 @@ class TestEmailComposition:
         assert parsed["Bcc"] == "Secret <secret@example.com>"
         assert parsed["Subject"] == "Email to Multiple Recipients"
 
+    def test_compose_to_header_with_non_ascii_recipients_is_rfc5322_valid(self):
+        """Long To header with non-ASCII display names must stay RFC 5322 + 2047 valid.
+
+        Regression test: when any recipient has a non-ASCII display name, the
+        underlying MIME library used to re-serialize the whole To header and join
+        addresses with '; ' instead of ', '. Because ';' is not a valid
+        address-list separator (RFC 5322 §3.4 requires ','), Python's stdlib refold
+        in compose_email() then failed to recognise the structure and refolded it
+        as unstructured text, hiding '<', '>', '@', ';' inside =?utf-8?q?...?=
+        encoded words — which also violates RFC 2047 §5.
+        """
+        jmap_data = {
+            "from": [{"name": "Sender", "email": "sender@example.com"}],
+            "to": [
+                {"name": "Alice Doe", "email": "alice@example.com"},
+                {"name": "Benoît Dupont", "email": "benoit@example.com"},
+                {"name": "GARCIA Chloé", "email": "chloe@example.com"},
+                {"name": "david.smith", "email": "david@example.com"},
+                {"name": "eve@example.com", "email": "eve@example.com"},
+                {"name": "MÜLLER Frank", "email": "frank@example.com"},
+                {"name": "MARTIN Géraldine", "email": "geraldine@example.com"},
+                {"name": "Hélène Roux", "email": "helene@example.com"},
+            ],
+            "subject": "Test",
+            "textBody": ["body"],
+        }
+
+        result_bytes = compose_email(jmap_data)
+        raw = result_bytes.decode("utf-8")
+
+        # Extract the folded To header.
+        to_match = re.search(r"^To:(.*?)(?=^\S)", raw, re.MULTILINE | re.DOTALL)
+        assert to_match, "To header not found"
+        to_value = to_match.group(1).replace("\r\n", " ").replace("\n", " ").strip()
+
+        # RFC 5322 §3.4: address-list MUST be comma-separated. ';' is only valid
+        # as the terminator of a `group:` construct, which we do not use.
+        assert "; " not in to_value, (
+            f"To header uses ';' as separator (RFC 5322 violation): {to_value!r}"
+        )
+
+        # RFC 2047 §5: encoded-words may only appear in the phrase part of an
+        # address. They must not encode addr-spec delimiters.
+        forbidden = {"=3C", "=3E", "=40", "=3B", "=2C"}  # < > @ ; ,
+        for ew in re.findall(r"=\?[^?]+\?[QqBb]\?[^?]*\?=", to_value):
+            hits = [tok for tok in forbidden if tok.lower() in ew.lower()]
+            assert not hits, (
+                f"Encoded-word encodes structural delimiter(s) {hits} "
+                f"(RFC 2047 §5 violation): {ew!r}"
+            )
+
+        # Round-trip: stdlib must parse back the same set of recipients.
+        parsed = BytesParser().parsebytes(result_bytes)
+        addrs = email.utils.getaddresses([parsed["To"]])
+        emails = {addr for _, addr in addrs}
+        expected = {a["email"] for a in jmap_data["to"]}
+        assert emails == expected, (
+            f"Recipient set mangled by header serialization. "
+            f"expected={expected}, got={emails}"
+        )
+
+    def test_compose_to_header_with_comma_in_non_ascii_name(self):
+        """Display names that contain ',' and non-ASCII chars must round-trip.
+
+        ',' is the address-list separator, so a name like "Doe, Jané" must be
+        quoted (RFC 5322 §3.2.4) AND any non-ASCII content must be encoded per
+        RFC 2047. After composing, parsing back must yield exactly one recipient
+        with the original name. Mixing both axes is the dangerous case: each
+        rule alone is fine, but together they have historically broken in the
+        underlying MIME library (e.g. naive encoded-word wrapping that drops
+        the surrounding quotes, turning the ',' into a list separator).
+        """
+        jmap_data = {
+            "from": [{"name": "Sender", "email": "sender@example.com"}],
+            "to": [
+                {"name": "Doe, Jané", "email": "jane@example.com"},
+                {"name": "Müller, Frank", "email": "frank@example.com"},
+                {"name": "Plain Bob", "email": "bob@example.com"},
+            ],
+            "subject": "Test",
+            "textBody": ["body"],
+        }
+
+        result_bytes = compose_email(jmap_data)
+        parsed = BytesParser().parsebytes(result_bytes)
+
+        addrs = email.utils.getaddresses([parsed["To"]])
+        # Decode any encoded-words inside the names before comparing.
+        decoded = [(decode_header_string(n), e) for n, e in addrs]
+
+        assert decoded == [
+            ("Doe, Jané", "jane@example.com"),
+            ("Müller, Frank", "frank@example.com"),
+            ("Plain Bob", "bob@example.com"),
+        ], (
+            f"Comma-in-non-ASCII-name lost in round-trip. "
+            f"raw To header: {parsed['To']!r}, decoded: {decoded}"
+        )
+
     def test_compose_with_custom_headers(self):
         """Test composing an email with custom headers."""
         jmap_data = {

--- a/src/backend/core/tests/mda/test_rfc5322_parser.py
+++ b/src/backend/core/tests/mda/test_rfc5322_parser.py
@@ -279,6 +279,42 @@ class TestEmailAddressParsing:
         assert name == "José García"
         assert email_addr == "jose@example.es"
 
+    def test_parse_address_with_comma_and_unicode_in_name(self):
+        """Quoted name combining ',' and non-ASCII must yield one recipient.
+
+        ',' is the address-list separator; if quote-stripping or encoded-word
+        decoding misorders, the parser can split a single recipient into two.
+        """
+        name, email_addr = parse_email_address('"García, José" <jose@example.es>')
+        assert name == "García, José"
+        assert email_addr == "jose@example.es"
+
+        # Same idea but with the non-ASCII coming through an RFC 2047
+        # encoded-word inside the quoted display-name.
+        name, email_addr = parse_email_address(
+            '"=?utf-8?q?Garc=C3=ADa=2C_Jos=C3=A9?=" <jose@example.es>'
+        )
+        assert name == "García, José"
+        assert email_addr == "jose@example.es"
+
+    def test_parse_multiple_recipients_with_comma_and_unicode_in_names(self):
+        """Address-list with ',' inside non-ASCII display names must not be split.
+
+        Three recipients where two have both a literal ',' and non-ASCII chars
+        in their names. A naive splitter that decodes encoded-words before
+        splitting on ',' (or that ignores quotes) would yield more than three
+        addresses.
+        """
+        addresses = parse_email_addresses(
+            '"Doe, Jané" <jane@example.com>, '
+            '"=?utf-8?q?M=C3=BCller=2C_Frank?=" <frank@example.com>, '
+            "third@example.com"
+        )
+        assert len(addresses) == 3
+        assert addresses[0] == ("Doe, Jané", "jane@example.com")
+        assert addresses[1] == ("Müller, Frank", "frank@example.com")
+        assert addresses[2] == ("", "third@example.com")
+
     # RFC 5322 Group Syntax Tests
     # These test cases handle email headers like "undisclosed-recipients:;"
     # which are valid RFC 5322 group syntax used to hide recipients.

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "drf_spectacular==0.29.0",
     "opensearch-py==2.8.0",
     "factory_boy==3.3.3",
-    "flanker@git+https://github.com/sylvinus/flanker@f94ba2c15ab310e333610a78828d09be4e11a6b6",
+    "flanker@git+https://github.com/sylvinus/flanker@a4248826794d446b07fb26719479c1c355411f5a",
     "gunicorn==25.1.0",
     "jsonschema==4.26.0",
     "nested-multipart-parser==1.6.0",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -878,7 +878,7 @@ wheels = [
 [[package]]
 name = "flanker"
 version = "0.9.11"
-source = { git = "https://github.com/sylvinus/flanker?rev=f94ba2c15ab310e333610a78828d09be4e11a6b6#f94ba2c15ab310e333610a78828d09be4e11a6b6" }
+source = { git = "https://github.com/sylvinus/flanker?rev=a4248826794d446b07fb26719479c1c355411f5a#a4248826794d446b07fb26719479c1c355411f5a" }
 dependencies = [
     { name = "attrs" },
     { name = "chardet" },
@@ -1307,7 +1307,7 @@ requires-dist = [
     { name = "drf-spectacular", specifier = "==0.29.0" },
     { name = "drf-spectacular-sidecar", marker = "extra == 'dev'", specifier = "==2026.1.1" },
     { name = "factory-boy", specifier = "==3.3.3" },
-    { name = "flanker", git = "https://github.com/sylvinus/flanker?rev=f94ba2c15ab310e333610a78828d09be4e11a6b6" },
+    { name = "flanker", git = "https://github.com/sylvinus/flanker?rev=a4248826794d446b07fb26719479c1c355411f5a" },
     { name = "flower", marker = "extra == 'dev'", specifier = "==2.0.1" },
     { name = "gunicorn", specifier = "==25.1.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.151.9" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests validating RFC 5322 compliance for email headers with non-ASCII recipients and international display names.
  * Added tests for parsing email addresses containing Unicode characters and commas in display names.

* **Chores**
  * Updated dependency version in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->