### PR TITLE
🐛(frontend) do not refetch thread messages on draft deletion

### DIFF
--- a/src/frontend/src/features/forms/components/message-form/index.tsx
+++ b/src/frontend/src/features/forms/components/message-form/index.tsx
@@ -106,7 +106,7 @@ export const MessageForm = ({
     const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
     const saveDraftRef = useRef<() => void>(() => {});
     const quoteType: QuoteType | undefined = mode !== "new" ? (mode === "forward" ? "forward" : "reply") : undefined;
-    const { selectedMailbox, selectedThread, mailboxes, removeMessages, patchMessages, invalidateMailbox, invalidateThreadsStats, unselectThread, unpinThreads, pinThreads } = useMailboxContext();
+    const { selectedMailbox, selectedThread, mailboxes, removeMessages, patchMessages, invalidateMailbox, invalidateThreadList, invalidateThreadsStats, unselectThread, unpinThreads, pinThreads } = useMailboxContext();
     const hideSubjectField = Boolean(draftMessage?.parent_id ?? parentMessage);
     // For replies/forwards, only allow sending from a mailbox that has access to the thread.
     const availableMailboxes = useMemo(() => {
@@ -360,6 +360,7 @@ export const MessageForm = ({
         await saveDraftPromiseRef.current;
         stopAutoSave();
 
+        const isSingleMessage = selectedThread?.messages.length === 1;
         deleteMessageMutation.mutate({
             id: messageId
         }, {
@@ -373,12 +374,17 @@ export const MessageForm = ({
                     // is authoritative.
                     unpinThreads([selectedThread.id]);
                 }
-                invalidateMailbox();
-                invalidateThreadsStats();
-                // Unselect the thread if we are in the draft view
-                if (searchParams.get('has_draft') === '1') {
+                if (isSingleMessage) {
+                    invalidateThreadList();
                     unselectThread();
+                } else {
+                    invalidateMailbox();
+                    // Unselect the thread if we are in the draft view
+                    if (searchParams.get('has_draft') === '1') {
+                        unselectThread();
+                    }
                 }
+                invalidateThreadsStats();
                 addToast(
                     <ToasterItem type="info">
                         <span>{t("Draft deleted")}</span>


### PR DESCRIPTION
## Purpose

If a draft is the single thread message, delete it should not trigger a request to refresh thread message list because this is wasteful and it also display a toast error as the thread does not exist anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined draft deletion handling to ensure proper cache updates and thread state management, particularly when removing drafts from single-message threads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/messages/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->