### PR TITLE
👔(backend) allow to delete internal message at any time

### DIFF
--- a/src/backend/core/api/viewsets/thread_event.py
+++ b/src/backend/core/api/viewsets/thread_event.py
@@ -88,18 +88,6 @@ class ThreadEventViewSet(
         # that changes the mentions list adds/removes notifications.
         thread_events_service.sync_im_mentions(thread_event=thread_event)
 
-    def perform_destroy(self, instance):
-        """Reject deletions made after the configured edit delay elapsed.
-
-        Deletion is gated alongside edits so users cannot circumvent the
-        window by deleting and recreating an event.
-        """
-        if not instance.is_editable():
-            raise PermissionDenied(
-                "This event can no longer be deleted (edit delay expired)."
-            )
-        instance.delete()
-
     @extend_schema(
         request=None,
         responses={

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1709,7 +1709,7 @@ class ThreadEvent(BaseModel):
         super().clean()
 
     def is_editable(self):
-        """Return whether the event can still be edited or deleted.
+        """Return whether the event can still be edited.
 
         The time window is controlled by `settings.MAX_THREAD_EVENT_EDIT_DELAY`
         (in seconds). A value of 0 disables the restriction.

--- a/src/backend/core/tests/api/test_thread_event.py
+++ b/src/backend/core/tests/api/test_thread_event.py
@@ -509,7 +509,7 @@ class TestThreadEventDelete:
 
 
 class TestThreadEventEditDelay:
-    """Test the MAX_THREAD_EVENT_EDIT_DELAY window on update and delete."""
+    """Test the MAX_THREAD_EVENT_EDIT_DELAY window on update."""
 
     @override_settings(MAX_THREAD_EVENT_EDIT_DELAY=24 * 60 * 60)
     def test_update_within_delay_allowed(self, api_client):
@@ -546,8 +546,8 @@ class TestThreadEventEditDelay:
         assert event.data.get("content") != "Too late"
 
     @override_settings(MAX_THREAD_EVENT_EDIT_DELAY=24 * 60 * 60)
-    def test_delete_after_delay_forbidden(self, api_client):
-        """An event older than the edit delay cannot be deleted."""
+    def test_delete_after_delay_allowed(self, api_client):
+        """Deletion is not bound by the edit delay — authors can always retract."""
         user, _mailbox, thread = setup_user_with_thread_access()
         api_client.force_authenticate(user=user)
 
@@ -555,8 +555,8 @@ class TestThreadEventEditDelay:
         _force_created_at(event, timezone.now() - timedelta(hours=25))
 
         response = api_client.delete(get_thread_event_url(thread.id, event.id))
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert models.ThreadEvent.objects.filter(pk=event.pk).exists()
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not models.ThreadEvent.objects.filter(pk=event.pk).exists()
 
     @override_settings(MAX_THREAD_EVENT_EDIT_DELAY=0)
     def test_update_when_delay_disabled(self, api_client):
@@ -573,18 +573,6 @@ class TestThreadEventEditDelay:
             format="json",
         )
         assert response.status_code == status.HTTP_200_OK
-
-    @override_settings(MAX_THREAD_EVENT_EDIT_DELAY=0)
-    def test_delete_when_delay_disabled(self, api_client):
-        """A zero delay allows deletion regardless of age."""
-        user, _mailbox, thread = setup_user_with_thread_access()
-        api_client.force_authenticate(user=user)
-
-        event = factories.ThreadEventFactory(thread=thread, author=user)
-        _force_created_at(event, timezone.now() - timedelta(days=365))
-
-        response = api_client.delete(get_thread_event_url(thread.id, event.id))
-        assert response.status_code == status.HTTP_204_NO_CONTENT
 
     @override_settings(MAX_THREAD_EVENT_EDIT_DELAY=24 * 60 * 60)
     def test_is_editable_field_in_response(self, api_client):

--- a/src/backend/e2e/management/commands/e2e_demo.py
+++ b/src/backend/e2e/management/commands/e2e_demo.py
@@ -521,10 +521,11 @@ class Command(BaseCommand):
         #
         # The "edit delay elapsed" test needs a ThreadEvent whose
         # `created_at` is older than `MAX_THREAD_EVENT_EDIT_DELAY`, so that
-        # `is_editable` returns false and the UI hides Edit/Delete actions.
+        # `is_editable` returns false and the UI hides the Edit action
+        # (Delete remains available — it is not gated by the delay).
         #
         # Each browser gets its own aged event authored by its own user so
-        # the `canModify = isAuthor && is_editable` check in the frontend
+        # the `canEdit = isAuthor && is_editable` check in the frontend
         # exercises the `is_editable: false` branch (not the `isAuthor: false`
         # one).
         past = timezone.now() - timezone.timedelta(

--- a/src/e2e/src/__tests__/thread-event.spec.ts
+++ b/src/e2e/src/__tests__/thread-event.spec.ts
@@ -517,7 +517,7 @@ test.describe("Thread Events (Internal Messages)", () => {
     expect(deleteResponse.ok()).toBeTruthy();
   });
 
-  test("should hide edit and delete actions once the edit delay has elapsed", async ({
+  test("should hide edit but keep delete once the edit delay has elapsed", async ({
     page,
     browserName,
   }) => {
@@ -526,28 +526,26 @@ test.describe("Thread Events (Internal Messages)", () => {
     // The e2e_demo management command seeds one pre-aged ThreadEvent per
     // browser user with a browser-scoped content string. That event's
     // `created_at` is pushed 2h into the past, so the backend's
-    // `is_editable` returns false and the frontend's `canModify` guard
-    // hides Edit/Delete. We locate the bubble by its unique content
-    // instead of sending a fresh message and ageing it at runtime.
+    // `is_editable` returns false and the frontend's `canEdit` guard
+    // hides the Edit button — but Delete must stay available since the
+    // author should always be able to retract their comment.
     const agedContent = `[e2e-aged-${browserName}] Message past edit delay`;
     const agedBubble = page
       .locator(".thread-event--im")
       .filter({ hasText: agedContent });
     await expect(agedBubble).toBeVisible();
 
-    // Hover to try and reveal actions — they must remain hidden because
-    // `canModify` in the component is false.
+    // Hover to reveal actions: Edit must stay hidden, Delete must appear.
     await agedBubble.locator(".thread-event__bubble").hover();
     await expect(
       agedBubble.getByRole("button", { name: "Edit" }),
     ).toHaveCount(0);
     await expect(
       agedBubble.getByRole("button", { name: "Delete" }),
-    ).toHaveCount(0);
+    ).toBeVisible();
 
-    // And the server must reject the write even if the button were forced:
-    // this guards against the UI hiding actions while the backend still
-    // allows edits (or vice versa).
+    // Guard against UI/backend drift: PATCH must still be rejected, but
+    // DELETE must succeed and actually remove the event.
     const eventDomId = await agedBubble.getAttribute("id");
     const eventId = eventDomId?.replace(/^thread-event-/, "");
     expect(eventId, "event id should be present on aged bubble").toBeTruthy();
@@ -567,6 +565,12 @@ test.describe("Thread Events (Internal Messages)", () => {
       },
     );
     expect(updateResponse.status()).toBe(403);
+
+    const deleteResponse = await page.request.delete(
+      `${API_URL}/api/v1.0/threads/${threadId}/events/${eventId}/`,
+      { headers: { "X-CSRFToken": csrfToken } },
+    );
+    expect(deleteResponse.status()).toBe(204);
   });
 });
 

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-event/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-event/index.tsx
@@ -153,9 +153,10 @@ export const ThreadEvent = ({ event, isCondensed = false, onEdit, onDelete, ment
     const copyDeepLink = useCopyDeepLink();
     const isAuthor = event.author?.id === user?.id;
     const isEdited = Math.abs(new Date(event.updated_at).getTime() - new Date(event.created_at).getTime()) > 1000;
-    // Edit/delete actions are only available to the author while the
-    // server-side edit delay has not elapsed (MAX_THREAD_EVENT_EDIT_DELAY).
-    const canModify = isAuthor && event.is_editable;
+    // Authors can always delete their own comment; editing is additionally
+    // gated by the server-side delay (MAX_THREAD_EVENT_EDIT_DELAY).
+    const canDelete = isAuthor;
+    const canEdit = isAuthor && event.is_editable;
 
     const deleteEvent = useThreadsEventsDestroy();
     const [showActions, setShowActions] = useState(false);
@@ -287,10 +288,10 @@ export const ThreadEvent = ({ event, isCondensed = false, onEdit, onDelete, ment
                     )}
                     <div
                         className={`thread-event__content${pressing ? " thread-event__content--pressing" : ""}`}
-                        onTouchStart={canModify ? handleTouchStart : undefined}
-                        onTouchEnd={canModify ? cancelLongPress : undefined}
-                        onTouchMove={canModify ? cancelLongPress : undefined}
-                        onTouchCancel={canModify ? cancelLongPress : undefined}
+                        onTouchStart={canDelete ? handleTouchStart : undefined}
+                        onTouchEnd={canDelete ? cancelLongPress : undefined}
+                        onTouchMove={canDelete ? cancelLongPress : undefined}
+                        onTouchCancel={canDelete ? cancelLongPress : undefined}
                     >
                         {TextHelper.renderLinks(
                           TextHelper.renderMentions(
@@ -313,33 +314,33 @@ export const ThreadEvent = ({ event, isCondensed = false, onEdit, onDelete, ment
                             title={t("Copy link to comment")}
                             onClick={handleCopyLink}
                         />
-                        {canModify && (
-                            <>
-                                <Button
-                                    size="nano"
-                                    variant="tertiary"
-                                    color="brand"
-                                    icon={<Icon type={IconType.OUTLINED} name="edit" aria-hidden="true" />}
-                                    aria-label={t("Edit")}
-                                    title={t("Edit")}
-                                    onClick={() => {
-                                        setShowActions(false);
-                                        onEdit?.(event);
-                                    }}
-                                />
-                                <Button
-                                    size="nano"
-                                    variant="tertiary"
-                                    color="brand"
-                                    icon={<Icon type={IconType.OUTLINED} name="delete" aria-hidden="true" />}
-                                    aria-label={t("Delete")}
-                                    title={t("Delete")}
-                                    onClick={() => {
-                                        setShowActions(false);
-                                        handleDelete();
-                                    }}
-                                />
-                            </>
+                        {canEdit && (
+                            <Button
+                                size="nano"
+                                variant="tertiary"
+                                color="brand"
+                                icon={<Icon type={IconType.OUTLINED} name="edit" aria-hidden="true" />}
+                                aria-label={t("Edit")}
+                                title={t("Edit")}
+                                onClick={() => {
+                                    setShowActions(false);
+                                    onEdit?.(event);
+                                }}
+                            />
+                        )}
+                        {canDelete && (
+                            <Button
+                                size="nano"
+                                variant="tertiary"
+                                color="brand"
+                                icon={<Icon type={IconType.OUTLINED} name="delete" aria-hidden="true" />}
+                                aria-label={t("Delete")}
+                                title={t("Delete")}
+                                onClick={() => {
+                                    setShowActions(false);
+                                    handleDelete();
+                                }}
+                            />
                         )}
                     </div>
                 </div>

--- a/src/frontend/src/hooks/use-searchable-pagination.ts
+++ b/src/frontend/src/hooks/use-searchable-pagination.ts
@@ -1,5 +1,5 @@
 import { usePagination } from "@gouvfr-lasuite/cunningham-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { DEFAULT_PAGE_SIZE } from "@/features/config/constants";
 import usePrevious from "./use-previous";
 


### PR DESCRIPTION
## Purpose

Currently, user can delete/edit an internal message while it is within the edit timeframe defined by
`MAX_THREAD_EVENT_EDIT_DELAY`. First feedbacks raises that this limit is not relevant for deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Decoupled message deletion from the edit-delay time window—users can now delete their messages at any time, while editing remains restricted to the configured delay window. The Delete action remains available in the UI even after the edit window expires.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/messages/pull/669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->