### PR TITLE
🚸(frontend) add read/unread action on thread action bar

### DIFF
--- a/src/e2e/src/__tests__/thread-starred-read.spec.ts
+++ b/src/e2e/src/__tests__/thread-starred-read.spec.ts
@@ -119,18 +119,17 @@ test.describe("Thread read / unread", () => {
       .getByRole("heading", { name: "Inbox thread alpha", level: 2 })
       .waitFor({ state: "visible" });
 
-    // Wait for the auto-read mechanism to kick in
-    await page.waitForLoadState("networkidle");
-
-    // Click "More options" dropdown in the thread action bar
-    // Use dispatchEvent to bypass Tooltip interference with DropdownMenu click handling
+    // Wait for the auto-read mechanism to kick in: the thread becomes
+    // read, so the action bar swaps the "Mark as read" button for
+    // "Mark as unread".
     const threadActionBar = page.locator(".thread-action-bar");
-    await threadActionBar
-      .getByRole("button", { name: "More options" })
-      .dispatchEvent("click");
+    const markAsUnreadButton = threadActionBar.getByRole("button", {
+      name: "Mark as unread",
+    });
+    await expect(markAsUnreadButton).toBeVisible();
 
     // Click "Mark as unread" — this also triggers unselectThread
-    await page.getByRole("menuitem", { name: "Mark as unread" }).click();
+    await markAsUnreadButton.click();
 
     // After marking as unread, the thread is deselected and we're back at the list
     // Verify thread item shows unread indicator
@@ -174,8 +173,8 @@ test.describe("Thread read / unread", () => {
     // Close the thread to go back to the list
     await page.getByRole("button", { name: "Close this thread" }).click();
 
-    // The thread should still be visible in the list thanks to structuralSharing
-    // (optimistic update keeps it in place even though the server would filter it out)
+    // The thread should still be visible in the list thanks to thread pinning logic
+    // Check @/features/providers/mailbox-cache.ts
     await expect(
       page.getByRole("link", { name: "Inbox thread alpha" }).first(),
     ).toBeVisible();

--- a/src/frontend/src/features/controlled-modals/message-importer/step-completed.tsx
+++ b/src/frontend/src/features/controlled-modals/message-importer/step-completed.tsx
@@ -11,7 +11,7 @@ export const StepCompleted = ({ onClose }: StepCompletedProps) => {
     return (
         <div className="importer-completed">
             <div className="importer-completed__description">
-                <span className="material-icons">mark_email_read</span>
+                <span className="material-icons">drafts</span>
                 <p>{t('Your messages have been imported successfully!')}</p>
             </div>
             <Button onClick={onClose}>{t('Close')}</Button>

--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-panel-header.tsx
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-panel-header.tsx
@@ -205,7 +205,7 @@ const ThreadPanelTitle = ({ selectedThreadIds, isAllSelected, isSomeSelected, is
                                     readAt: selectionReadStatus === SelectionReadStatus.READ ? null : new Date().toISOString(),
                                 });
                             }}
-                            icon={<Icon name={selectionReadStatus === SelectionReadStatus.READ ? 'mark_email_unread' : 'mark_email_read'} type={IconType.OUTLINED} />}
+                            icon={<Icon name={selectionReadStatus === SelectionReadStatus.READ ? 'mark_email_unread' : 'drafts'} type={IconType.OUTLINED} />}
                             variant="tertiary"
                             size="nano"
                             aria-label={mainReadTooltip}
@@ -300,7 +300,7 @@ const ThreadPanelTitle = ({ selectedThreadIds, isAllSelected, isSomeSelected, is
                             },
                             ...([SelectionReadStatus.MIXED, SelectionReadStatus.UNREAD].includes(selectionReadStatus) ? [{
                                 label: markAllTooltip,
-                                icon: <span className="material-icons">mark_email_read</span>,
+                                icon: <span className="material-icons">drafts</span>,
                                 callback: () => {
                                     markAsReadAt({
                                         threadIds: threadIdsToMark,

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-action-bar/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-action-bar/index.tsx
@@ -31,7 +31,7 @@ export const ThreadActionBar = ({ canUndelete, canUnarchive }: ThreadActionBarPr
     const { deleteThreadAccess } = useDeleteThreadAccess();
     const modals = useModals();
     // Full edit rights on the thread — gates archive, spam, delete.
-    // Star and "mark as unread" remain visible because they are personal
+    // Star and read/unread toggle remain visible because they are personal
     // state on the user's ThreadAccess (read_at / starred_at).
     // Label assignment is scoped to the mailbox (see `LabelsWidget`) and
     // therefore stays visible for viewer-only threads.
@@ -39,6 +39,7 @@ export const ThreadActionBar = ({ canUndelete, canUnarchive }: ThreadActionBarPr
     const canShowArchiveCTA = canEditThread && !selectedThread?.is_spam
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
     const isStarred = selectedThread?.has_starred;
+    const hasUnread = selectedThread?.has_unread;
     const mailboxAccess = selectedThread?.accesses.find((a) => a.mailbox.id === selectedMailbox?.id);
     const hasOnlyOneEditor = selectedThread?.accesses.filter((a) => a.role === ThreadAccessRoleChoices.editor).length === 1;
     const canLeaveThread = selectedMailbox?.role !== MailboxRoleChoices.viewer && mailboxAccess && selectedThread && (!hasOnlyOneEditor || mailboxAccess.role !== ThreadAccessRoleChoices.editor);
@@ -149,6 +150,30 @@ export const ThreadActionBar = ({ canUndelete, canUnarchive }: ThreadActionBarPr
                 )
             )}
             {canEditThread && <VerticalSeparator />}
+            {hasUnread ? (
+                <Tooltip content={t('Mark as read')}>
+                    <Button
+                        variant="tertiary"
+                        aria-label={t('Mark as read')}
+                        size="nano"
+                        icon={<Icon name="drafts" type={IconType.OUTLINED} />}
+                        onClick={() => markAsReadAt({ threadIds: [selectedThread!.id], readAt: new Date().toISOString() })}
+                    />
+                </Tooltip>
+            ) : (
+                <Tooltip content={t('Mark as unread')}>
+                    <Button
+                        variant="tertiary"
+                        aria-label={t('Mark as unread')}
+                        size="nano"
+                        icon={<Icon name="mark_email_unread" type={IconType.OUTLINED} />}
+                        onClick={() => {
+                            unselectThread();
+                            markAsReadAt({ threadIds: [selectedThread!.id], readAt: null });
+                        }}
+                    />
+                </Tooltip>
+            )}
             {isStarred ? (
                 <Tooltip content={t('Unstar this thread')}>
                     <Button
@@ -172,39 +197,29 @@ export const ThreadActionBar = ({ canUndelete, canUnarchive }: ThreadActionBarPr
             )}
             <LabelsWidget threadIds={[selectedThread!.id]} initialLabels={selectedThread!.labels} />
             <ThreadAccessesWidget accesses={selectedThread!.accesses} />
-            <DropdownMenu
-                isOpen={isDropdownOpen}
-                onOpenChange={setIsDropdownOpen}
-                options={[
-                    {
-                        label: t('Mark as unread'),
-                        icon: <Icon name="mark_email_unread" type={IconType.OUTLINED} />,
-                        // Unmount the thread view before firing the mutation. If we waited for
-                        // onSuccess, the cache patch would re-flag visible messages as unread
-                        // while the view is still mounted, letting the visibility observer
-                        // debounce a mark-as-read request that silently reverts this action.
-                        callback: () => {
-                            unselectThread();
-                            markAsReadAt({ threadIds: [selectedThread!.id], readAt: null });
+            {canLeaveThread && (
+                <DropdownMenu
+                    isOpen={isDropdownOpen}
+                    onOpenChange={setIsDropdownOpen}
+                    options={[
+                        {
+                            label: t('Leave this thread'),
+                            icon: <Icon name="exit_to_app" type={IconType.OUTLINED} />,
+                            callback: handleLeaveThread,
                         },
-                    },
-                    ...(canLeaveThread ? [{
-                        label: t('Leave this thread'),
-                        icon: <Icon name="exit_to_app" type={IconType.OUTLINED} />,
-                        callback: handleLeaveThread,
-                    }] : []),
-                ]}
-            >
-                <Tooltip content={t('More options')}>
-                    <Button
-                        onClick={() => setIsDropdownOpen(true)}
-                        icon={<Icon name="more_vert" type={IconType.OUTLINED} />}
-                        variant="tertiary"
-                        aria-label={t('More options')}
-                        size="nano"
-                    />
-                </Tooltip>
-            </DropdownMenu>
+                    ]}
+                >
+                    <Tooltip content={t('More options')}>
+                        <Button
+                            onClick={() => setIsDropdownOpen(true)}
+                            icon={<Icon name="more_vert" type={IconType.OUTLINED} />}
+                            variant="tertiary"
+                            aria-label={t('More options')}
+                            size="nano"
+                        />
+                    </Tooltip>
+                </DropdownMenu>
+            )}
         </div>
     )
 }

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-actions.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-actions.tsx
@@ -108,7 +108,7 @@ const ThreadMessageActions = ({
         }] : []),
         ...(message.is_unread ? [{
             label: hasSiblingMessages ? t('Mark as read from here') : t('Mark as read'),
-            icon: <Icon type={IconType.FILLED} name="mark_email_read" />,
+            icon: <Icon type={IconType.FILLED} name="drafts" />,
             callback: () => toggleReadStateFrom(false)
         }] :
         [{


### PR DESCRIPTION
## Purpose

Currently to mark a thread as read/unread, the user have to open a dropdown
menu then click on the action... as this action can be done often, we put it
directly in the thread action bar.

<img width="942" height="198" alt="Capture d’écran 2026-05-06 à 18 52 37" src="https://github.com/user-attachments/assets/ef7b8e49-998b-4f70-a44b-6e04f9e1c1b9" />
<img width="942" height="199" alt="Capture d’écran 2026-05-06 à 18 52 16" src="https://github.com/user-attachments/assets/bf2a02d8-10ea-4c44-b654-d6519a578ed5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual icons for mark read/unread actions across the interface.

* **Tests**
  * Updated test cases for thread marking functionality and filter behavior.

* **UX Improvement**
  * Reorganized thread action controls to make mark read/unread actions more directly accessible in the action bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->