### PR TITLE
🐛(frontend) unmount thread view immediately on unselect thread

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-actions.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-message/thread-message-actions.tsx
@@ -60,8 +60,10 @@ const ThreadMessageActions = ({
         if (!selectedThread) return;
         if (is_unread) {
             // Mark as unread from here: subtract 1ms so this message becomes unread.
-            // Unmount the thread view before the mutation so the visibility observer
-            // cannot debounce a mark-as-read request on the newly-unread messages.
+            // `unselectThread()` unmounts the thread view synchronously, tearing
+            // down its auto-mark-as-read observer before this mutation's cache
+            // patch lands — otherwise the observer would re-read the messages we
+            // just flagged unread.
             const readAt = new Date(new Date(message.created_at!).getTime() - 1).toISOString();
             unselectThread();
             markAsReadAt({ threadIds: [selectedThread.id], readAt });

--- a/src/frontend/src/features/layouts/components/thread-view/components/thread-view-empty/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/thread-view-empty/index.tsx
@@ -1,0 +1,30 @@
+import { Button } from "@gouvfr-lasuite/cunningham-react";
+import Image from "next/image";
+import { useTranslation } from "react-i18next";
+
+type ThreadViewEmptyProps = {
+    showImportButton?: boolean;
+    label?: string;
+}
+
+/**
+ * Placeholder shown in the thread-view panel when no conversation is open:
+ * either nothing is selected, or a just-closed thread is still settling its
+ * navigation. Kept as a standalone component so the thread view and the
+ * mailbox page render the exact same empty state.
+ */
+export const ThreadViewEmpty = ({ showImportButton = false, label }: ThreadViewEmptyProps) => {
+    const { t } = useTranslation();
+
+    return (
+        <div className="thread-view thread-view--empty">
+            <div>
+                <Image src="/images/svg/read-mail.svg" alt="" width={60} height={60} />
+                <p>{label ?? t('Select a thread')}</p>
+                {showImportButton && (
+                    <Button href="#modal-message-importer">{t('Import messages')}</Button>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/src/frontend/src/features/layouts/components/thread-view/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/index.tsx
@@ -17,6 +17,7 @@ import { SKIP_LINK_TARGET_ID } from "@/features/ui/components/skip-link"
 import { useTranslation } from "react-i18next"
 import { ThreadViewLabelsList } from "./components/thread-view-labels-list"
 import { ThreadSummary } from "./components/thread-summary";
+import { ThreadViewEmpty } from "./components/thread-view-empty";
 import clsx from "clsx";
 import ThreadViewProvider, { useThreadViewContext } from "./provider";
 import useSpam from "@/features/message/use-spam";
@@ -431,7 +432,7 @@ const ThreadViewComponent = ({ threadItems, mailboxId, thread, showTrashedMessag
 
 export const ThreadView = () => {
     const isTrashView = ViewHelper.isTrashedView();
-    const { selectedMailbox, selectedThread, messages, threadItems, queryStates } = useMailboxContext();
+    const { selectedMailbox, selectedThread, unmountThreadViewNeeded, messages, threadItems, queryStates } = useMailboxContext();
     const [showTrashedMessages, setShowTrashedMessages] = useState(isTrashView);
     // Nest draft messages under their parent messages
     const messagesWithDraftChildren = useMemo(() => {
@@ -498,6 +499,11 @@ export const ThreadView = () => {
         setShowTrashedMessages(isTrashView);
     }, [selectedThread]);
 
+    // `unmountThreadViewNeeded` unmounts the heavy thread view (and its
+    // auto-mark-as-read observer) synchronously on unselect, before the
+    // navigation completes, while still showing the empty placeholder rather
+    // than a blank panel.
+    if (unmountThreadViewNeeded) return <ThreadViewEmpty />
     if (!selectedMailbox || !selectedThread) return null
 
     if (queryStates.messages.isLoading || queryStates.threadEvents.isLoading) {

--- a/src/frontend/src/features/message/use-read.tsx
+++ b/src/frontend/src/features/message/use-read.tsx
@@ -41,9 +41,8 @@ const deriveThreadHasUnread = (messagedAt: string | null | undefined, readAt: st
  * callback — NOT on a per-call `onSuccess` — so they still fire when the
  * caller component (e.g. `ThreadActionBar`) unmounts before the mutation
  * settles. React Query drops per-call callbacks of unmounted hooks but keeps
- * mutation-level ones; routing both through `useFlag` options makes the
- * "mark as unread" flow survive the synchronous `unselectThread()` that
- * precedes it.
+ * mutation-level ones — this is what makes the "mark as unread" flow survive
+ * the synchronous `unselectThread()` that precedes it.
  */
 const useRead = () => {
     const { selectedMailbox, pinThreads, patchMessages, invalidateThreadsStats } = useMailboxContext();

--- a/src/frontend/src/features/providers/mailbox.tsx
+++ b/src/frontend/src/features/providers/mailbox.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef } from "react";
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { Mailbox, MailboxRoleChoices, Message, PaginatedThreadList, Thread, ThreadEvent, ThreadsListParams, useLabelsList, useMailboxesList, useMessagesList, useThreadsEventsList, useThreadsListInfinite, useThreadsRetrieve, getThreadsEventsListQueryKey, getThreadsRetrieveQueryKey } from "../api/gen";
 import { FetchStatus, InfiniteData, QueryStatus, RefetchOptions, useQueryClient } from "@tanstack/react-query";
 import type { threadsListResponse } from "../api/gen/threads/threads";
@@ -42,6 +42,8 @@ type MailboxContextType = {
     threadItems: readonly TimelineItem[] | null;
     selectedMailbox: Mailbox | null;
     selectedThread: Thread | null;
+    // Lets the thread view unmount synchronously instead of waiting for the async navigation.
+    unmountThreadViewNeeded: boolean;
     unselectThread: () => void;
     loadNextThreads: () => Promise<unknown>;
     /** Patch threads in every cached list variant of the current mailbox AND
@@ -185,6 +187,7 @@ const MailboxContext = createContext<MailboxContextType>({
     threadItems: null,
     selectedMailbox: null,
     selectedThread: null,
+    unmountThreadViewNeeded: false,
     loadNextThreads: async () => {},
     unselectThread: () => {},
     pinThreads: () => {},
@@ -244,6 +247,7 @@ export const MailboxProvider = ({ children }: PropsWithChildren) => {
     const queryClient = useQueryClient();
     const router = useRouter();
     const pinnedThreadIdsRef = useRef(new Set<string>());
+    const [unmountThreadViewNeeded, setUnmountThreadViewNeeded] = useState(false);
     const searchParams = useSearchParams();
     const previousSearchParams = usePrevious(searchParams);
     const hasSearchParamsChanged = useMemo(() => {
@@ -360,6 +364,7 @@ export const MailboxProvider = ({ children }: PropsWithChildren) => {
     }, [threadsQuery.data?.pages]);
 
     const threadIdFromRoute = typeof router.query.threadId === 'string' ? router.query.threadId : undefined;
+
     const threadInList = useMemo(() => {
         if (!threadIdFromRoute) return null;
         return flattenThreads?.results.find((thread) => thread.id === threadIdFromRoute) ?? null;
@@ -550,7 +555,13 @@ export const MailboxProvider = ({ children }: PropsWithChildren) => {
 
         const threadId = router.query.threadId as string | undefined;
         if (selectedMailbox && threadId && window.location.pathname.includes(threadId)) {
-            router.push(`/mailbox/${selectedMailbox!.id}${window.location.search}`);
+            // Unmount the thread view now (tearing down its auto-mark-as-read
+            // observer before the mutation's cache patch lands), then clear the
+            // flag once navigation has settled and `selectedThread` is null on
+            // its own.
+            setUnmountThreadViewNeeded(true);
+            router.push(`/mailbox/${selectedMailbox!.id}${window.location.search}`)
+                .finally(() => setUnmountThreadViewNeeded(false));
         }
     }
 
@@ -562,6 +573,7 @@ export const MailboxProvider = ({ children }: PropsWithChildren) => {
         threadItems: threadItems,
         selectedMailbox,
         selectedThread,
+        unmountThreadViewNeeded,
         unselectThread,
         loadNextThreads: threadsQuery.fetchNextPage,
         pinThreads,

--- a/src/frontend/src/pages/mailbox/[mailboxId]/index.tsx
+++ b/src/frontend/src/pages/mailbox/[mailboxId]/index.tsx
@@ -2,15 +2,14 @@ import { MainLayout } from "@/features/layouts/components/main";
 import { useResponsive } from "@gouvfr-lasuite/ui-kit";
 import { ThreadPanel } from "@/features/layouts/components/thread-panel";
 import { ThreadSelectionPlaceholder } from "@/features/layouts/components/thread-selection-placeholder";
+import { ThreadViewEmpty } from "@/features/layouts/components/thread-view/components/thread-view-empty";
 import { ThreadSelectionProvider, useThreadSelection } from "@/features/providers/thread-selection";
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import { Panel, Group, Separator, useDefaultLayout } from "react-resizable-panels";
 import { useMailboxContext } from "@/features/providers/mailbox";
 import useAbility, { Abilities } from "@/hooks/use-ability";
 import { useMemo } from "react";
 import ViewHelper from "@/features/utils/view-helper";
-import { Button } from "@gouvfr-lasuite/cunningham-react";
 import { useSearchParams } from "next/navigation";
 
 const Mailbox = () => {
@@ -36,17 +35,7 @@ const Mailbox = () => {
     }, [canImportMessages, searchParams]);
 
     if (emptyMailbox) {
-        return (
-            <div className="thread-view thread-view--empty" style={{ top: 0 }}>
-                <div>
-                    <Image src="/images/svg/read-mail.svg" alt="" width={60} height={60} />
-                    <p>{t('No threads')}</p>
-                    {showImportButton && (
-                        <Button href="#modal-message-importer">{t('Import messages')}</Button>
-                    )}
-                </div>
-            </div>
-        )
+        return <ThreadViewEmpty label={t('No threads')} showImportButton={showImportButton} />
     }
 
     return (
@@ -61,12 +50,7 @@ const Mailbox = () => {
                         {selectedThreadIds.size > 0 ? (
                             <ThreadSelectionPlaceholder />
                         ) : (
-                            <div className="thread-view thread-view--empty">
-                                <div>
-                                    <Image src="/images/svg/read-mail.svg" alt="" width={60} height={60} />
-                                    <p>{t('Select a thread')}</p>
-                                </div>
-                            </div>
+                            <ThreadViewEmpty />
                         )}
                     </Panel>
                 </>


### PR DESCRIPTION
## Purpose

On slow machines, a race condition can occur when unselectThread is trigger and another action is also triggered. e.g: when user mark as unread a thread, the thread is unselect and the request to mark it as unread is trigger but sometimes, the request is completed before the router navigation so the observer in charge to mark visible message has unread is trigger again and finally, the thread is not marked as unread...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a consistent empty state display when no thread is selected, with optional import button for empty mailboxes.

* **Bug Fixes**
  * Improved thread view state transitions to prevent race conditions during navigation.

* **Refactor**
  * Consolidated duplicate empty state UI across pages into a shared, reusable component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/messages/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->