### PR TITLE
🌐(frontend) localized attachment separator

### DIFF
--- a/src/frontend/src/features/utils/mail-helper.test.tsx
+++ b/src/frontend/src/features/utils/mail-helper.test.tsx
@@ -1,8 +1,19 @@
 import { vi } from 'vitest';
 import MailHelper, { SUPPORTED_IMAP_DOMAINS, ATTACHMENT_SEPARATORS } from './mail-helper';
 import DetectionMap from '@/features/i18n/attachments-detection-map.json';
+import i18n from '@/features/i18n/initI18n';
 
 vi.mock('./errors', () => ({ handle: vi.fn() }));
+
+const withLanguage = (lng: string, fn: () => void) => {
+  const previous = i18n.language;
+  i18n.language = lng;
+  try {
+    fn();
+  } finally {
+    i18n.language = previous;
+  }
+};
 
 describe('MailHelper', () => {
   describe('markdownToHtml', () => {
@@ -870,6 +881,82 @@ describe('MailHelper', () => {
       for (const pattern of regexPatterns) {
         expect(() => new RegExp(pattern.slice(1, -1), 'i')).not.toThrowError();
       }
+    });
+  });
+
+  describe('localized attachment separator', () => {
+    const attachments = [
+      { id: '1', name: 'test.pdf', url: 'https://example.com/test.pdf', type: 'application/pdf', size: 100, created_at: '2021-01-01' }
+    ];
+
+    it('should use the French separator when i18n language is fr-FR', () => {
+      withLanguage('fr-FR', () => {
+        const draft = MailHelper.attachDriveAttachmentsToDraft('Bonjour', attachments);
+        expect(draft).toContain('---------- Fichiers joints ----------');
+        expect(draft).not.toContain('---------- Drive attachments ----------');
+      });
+    });
+
+    it('should use the Dutch separator when i18n language is nl-NL', () => {
+      withLanguage('nl-NL', () => {
+        const text = MailHelper.attachDriveAttachmentsToTextBody('Hallo', attachments);
+        expect(text).toContain('---------- Drive-bijlagen ----------');
+      });
+    });
+
+    it('should use the English separator when i18n language is en-US', () => {
+      withLanguage('en-US', () => {
+        const html = MailHelper.attachDriveAttachmentsToHtmlBody('<p>Hi</p>', attachments);
+        expect(html).toContain('---------- Drive attachments ----------');
+      });
+    });
+
+    it('should fall back to the legacy English separator for an unknown language', () => {
+      withLanguage('xx-XX', () => {
+        const draft = MailHelper.attachDriveAttachmentsToDraft('Hello', attachments);
+        expect(draft).toContain('---------- Drive attachments ----------');
+      });
+    });
+
+    it('should round-trip a French-localized text body regardless of the reader language', () => {
+      let text = '';
+      withLanguage('fr-FR', () => {
+        text = MailHelper.attachDriveAttachmentsToTextBody('Bonjour', attachments);
+      });
+      expect(text).toContain('---------- Fichiers joints ----------');
+
+      withLanguage('en-US', () => {
+        const result = MailHelper.extractDriveAttachmentsFromTextBody(text);
+        expect(result).toEqual([
+          'Bonjour',
+          [{ name: 'test.pdf', url: 'https://example.com/test.pdf' }]
+        ]);
+      });
+    });
+
+    it('should round-trip a Dutch-localized html body regardless of the reader language', () => {
+      let html = '';
+      withLanguage('nl-NL', () => {
+        html = MailHelper.attachDriveAttachmentsToHtmlBody('<h1>Hallo</h1>', attachments);
+      });
+      expect(html).toContain('---------- Drive-bijlagen ----------');
+
+      withLanguage('fr-FR', () => {
+        const [body, extracted] = MailHelper.extractDriveAttachmentsFromHtmlBody(html);
+        expect(body).toBe('<h1>Hallo</h1>');
+        expect(extracted).toHaveLength(1);
+        expect(extracted[0].name).toBe('test.pdf');
+      });
+    });
+
+    it('should expose every localized separator in ATTACHMENT_SEPARATORS for parsing', () => {
+      // Guards against accidentally adding a localized separator without
+      // appending it to ATTACHMENT_SEPARATORS, which would break parsing.
+      expect(ATTACHMENT_SEPARATORS).toEqual(expect.arrayContaining([
+        '---------- Drive attachments ----------',
+        '---------- Fichiers joints ----------',
+        '---------- Drive-bijlagen ----------',
+      ]));
     });
   });
 });

--- a/src/frontend/src/features/utils/mail-helper.tsx
+++ b/src/frontend/src/features/utils/mail-helper.tsx
@@ -1,6 +1,7 @@
 import { renderToString, renderToStaticMarkup } from "react-dom/server";
 import { Markdown } from "@react-email/components";
 import DetectionMap from "@/features/i18n/attachments-detection-map.json";
+import i18n from "@/features/i18n/initI18n";
 import z from "zod";
 import { DriveFile } from "../forms/components/message-form/drive-attachment-picker";
 import { handle } from "./errors";
@@ -42,8 +43,22 @@ export const SUPPORTED_IMAP_DOMAINS = new Map<string, ImapConfig>([
    If you want to change the separator, you must add a new value in the array
    Otherwise, previous messages will not be able to be parsed correctly
    /!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\/!\ */
-export const ATTACHMENT_SEPARATORS = ['---------- Drive attachments ----------'];
-const ATTACHMENT_SEPARATOR = ATTACHMENT_SEPARATORS[ATTACHMENT_SEPARATORS.length - 1];
+export const ATTACHMENT_SEPARATORS = [
+    '---------- Drive attachments ----------',
+    '---------- Fichiers joints ----------',
+    '---------- Drive-bijlagen ----------',
+];
+
+// Active separator used when sending a new message, keyed by i18n language code.
+// Unknown languages fall back to the legacy English value (first entry above).
+const ATTACHMENT_SEPARATORS_BY_LANG: Record<string, string> = {
+    'en-US': '---------- Drive attachments ----------',
+    'fr-FR': '---------- Fichiers joints ----------',
+    'nl-NL': '---------- Drive-bijlagen ----------',
+};
+
+const getAttachmentSeparator = (): string =>
+    ATTACHMENT_SEPARATORS_BY_LANG[i18n.language] ?? ATTACHMENT_SEPARATORS[0];
 
 /** An helper which aims to gather all utils related write and send a message */
 class MailHelper {
@@ -174,7 +189,7 @@ class MailHelper {
     static attachDriveAttachmentsToDraft(draft: string = '', attachments: DriveFile[] = []) {
         if (attachments.length === 0) return draft;
         return draft
-        + ATTACHMENT_SEPARATOR
+        + getAttachmentSeparator()
         + JSON.stringify(attachments);
     }
 
@@ -185,7 +200,7 @@ class MailHelper {
     static attachDriveAttachmentsToTextBody(textBody: string = '', attachments: DriveFile[] = []) {
         if (attachments.length === 0) return textBody;
         return textBody
-        + `\n${ATTACHMENT_SEPARATOR}\n`
+        + `\n${getAttachmentSeparator()}\n`
         + attachments.map(a =>
             `- [${a.name}](${a.url})`
         ).join('\n')
@@ -199,7 +214,7 @@ class MailHelper {
     static attachDriveAttachmentsToHtmlBody(htmlBody: string = '', attachments: DriveFile[] = []) {
         if (attachments.length === 0) return htmlBody;
         return htmlBody
-        + `\n${ATTACHMENT_SEPARATOR}\n`
+        + `\n${getAttachmentSeparator()}\n`
         + renderToStaticMarkup(
             <ul>
                 {attachments.map((a) => (


### PR DESCRIPTION
## Purpose

The `ATTACHMENT_SEPARATORS` only contains a english separator and as this
string is displayed within other mail client, for non-english users it can
be weird to see an english string. That's why we add new separators and according to the sender language, we use the localized separator that correspond to him.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Attachment separators in email messages now support multiple languages including English, French, and Dutch. The system automatically falls back to English for unsupported languages and correctly extracts attachments regardless of the separator language used.

* **Tests**
  * Added comprehensive test coverage for localized attachment separator functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/messages/pull/660)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->