### PR TITLE
🐛(mta-in) fix milter socket permission race on startup

### DIFF
--- a/src/mta-in/entrypoint.sh
+++ b/src/mta-in/entrypoint.sh
@@ -47,26 +47,19 @@ postfix check -v || exit 1
 
 echo "Starting delivery milter in background..."
 
-# Create milter socket directory with proper permissions
-mkdir -p /var/spool/postfix/milter
-chown postfix:postfix /var/spool/postfix/milter
-chmod 755 /var/spool/postfix/milter
-
 /venv/bin/python3 /app/src/delivery_milter.py &
 MILTER_PID=$!
 
-# Wait until the milter is ready, with a maximum of 10 seconds
+# Wait up to 10s for the milter to bind its socket before starting postfix.
+# Socket ownership/mode are set by the milter process itself (setgid + umask).
 for i in {1..10}; do
     if [ -S /var/spool/postfix/milter/delivery.sock ]; then
-        chown postfix:postfix /var/spool/postfix/milter/delivery.sock
-        chmod 660 /var/spool/postfix/milter/delivery.sock
         echo "Milter socket ready"
         break
     fi
     sleep 1
 done
 
-# If socket still doesn't exist, exit
 if [ ! -S /var/spool/postfix/milter/delivery.sock ]; then
     echo "ERROR: Milter socket not found"
     exit 1

--- a/src/mta-in/src/delivery_milter.py
+++ b/src/mta-in/src/delivery_milter.py
@@ -6,6 +6,7 @@ This milter processes messages before they are queued and performs
 delivery immediately. If delivery fails, the SMTP session is rejected.
 """
 
+import grp
 import json
 import os
 import sys
@@ -166,6 +167,14 @@ def main():
 
     # Create directory if it doesn't exist
     os.makedirs("/var/spool/postfix/milter", exist_ok=True)
+
+    # Ensure the socket is born group=postfix mode 0660 — libmilter may unlink
+    # and rebind during startup, racing any chown/chmod done from the outside.
+    try:
+        os.setgid(grp.getgrnam("postfix").gr_gid)
+    except (KeyError, OSError) as e:
+        print(f"Warning: could not set gid to postfix: {e}", file=sys.stderr)
+    os.umask(0o117)
 
     # Register our milter class
     Milter.factory = DeliveryMilter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed manual socket pre-creation and permission configuration from system startup procedure
  * Mail delivery service now automatically configures its process group identity and file permissions during initialization
  * Enhanced startup validation to confirm socket availability before activating dependent services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->