### PR TITLE
🐛(backend) allow thread editor to destroy thread accesses

### DIFF
--- a/src/backend/core/api/permissions.py
+++ b/src/backend/core/api/permissions.py
@@ -277,6 +277,21 @@ class IsAllowedToCreateMessage(IsAuthenticated):
         return True
 
 
+def _user_can_manage_thread_access(user, thread_id):
+    """True if ``user`` has full edit rights on the thread.
+
+    Full edit rights on a thread are the prerequisite for managing its
+    ``ThreadAccess`` rows (list, create, update, destroy peers' access).
+    They require an EDITOR ``ThreadAccess`` on the thread via a mailbox
+    where the user holds ``MAILBOX_ROLES_CAN_EDIT``.
+    """
+    return (
+        models.ThreadAccess.objects.editable_by(user)
+        .filter(thread_id=thread_id)
+        .exists()
+    )
+
+
 class IsAllowedToManageThreadAccess(IsAuthenticated):
     """Permission class for access to create, update, delete and list thread accesses."""
 
@@ -286,33 +301,8 @@ class IsAllowedToManageThreadAccess(IsAuthenticated):
         if not thread_id:
             return False
 
-        # if create action, check if user has admin/editor access to the mailbox and the thread access role is editor
-        if view.action == "create":
-            # authenticated user wants to create a thread access for a specific thread
-            # check if user has admin/editor access to the mailbox and the
-            # thread access role is editor already exists for them
-            return (
-                models.ThreadAccess.objects.select_related("mailbox")
-                .filter(
-                    thread_id=thread_id,
-                    mailbox__accesses__user=request.user,
-                    mailbox__accesses__role__in=enums.MAILBOX_ROLES_CAN_EDIT,
-                    role=enums.ThreadAccessRoleChoices.EDITOR,
-                )
-                .exists()
-            )
-        if view.action == "list":
-            # list is only allowed for a user with access to the thread
-            return (
-                models.ThreadAccess.objects.select_related("mailbox")
-                .filter(
-                    thread_id=thread_id,
-                    mailbox__accesses__user=request.user,
-                    mailbox__accesses__role__in=enums.MAILBOX_ROLES_CAN_EDIT,
-                    role=enums.ThreadAccessRoleChoices.EDITOR,
-                )
-                .exists()
-            )
+        if view.action in ("create", "list"):
+            return _user_can_manage_thread_access(request.user, thread_id)
 
         return True  # to proceed to object-level checks
 
@@ -324,27 +314,21 @@ class IsAllowedToManageThreadAccess(IsAuthenticated):
         if obj.thread.id != view.kwargs.get("thread_id"):
             return False
 
-        # Destroying a ThreadAccess removes the thread for every member of
-        # `obj.mailbox` (the row is unique per (thread, mailbox)). Require
-        # editor-level rights on that mailbox so a viewer cannot revoke
-        # access on behalf of the whole team. Thread role is irrelevant:
-        # a viewer on the thread but editor on the mailbox can still leave.
-        if view.action == "destroy":
+        can_manage_thread_access = _user_can_manage_thread_access(
+            request.user, obj.thread_id
+        )
+
+        # Destroy is symmetric with create: any user who can manage the
+        # thread's accesses (full edit rights on the thread) can revoke a
+        # peer's ThreadAccess. Additionally users who only have edit-rights
+        # on the mailbox being removed can leave the thread.
+        if view.action == "destroy" and not can_manage_thread_access:
             return obj.mailbox.accesses.filter(
                 user=request.user,
                 role__in=enums.MAILBOX_ROLES_CAN_EDIT,
             ).exists()
 
-        return (
-            models.ThreadAccess.objects.select_related("mailbox")
-            .filter(
-                thread=obj.thread,
-                mailbox__accesses__user=request.user,
-                mailbox__accesses__role__in=enums.MAILBOX_ROLES_CAN_EDIT,
-                role=enums.ThreadAccessRoleChoices.EDITOR,
-            )
-            .exists()
-        )
+        return can_manage_thread_access
 
 
 class IsMailDomainAdmin(permissions.BasePermission):

--- a/src/backend/core/tests/api/test_thread_access.py
+++ b/src/backend/core/tests/api/test_thread_access.py
@@ -709,6 +709,48 @@ class TestThreadAccessDelete:
         response = api_client.delete(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    @pytest.mark.parametrize(
+        "mailbox_access_role",
+        [
+            enums.MailboxRoleChoices.ADMIN,
+            enums.MailboxRoleChoices.EDITOR,
+            enums.MailboxRoleChoices.SENDER,
+        ],
+    )
+    def test_delete_other_mailbox_thread_access_allowed_when_manager(
+        self, api_client, mailbox_access_role
+    ):
+        """A user with full edit rights on the thread can revoke another
+        mailbox's ThreadAccess — symmetric with the create permission."""
+        user = factories.UserFactory()
+        api_client.force_authenticate(user=user)
+
+        mailbox = factories.MailboxFactory()
+        factories.MailboxAccessFactory(
+            mailbox=mailbox,
+            user=user,
+            role=mailbox_access_role,
+        )
+        thread = factories.ThreadFactory()
+        # User's own EDITOR access — grants management rights on the thread
+        factories.ThreadAccessFactory(
+            mailbox=mailbox,
+            thread=thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+        # Another mailbox's access on the same thread that the user wants to revoke
+        other_thread_access = factories.ThreadAccessFactory(
+            thread=thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+
+        url = get_thread_access_url(thread.id, other_thread_access.id)
+        response = api_client.delete(url)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not models.ThreadAccess.objects.filter(
+            id=other_thread_access.id
+        ).exists()
+
     def test_delete_thread_access_not_found(self, api_client, mailbox_with_access):
         """Test deleting a non-existent thread access."""
         user, _ = mailbox_with_access


### PR DESCRIPTION
## Purpose

Currently, only mailbox editors can remove thread access to their mailbox.
Actually, thread access deletion must be symmetric with creation rights. So
any user with thread management ability should be able to delete a thread
access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved permission checks for thread access operations, with enhanced authorization validation to ensure proper access control when managing and deleting thread permissions.

* **Tests**
  * Added test coverage validating user permissions and authorization when performing thread access operations, including deletion scenarios across different user roles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/messages/pull/668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->