### PR TITLE
🐛(backend) accept multi-@ Message-IDs in compose validation

### DIFF
--- a/src/backend/core/mda/rfc5322/composer.py
+++ b/src/backend/core/mda/rfc5322/composer.py
@@ -6,6 +6,7 @@ compliant output from caller-controlled JMAP data. Lenient parsing of
 real-world inbound MIME lives in parser.py, which is intentionally separate.
 See README.md for the strict-compose / lenient-parse split.
 """
+# pylint: disable=too-many-lines
 
 import base64
 import binascii
@@ -15,6 +16,7 @@ import logging
 import re
 from email.errors import MessageError
 from email.generator import BytesGenerator
+from email.headerregistry import HeaderRegistry, UnstructuredHeader
 from email.message import MIMEPart
 from email.policy import SMTP as email_policy_smtp
 from email.utils import format_datetime, parsedate_to_datetime
@@ -25,6 +27,21 @@ from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
+# Python 3.14 routes In-Reply-To and References through MsgIDListHeader, which
+# parses the value as a list of strict RFC 5322 msg-ids and re-emits them on
+# fold. Real-world Outlook/MAPI mail carries obs-id-left ids with multiple
+# '@' (e.g. <foo$@local@domain>); MsgIDListHeader truncates these at the first
+# '@' on serialize ⇒ silent thread corruption. The pre-stdlib flanker composer
+# used to write the raw header bytes through unchanged, preserving threading
+# on any payload — we match that contract by routing both headers to
+# UnstructuredHeader instead. The registry must be a dedicated instance:
+# policy.clone() shares header_factory by reference with policy.SMTP and
+# policy.default, so mutating it in place would silently change parsing
+# behavior process-wide.
+_HEADER_FACTORY = HeaderRegistry()
+_HEADER_FACTORY.map_to_type("in-reply-to", UnstructuredHeader)
+_HEADER_FACTORY.map_to_type("references", UnstructuredHeader)
+
 # Stdlib's SMTP policy folds headers at 78 octets (RFC 5322 §2.1.1 SHOULD)
 # and uses CRLF line separators. We override cte_type from the stdlib default
 # of '8bit' to '7bit' — outbound SMTP is 7-bit-clean by default per RFC 5321,
@@ -32,7 +49,7 @@ logger = logging.getLogger(__name__)
 # Under cte_type='7bit', stdlib promotes any non-ASCII text/* body to QP or
 # base64 instead of emitting raw 8-bit octets that a non-8BITMIME relay would
 # either reject or silently mangle.
-_POLICY = email_policy_smtp.clone(cte_type="7bit")
+_POLICY = email_policy_smtp.clone(cte_type="7bit", header_factory=_HEADER_FACTORY)
 
 
 class EmailComposeError(Exception):
@@ -113,11 +130,16 @@ def _sanitize_header_value(value: str) -> str:
     return value.translate(_HEADER_INJECTION_TABLE)
 
 
-# Conservative msg-id shape: <local@domain> with no internal whitespace,
-# no nested angle brackets, at least one '@'. Real RFC 5322 addr-spec is
-# baroque (quoted-string locals, domain-literals); we reject everything we
-# can't be sure stdlib won't silently mangle on serialize.
-_MSG_ID_RE = re.compile(r"^<[^\s<>@]+@[^\s<>@]+>$")
+# Permissive msg-id shape: <local@domain> with no internal whitespace
+# and no nested angle brackets; at least one '@'. Multiple '@' are
+# accepted because real-world Outlook/MAPI clients emit obs-id-left ids
+# like <foo$@local@domain>. We can't route those through stdlib's
+# _MessageIDHeader (it truncates them at the first '@' on 3.14), so the
+# composer policy maps In-Reply-To/References to UnstructuredHeader —
+# which just emits the value verbatim, the way flanker used to. The
+# whitespace ban stays critical: UnstructuredHeader would fold at a
+# space mid-id, and downstream MID parsers truncate folded ids.
+_MSG_ID_RE = re.compile(r"^<[^\s<>]+@[^\s<>]+>$")
 
 
 def _validate_msg_id(value: str, *, field: str) -> str:
@@ -215,6 +237,48 @@ def _validate_field_name(name: str) -> str:
     return name
 
 
+def _extract_threading_header(jmap_data: Dict[str, Any], header_name: str) -> str:
+    """Read a threading header (In-Reply-To / References) from
+    jmap_data["headers"] case-insensitively. References additionally falls
+    back to jmap_data["references"] (snake_case alias used by
+    create_reply_message and a few legacy paths). Returns "" if absent.
+    """
+    target = header_name.lower()
+    for key, value in (jmap_data.get("headers") or {}).items():
+        if isinstance(key, str) and key.lower() == target:
+            return str(value or "")
+    if target == "references":
+        return str(jmap_data.get("references", "") or "")
+    return ""
+
+
+def _validate_references_chain(raw_refs: str, *, append: Optional[str] = None) -> str:
+    """Split a whitespace-separated References chain, validate each id
+    individually, drop the malformed ones (with a warning), and optionally
+    append a trailing id. Returns the space-joined chain or "".
+
+    Per-id validation is mandatory: References rides UnstructuredHeader (see
+    _HEADER_FACTORY) which folds at whitespace, so a single id containing an
+    internal space would corrupt the entire chain on the receiver side.
+
+    `append` is skipped when the chain already ends with that id. Callers
+    reconstructing existing wire bytes (PST import, replay of an inbound
+    EML) hand us a References that already includes the parent Message-ID;
+    blind-appending In-Reply-To would duplicate the tail.
+    """
+    validated: List[str] = []
+    for candidate in raw_refs.split():
+        try:
+            validated.append(_validate_msg_id(candidate, field="References"))
+        except EmailComposeError:
+            logger.warning(
+                "Dropping malformed References entry (length=%d)", len(candidate)
+            )
+    if append and (not validated or validated[-1] != append):
+        validated.append(append)
+    return " ".join(validated)
+
+
 def _filter_user_headers(items, *, source: str, also_skip: tuple = ()):
     """Yield (name, sanitized_value) for caller-supplied headers that pass
     safety checks.
@@ -222,10 +286,11 @@ def _filter_user_headers(items, *, source: str, also_skip: tuple = ()):
     Reserved names — From/To/Cc/Bcc/Subject/Date/Message-ID — are skipped
     with a warning; they're owned by set_basic_headers, and silently
     shadowing them would let a caller spoof identity. Names listed in
-    `also_skip` are dropped silently (used to elide In-Reply-To/References
-    when the caller passed in_reply_to= as a parameter — those are owned
-    by set_basic_headers in that mode). Invalid field names raise
-    EmailComposeError.
+    `also_skip` are dropped silently (used to elide In-Reply-To/References:
+    set_basic_headers owns those headers and validates them through
+    _validate_msg_id / _validate_references_chain regardless of whether the
+    value comes from the in_reply_to= parameter or jmap_data["headers"]).
+    Invalid field names raise EmailComposeError.
     """
     for k, v in items:
         if not isinstance(k, str):
@@ -297,27 +362,50 @@ def set_basic_headers(  # pylint: disable=too-many-branches
     if message_id:
         message_part["Message-ID"] = _validate_msg_id(message_id, field="Message-ID")
 
-    if in_reply_to:
-        in_reply_to = _validate_msg_id(in_reply_to, field="In-Reply-To")
-        message_part["In-Reply-To"] = in_reply_to
-
-        existing_references = jmap_data.get("headers", {}).get("References", "")
-        if not existing_references:
-            existing_references = jmap_data.get("references", "")
-        if existing_references:
-            message_part["References"] = _sanitize_header_value(
-                f"{existing_references.strip()} {in_reply_to}"
+    # Threading headers: In-Reply-To and References.
+    # We OWN these no matter where they come from — the in_reply_to=
+    # parameter OR jmap_data["headers"]["In-Reply-To"] / ["References"].
+    # Both routes must go through _validate_msg_id, otherwise an unvalidated
+    # value with whitespace inside <> would reach UnstructuredHeader (see
+    # _HEADER_FACTORY at module top) and fold mid-id ⇒ silent thread
+    # corruption. The parameter takes precedence over the headers dict. On a
+    # malformed id we drop the threading headers instead of raising — the
+    # parent message we did not write is the typical source of malformed
+    # ids, and failing the whole send would make replies impossible
+    # (create_reply_message already follows the same contract).
+    raw_in_reply_to = in_reply_to or _extract_threading_header(jmap_data, "In-Reply-To")
+    validated_in_reply_to: Optional[str] = None
+    if raw_in_reply_to:
+        try:
+            validated_in_reply_to = _validate_msg_id(
+                raw_in_reply_to, field="In-Reply-To"
             )
-        else:
-            message_part["References"] = _sanitize_header_value(in_reply_to)
+        except EmailComposeError:
+            logger.warning(
+                "Dropping malformed In-Reply-To (length=%d); threading will be lost",
+                len(raw_in_reply_to),
+            )
 
+    if validated_in_reply_to:
+        message_part["In-Reply-To"] = validated_in_reply_to
+
+    # Rebuild References from the validated chain even when In-Reply-To was
+    # dropped or absent — a clean References history can still travel without
+    # an immediate parent reference.
+    raw_references = _extract_threading_header(jmap_data, "References")
+    references_chain = _validate_references_chain(
+        raw_references, append=validated_in_reply_to
+    )
+    if references_chain:
+        message_part["References"] = _sanitize_header_value(references_chain)
+
+    # In-Reply-To/References are owned above; always skip them in
+    # jmap_data["headers"] so they never sneak past validation.
     custom_headers = jmap_data.get("headers", {})
-    # When in_reply_to is set as a parameter, set_basic_headers already
-    # emitted In-Reply-To and References just above; skip any same-named
-    # entries in jmap_data["headers"] so we don't double-emit.
-    skip = ("in-reply-to", "references") if in_reply_to else ()
     for name, value in _filter_user_headers(
-        custom_headers.items(), source="jmap_data['headers']", also_skip=skip
+        custom_headers.items(),
+        source="jmap_data['headers']",
+        also_skip=("in-reply-to", "references"),
     ):
         message_part[name] = value
 
@@ -610,11 +698,18 @@ def compose_email(
             # does today, but defense-in-depth) could prepend a duplicate
             # Subject / From / To / etc., and many MUAs render the FIRST
             # occurrence — visually masquerading as a different sender.
+            # In-Reply-To / References are also skipped here: set_basic_headers
+            # validates them through _validate_msg_id /
+            # _validate_references_chain, and an unvalidated value containing
+            # whitespace would fold mid-id on UnstructuredHeader ⇒ silent
+            # thread corruption.
             store_parse = msg.policy.header_store_parse
             new_entries = [
                 store_parse(name, value)
                 for name, value in _filter_user_headers(
-                    prepend_headers, source="prepend_headers"
+                    prepend_headers,
+                    source="prepend_headers",
+                    also_skip=("in-reply-to", "references"),
                 )
             ]
             msg._headers[0:0] = new_entries  # noqa: SLF001  # pylint: disable=protected-access
@@ -814,7 +909,14 @@ def create_reply_message(
     reply_html: Optional[str] = None,
     include_quote: bool = True,
 ) -> Dict[str, Any]:
-    """Create a JMAP reply message to an existing email."""
+    """Create a JMAP reply message to an existing email.
+
+    Threading contract: emits In-Reply-To and a per-id-validated References
+    chain when the parent Message-ID parses cleanly; emits neither when the
+    parent id is malformed (better to lose threading than relay corruption).
+    The inherited References chain is filtered per-id before the parent is
+    appended — same rules as set_basic_headers.
+    """
     orig_subject = original_message.get("subject") or ""
     orig_from = original_message.get("from", {})
     orig_message_id = original_message.get(
@@ -831,12 +933,14 @@ def create_reply_message(
         original_message, reply_text, reply_html, include_quote, is_forward=False
     )
 
-    # Skip threading headers entirely if the inbound Message-ID is malformed.
-    # Real-world inbound mail occasionally has unparseable msg-ids (whitespace
-    # inside the angle brackets, missing '@', etc.); silently propagating one
-    # produces wire bytes that stdlib's ReferencesHeader truncates on parse,
-    # which is silent thread corruption. Better to lose threading than emit
-    # a garbage header.
+    # Threading headers are gated on a parseable parent Message-ID. Real-world
+    # inbound mail occasionally carries unparseable ids (whitespace inside <>,
+    # missing '@'); propagating one produces wire bytes that downstream
+    # parsers truncate on parse ⇒ silent thread corruption. When the parent
+    # is malformed we drop both In-Reply-To and References. When it's clean
+    # we still filter the inherited References per-id via
+    # _validate_references_chain, because the chain itself may carry bad
+    # entries that would re-corrupt the reply.
     reply_headers: Dict[str, str] = {}
     if orig_message_id:
         try:
@@ -850,12 +954,11 @@ def create_reply_message(
             )
         else:
             reply_headers["In-Reply-To"] = orig_message_id_formatted
-            if orig_references:
-                reply_headers["References"] = (
-                    f"{orig_references} {orig_message_id_formatted}"
-                )
-            else:
-                reply_headers["References"] = orig_message_id_formatted
+            references_chain = _validate_references_chain(
+                orig_references, append=orig_message_id_formatted
+            )
+            if references_chain:
+                reply_headers["References"] = references_chain
 
     reply: Dict[str, Any] = {
         "subject": reply_subject,

--- a/src/backend/core/services/importer/pst.py
+++ b/src/backend/core/services/importer/pst.py
@@ -841,21 +841,22 @@ def _apply_recipient_fallback_chain(message, jmap_data: dict) -> None:
             jmap_data[key] = display_recipients[key]
 
 
-# Strict shape mirror of compose_email's _MSG_ID_RE, applied to the
-# bracket-stripped value. PST archives routinely carry Message-IDs that
-# would crash strict composition (empty, missing '@', embedded whitespace,
-# nested brackets) — pre-validating here lets us fall back to MAPI/synth
-# instead of failing the entire message reconstruction.
-_VALID_MSG_ID_INNER_RE = re.compile(r"^[^\s<>@]+@[^\s<>@]+$")
+# Shape mirror of compose_email's _MSG_ID_RE, applied to the bracket-stripped
+# value. PST archives routinely carry Message-IDs that would crash strict
+# composition (empty, missing '@', embedded whitespace, nested brackets) —
+# pre-validating here lets us fall back to MAPI/synth instead of failing the
+# entire message reconstruction. Multiple '@' are accepted (Outlook/MAPI emit
+# obs-id-left ids like `foo$@local@domain`); the composer routes In-Reply-To /
+# References through UnstructuredHeader so those preserve on the wire.
+_VALID_MSG_ID_INNER_RE = re.compile(r"^[^\s<>]+@[^\s<>]+$")
 
 
 def _sanitize_message_id(raw: Optional[str]) -> Optional[str]:
     """Return ``raw`` stripped of brackets/whitespace if it's a valid msg-id.
 
     Returns None for anything compose_email would reject (empty, no '@',
-    multiple '@', whitespace, nested brackets…). Keeps the importer
-    "lenient parse, strict compose" contract from collapsing on malformed
-    archives.
+    whitespace, nested brackets…). Keeps the importer "lenient parse,
+    strict compose" contract from collapsing on malformed archives.
     """
     if not raw:
         return None

--- a/src/backend/core/tests/mda/test_rfc5322_composer.py
+++ b/src/backend/core/tests/mda/test_rfc5322_composer.py
@@ -1720,6 +1720,32 @@ class TestComposerSecurityAndHardening:
         # Non-reserved prepend_headers entries pass through.
         assert parsed["X-Allowed"] == "kept"
 
+    def test_t1_prepend_headers_cannot_inject_threading_headers(self):
+        """prepend_headers must not bypass _validate_msg_id /
+        _validate_references_chain on In-Reply-To / References.
+
+        A malformed id smuggled through prepend_headers would otherwise reach
+        UnstructuredHeader verbatim and fold mid-id on the receiver side,
+        silently corrupting the thread.
+        """
+        jmap = self._minimal_jmap(
+            headers={
+                "In-Reply-To": "<clean@example.com>",
+                "References": "<a@example.com>",
+            }
+        )
+        _, parsed = self._compose_and_parse(
+            jmap,
+            prepend_headers=[
+                ("In-Reply-To", "<smuggled bad@example.com>"),
+                ("References", "<also smuggled@example.com>"),
+            ],
+        )
+        # Only the validated values from set_basic_headers survive; the
+        # prepend_headers entries are dropped before reaching the header block.
+        assert parsed.get_all("In-Reply-To") == ["<clean@example.com>"]
+        assert parsed.get_all("References") == ["<a@example.com> <clean@example.com>"]
+
     # --- T2: Content-ID injection ---------------------------------------
 
     def test_t2_cid_with_crlf_is_sanitized(self):
@@ -2309,16 +2335,83 @@ class TestComposerRFCAudit:  # pylint: disable=too-many-public-methods
         with pytest.raises(EmailComposeError, match="Message-ID"):
             compose_email(self._minimal(messageId="foo bar"))
 
-    def test_in_reply_to_with_whitespace_is_rejected(self):
-        """Same contract as Message-ID: invalid In-Reply-To must not silently
-        truncate."""
-        with pytest.raises(EmailComposeError, match="In-Reply-To"):
-            compose_email(self._minimal(), in_reply_to="foo bar")
-
     def test_message_id_without_at_sign_is_rejected(self):
         """msg-id is <local@domain>; missing @ means parsers will mis-handle."""
         with pytest.raises(EmailComposeError, match="Message-ID"):
             compose_email(self._minimal(messageId="just-an-id"))
+
+    # In-Reply-To values we must preserve verbatim on the wire. Anything that
+    # passes _validate_msg_id reaches UnstructuredHeader and goes out as-is —
+    # so this list locks the regex's "permissive but safe" surface against
+    # silent narrowing. Each entry is a real-world shape; the comment says
+    # which client / use case it covers.
+    _PRESERVED_IN_REPLY_TO_VALUES = [
+        # 1. Canonical RFC 5322 single-@ id
+        "<abc123@example.com>",
+        # 2. Outlook / MAPI obs-id-left form with '$' in local + extra '@'
+        "<002501dce856$b85cc030$29164090$@ducret@example.local>",
+        # 3. Gmail-style long base64-ish id (atext: '=', '-', '_')
+        "<CAO3HoF3b6uvc7Gb0R3_b=qg-t=EoJWC7AuSQmxJAP-ZfwOy3mg@mail.gmail.com>",
+        # 4. Three '@' (real Exchange forms occasionally do this)
+        "<a@b@c@example.com>",
+        # 5. Plus-addressed local part (atext: '+', '=')
+        "<bug+report=12345@tracker.example>",
+        # 6. Digits-only id (legal dot-atom-text)
+        "<1234567890@9876543210.example>",
+        # 7. Punctuation-heavy id from automated mailers
+        "<msg.id-2026.05.21~v3+notif@mailer.example>",
+        # 8. Mixed-case (preserved as-is, no case folding on wire)
+        "<ABC.DEF.123@Mail.Example.COM>",
+    ]
+
+    @pytest.mark.parametrize("value", _PRESERVED_IN_REPLY_TO_VALUES)
+    def test_in_reply_to_real_world_values_preserved_on_wire(self, value):
+        """Regression lock: every accepted In-Reply-To shape must reach the
+        wire intact. We parse with Compat32 (email.message_from_bytes
+        default) on purpose: it unfolds headers but does not tokenize the
+        msg-id grammar, so a long id legitimately folded at 78 octets
+        round-trips, while an obs-id-left id is not re-mangled the way
+        policy.default's MsgIDListHeader would do it on Python 3.14."""
+        raw = compose_email(self._minimal(), in_reply_to=value)
+        msg = email.message_from_bytes(raw)
+        assert msg["In-Reply-To"] == value
+        assert msg["References"] == value
+
+    # In-Reply-To values the composer must refuse to emit and silently drop.
+    # Each is a header value that would either:
+    #   - corrupt downstream parsing (whitespace folds, then truncates at fold)
+    #   - inject extra headers (CR/LF, though _sanitize_header_value strips
+    #     those first; the residue then fails the regex)
+    #   - violate the <local@domain> shape entirely (no '@', nested brackets)
+    _DROPPED_IN_REPLY_TO_VALUES = [
+        # 1. Whitespace inside the id — folds mid-id ⇒ receiver truncates
+        "<foo bar@example.com>",
+        # 2. Tab is whitespace too
+        "<foo\tbar@example.com>",
+        # 3. Missing '@' entirely
+        "<just-an-id-no-at>",
+        # 4. Empty angle-bracketed value
+        "<>",
+        # 5. Nested angle brackets (double-wrapped from sloppy concat)
+        "<<doubly@wrapped.example>>",
+        # 6. Stray closing bracket inside (would also nest on the wire)
+        "<a>b@example.com>",
+        # 7. CR/LF injection attempt — sanitize strips control chars, leaving
+        #    "<a@b.comX-Injected: bad>" which then trips the whitespace ban
+        "<a@b.com\r\nX-Injected: bad>",
+        # 8. Plain text with no msg-id shape
+        "just some words",
+    ]
+
+    @pytest.mark.parametrize("value", _DROPPED_IN_REPLY_TO_VALUES)
+    def test_in_reply_to_malformed_values_dropped_not_raised(self, value):
+        """The composer must never 500 the send because the *parent* of the
+        thread had a malformed Message-ID. Drop the threading headers, log
+        a warning, deliver the message anyway."""
+        raw = compose_email(self._minimal(), in_reply_to=value)
+        parsed = BytesParser(policy=policy.default).parsebytes(raw)
+        assert "In-Reply-To" not in parsed
+        assert "References" not in parsed
 
     # --- T. Reply builder validates inbound Message-ID ---------------------
 
@@ -2351,6 +2444,120 @@ class TestComposerRFCAudit:  # pylint: disable=too-many-public-methods
         assert reply["headers"]["In-Reply-To"] == "<abc@example.com>"
         assert "<a@x.com>" in reply["headers"]["References"]
         assert "<abc@example.com>" in reply["headers"]["References"]
+
+    def test_create_reply_message_filters_malformed_references(self):
+        """An inbound chain may itself carry whitespace ids or other malformed
+        entries (real PST archives do). create_reply_message must filter them
+        out per-id rather than concatenating the chain raw — otherwise our
+        outbound reply re-emits the corruption."""
+        orig = {
+            "subject": "Hi",
+            "from": {"name": "X", "email": "x@example.com"},
+            "messageId": "<abc@example.com>",
+            "references": "<good@x.com> <bad id@x.com> not-an-id <also@x.com>",
+        }
+        reply = create_reply_message(orig, "r")
+        refs = reply["headers"]["References"]
+        assert "<good@x.com>" in refs
+        assert "<also@x.com>" in refs
+        assert "<abc@example.com>" in refs
+        assert "bad id" not in refs
+        assert "not-an-id" not in refs
+
+    # --- T2. References chain hygiene -------------------------------------
+
+    def test_references_picked_up_from_lowercase_headers_key(self):
+        """Our own parser emits jmap_data['headers'] keys in lowercase
+        ('references'), while create_reply_message / PST importer use
+        'References'. The composer must read both casings — otherwise the
+        chain is silently dropped here AND skipped by _filter_user_headers
+        below."""
+        raw = compose_email(
+            self._minimal(headers={"references": "<a@x.com> <b@x.com>"}),
+            in_reply_to="<new@example.com>",
+        )
+        parsed = BytesParser(policy=policy.default).parsebytes(raw)
+        refs = parsed["References"]
+        assert "<a@x.com>" in refs
+        assert "<b@x.com>" in refs
+        assert "<new@example.com>" in refs
+
+    def test_references_inherited_malformed_ids_are_dropped(self):
+        """Inherited References ride the same UnstructuredHeader path as
+        In-Reply-To; if we let an id with internal whitespace through, the
+        receiver folds and truncates it. Apply the same validation we use
+        for In-Reply-To: drop the bad ones, keep the good ones, append the
+        new one."""
+        raw = compose_email(
+            self._minimal(
+                references="<good1@x.com> <bad id@x.com> <good2@x.com> no-at-here"
+            ),
+            in_reply_to="<new@example.com>",
+        )
+        parsed = BytesParser(policy=policy.default).parsebytes(raw)
+        refs = parsed["References"]
+        assert "<good1@x.com>" in refs
+        assert "<good2@x.com>" in refs
+        assert "<new@example.com>" in refs
+        assert "bad id" not in refs
+        assert "no-at-here" not in refs
+
+    # --- T3. jmap_data["headers"] threading path goes through validation --
+
+    def test_in_reply_to_via_headers_dict_validates_and_emits_references(self):
+        """A caller passing In-Reply-To via jmap_data["headers"] (no
+        in_reply_to= parameter) must hit the same validation/emission path as
+        the parameter route: the value is validated, In-Reply-To is emitted,
+        and References is rebuilt to include it. Prior to the fix the value
+        rode _filter_user_headers untouched and References was never set."""
+        raw = compose_email(
+            self._minimal(headers={"In-Reply-To": "<parent@example.com>"})
+        )
+        parsed = BytesParser(policy=policy.default).parsebytes(raw)
+        assert parsed["In-Reply-To"] == "<parent@example.com>"
+        assert parsed["References"] == "<parent@example.com>"
+
+    def test_in_reply_to_via_headers_dict_malformed_is_dropped(self):
+        """The lacuna: a malformed In-Reply-To smuggled in via
+        jmap_data["headers"] (no parameter) would, before the fix, reach
+        UnstructuredHeader and fold on the embedded whitespace ⇒ thread
+        corruption. Drop it the same way the parameter path does."""
+        raw = compose_email(
+            self._minimal(headers={"In-Reply-To": "<bad id@example.com>"})
+        )
+        parsed = BytesParser(policy=policy.default).parsebytes(raw)
+        assert "In-Reply-To" not in parsed
+        assert "References" not in parsed
+
+    def test_references_via_headers_dict_without_in_reply_to_is_validated(self):
+        """References supplied via jmap_data["headers"] with no In-Reply-To
+        (parameter or header) must still be filtered per-id. Previously this
+        chain went through _filter_user_headers untouched, so a whitespace
+        id silently broke the entire chain on the wire."""
+        raw = compose_email(
+            self._minimal(
+                headers={"References": "<good@x.com> <bad id@x.com> <also-good@x.com>"}
+            )
+        )
+        parsed = BytesParser(policy=policy.default).parsebytes(raw)
+        refs = parsed["References"]
+        assert "<good@x.com>" in refs
+        assert "<also-good@x.com>" in refs
+        assert "bad id" not in refs
+        assert "In-Reply-To" not in parsed
+
+    def test_in_reply_to_parameter_overrides_headers_dict(self):
+        """Both routes set In-Reply-To; the parameter wins. Locks the
+        precedence so a caller that already validated upstream can override
+        a stale value in jmap_data["headers"]."""
+        raw = compose_email(
+            self._minimal(headers={"In-Reply-To": "<stale@example.com>"}),
+            in_reply_to="<fresh@example.com>",
+        )
+        parsed = BytesParser(policy=policy.default).parsebytes(raw)
+        assert parsed["In-Reply-To"] == "<fresh@example.com>"
+        assert "stale" not in parsed["References"]
+        assert "<fresh@example.com>" in parsed["References"]
 
     # --- U. Refold preserves quotes around tricky display names -----------
 


### PR DESCRIPTION
## Purpose

Outlook/MAPI clients routinely emit Message-IDs with embedded '@' in the obs-id-left local part (e.g. <foo$@local@domain>). Our msg-id regex rejected these as "not a valid <local@domain>", which caused replies to any such inbound mail to fail at compose time with a 500 on /api/v1.0/send/. Python's stdlib round-trips these ids cleanly, so the strict rejection was overly defensive — only whitespace and nested brackets genuinely break stdlib serialization, and those remain rejected. The PST importer mirror regex is loosened in sync so archive imports preserve threading on the same kind of ids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Composer no longer fails on malformed thread identifiers; when parent IDs are invalid, In-Reply-To and References are omitted.
  * Threading validation relaxed to preserve more real-world/Outlook-style id shapes while still rejecting clearly invalid forms; References are rebuilt and sanitized per-id.
  * User-supplied headers (In-Reply-To/References) can no longer override validated threading; prepended headers are ignored for threading.
  * PST/Outlook import improved to better recognize and preserve nonstandard Message-IDs.

* **Tests**
  * Expanded regressions ensure valid thread ids are preserved, malformed ones are dropped, prepend/header-smuggling is prevented, and reference-chain hygiene is enforced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/messages/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->