### PR TITLE
🐛(import) fix mbox detection as text/html with some libmagic versions

### DIFF
--- a/src/backend/core/services/importer/service.py
+++ b/src/backend/core/services/importer/service.py
@@ -66,17 +66,24 @@ class ImportService:
             Key=file_key,
             Range="bytes=0-2047",
         )["Body"].read()
-        content_type = magic.from_buffer(head, mime=True)
 
-        # Disambiguate ambiguous MIME types using filename extension
-        if content_type in ("text/plain", "application/octet-stream") and filename:
-            ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-            extension_map = {
-                "eml": "message/rfc822",
-                "mbox": "application/mbox",
-                "pst": "application/vnd.ms-outlook",
-            }
-            content_type = extension_map.get(ext, content_type)
+        # RFC 4155: an mbox file starts with a "From " envelope line at offset 0.
+        # Trust that signature first — libmagic can otherwise misclassify mbox
+        # files whose first message body contains HTML as text/html.
+        if head.startswith(b"From "):
+            content_type = "application/mbox"
+        else:
+            content_type = magic.from_buffer(head, mime=True)
+
+            # Disambiguate ambiguous MIME types using filename extension
+            if content_type in ("text/plain", "application/octet-stream") and filename:
+                ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+                extension_map = {
+                    "eml": "message/rfc822",
+                    "mbox": "application/mbox",
+                    "pst": "application/vnd.ms-outlook",
+                }
+                content_type = extension_map.get(ext, content_type)
 
         if content_type not in enums.ARCHIVE_SUPPORTED_MIME_TYPES:
             return False, {

--- a/src/backend/core/tests/importer/test_import_service.py
+++ b/src/backend/core/tests/importer/test_import_service.py
@@ -453,6 +453,76 @@ def test_import_file_invalid_file(admin_user, mailbox, mock_request):
         )
 
 
+@pytest.mark.django_db
+def test_import_file_mbox_misclassified_by_libmagic(admin_user, mailbox, mock_request):
+    """Regression: an mbox file must be recognized even when libmagic
+    misclassifies it (e.g. returns text/html because the first message body
+    contains HTML strong enough to outrank the ``From `` envelope signature).
+
+    Observed against libmagic 5.41 (Ubuntu 22.04, the libmagic Scalingo's
+    scalingo-22 stack ships) on a real multipart/alternative Zimbra-exported
+    mbox: libmagic 5.41 returns text/html and the upload is rejected. Debian
+    13's libmagic 5.46 — used in the dev container and the distroless image
+    built from src/backend/Dockerfile — has tuned scoring so the same bytes
+    classify as application/mbox, which is why this test mocks
+    ``magic.from_buffer`` rather than relying on real bytes (a real-bytes
+    fixture passes trivially on the dev libmagic regardless of the fix).
+
+    RFC 4155 requires every mbox file to start with a ``From `` envelope line
+    at offset 0; we trust that signature ahead of libmagic.
+    """
+    mbox_content = (
+        b"From sender@example.com Mon Jun 01 00:00:00 2026\r\n"
+        b"From: sender@example.com\r\n"
+        b"To: jean.recipient@example.com\r\n"
+        b"Subject: HTML body trips libmagic\r\n"
+        b"MIME-Version: 1.0\r\n"
+        b"Content-Type: text/html; charset=utf-8\r\n"
+        b"\r\n"
+        b"<!DOCTYPE html><html><body><h1>Hello</h1></body></html>\r\n"
+    )
+    uploaded = SimpleUploadedFile(
+        # Deliberately no .mbox extension so the extension fallback can't rescue us.
+        "ambiguous-upload",
+        mbox_content,
+        content_type="application/octet-stream",
+    )
+    file_key = get_file_key(admin_user.id, uploaded.name)
+    storage = storages["message-imports"]
+    s3_client = storage.connection.meta.client
+    s3_client.put_object(
+        Bucket=storage.bucket_name,
+        Key=file_key,
+        Body=mbox_content,
+        ContentType=uploaded.content_type,
+    )
+
+    try:
+        with (
+            patch(
+                "core.services.importer.service.magic.from_buffer",
+                return_value="text/html",
+            ),
+            patch(
+                "core.services.importer.mbox_tasks.process_mbox_file_task.delay"
+            ) as mock_task,
+        ):
+            mock_task.return_value.id = "fake-task-id"
+            success, response_data = ImportService.import_file(
+                file_key=file_key,
+                recipient=mailbox,
+                user=admin_user,
+                request=mock_request,
+                filename=uploaded.name,
+            )
+
+            assert success is True, response_data
+            assert response_data["type"] == "mbox"
+            mock_task.assert_called_once()
+    finally:
+        s3_client.delete_object(Bucket=storage.bucket_name, Key=file_key)
+
+
 def test_import_imap_by_superuser(admin_user, mailbox, mock_request):
     """Test successful IMAP import."""
     with patch(

--- a/src/backend/core/tests/importer/test_import_service.py
+++ b/src/backend/core/tests/importer/test_import_service.py
@@ -502,7 +502,7 @@ def test_import_file_mbox_misclassified_by_libmagic(admin_user, mailbox, mock_re
             patch(
                 "core.services.importer.service.magic.from_buffer",
                 return_value="text/html",
-            ),
+            ) as mock_magic,
             patch(
                 "core.services.importer.mbox_tasks.process_mbox_file_task.delay"
             ) as mock_task,
@@ -519,6 +519,9 @@ def test_import_file_mbox_misclassified_by_libmagic(admin_user, mailbox, mock_re
             assert success is True, response_data
             assert response_data["type"] == "mbox"
             mock_task.assert_called_once()
+            # The RFC 4155 ``From `` envelope at offset 0 must short-circuit
+            # detection — libmagic is never consulted on this branch.
+            mock_magic.assert_not_called()
     finally:
         s3_client.delete_object(Bucket=storage.bucket_name, Key=file_key)
 


### PR DESCRIPTION
This would block the upload of imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of uploaded email archives so MBOX-formatted uploads are recognized reliably even when automatic type detection is ambiguous.

* **Tests**
  * Added a regression test to ensure MBOX uploads are correctly identified and routed for processing despite ambiguous automatic detection results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->