### PR TITLE
Fix/another pst issue

### DIFF
--- a/src/backend/core/mda/rfc5322/composer.py
+++ b/src/backend/core/mda/rfc5322/composer.py
@@ -477,6 +477,20 @@ def create_attachment_part(  # pylint: disable=too-many-return-statements
     content_id = attachment.get("cid")
     maintype, subtype = _split_content_type(content_type)
 
+    # Defensive relabel for message/delivery-status — the one media type whose
+    # email.generator handler (_handle_message_delivery_status) assumes a
+    # structured (list) payload and crashes on the flat byte string set_content
+    # produces, iterating it character by character until it hits
+    # "'str' object has no attribute 'policy'" and aborting the whole compose.
+    # It is never a legitimate opaque-bytes attachment (DSN/bounce archives are
+    # the only source); the bytes are RFC822-style text, so text/plain keeps
+    # them readable and intact. No other attachment type reaches a payload-
+    # structured generator branch, so nothing else is affected.
+    # MIME types are case-insensitive (RFC 2045), so normalize before matching
+    # to catch variants like "Message/Delivery-Status".
+    if (maintype.lower(), subtype.lower()) == ("message", "delivery-status"):
+        maintype, subtype = "text", "plain"
+
     try:
         part = MIMEPart(policy=_POLICY)
         kwargs: Dict[str, Any] = {

--- a/src/backend/core/services/importer/pst.py
+++ b/src/backend/core/services/importer/pst.py
@@ -1143,6 +1143,15 @@ def reconstruct_eml(
                 att_size = attachment.get_size()
                 att_data = attachment.read_buffer(att_size)
 
+                # Skip empty / whitespace-only parts. DSN and read-receipt
+                # reports routinely expose blank diagnostic parts (e.g. an empty
+                # text/rfc822-headers) that libpff surfaces as attachments;
+                # importing them yields 0-byte attachments that render as broken
+                # in the UI while carrying no information.
+                if not att_data or not att_data.strip():
+                    logger.debug("Skipping empty attachment %d", i)
+                    continue
+
                 # Filename from MAPI properties
                 filename = (
                     get_mapi_property_string(attachment, PR_ATTACH_LONG_FILENAME)
@@ -1155,6 +1164,15 @@ def reconstruct_eml(
                 mime_type = get_mapi_property_string(attachment, PR_ATTACH_MIME_TAG)
                 if not mime_type:
                     mime_type = "application/octet-stream"
+
+                # text/rfc822-headers (the original-headers part of a DSN/read
+                # receipt) composes fine but our display parser (flanker)
+                # silently drops the body of this subtype on re-parse, surfacing
+                # it as a 0-byte attachment in the UI. The content is plain
+                # RFC822 header text, so normalize the label to text/plain, which
+                # round-trips intact.
+                if mime_type.split(";")[0].strip().lower() == "text/rfc822-headers":
+                    mime_type = "text/plain"
 
                 # Content-ID for inline images
                 content_id = get_mapi_property_string(attachment, PR_ATTACH_CONTENT_ID)

--- a/src/backend/core/services/importer/pst.py
+++ b/src/backend/core/services/importer/pst.py
@@ -92,8 +92,11 @@ MSGFLAG_UNSENT = 0x8
 # Flag status values
 FLAG_STATUS_FOLLOWUP = 2  # Flagged for follow-up
 
-# Container class prefix for email folders (MAPI standard)
-EMAIL_CONTAINER_CLASS_PREFIX = "IPF.Note"
+# Container class prefixes for folders that hold mail items (MAPI standard).
+# IPF.Note — standard Outlook mail folders.
+# IPF.Imap — IMAP accounts archived to PST keep this class on their mail
+# folders (e.g. the inbox), so they must be treated as mail too.
+EMAIL_CONTAINER_CLASS_PREFIXES = ("IPF.Note", "IPF.Imap")
 
 # Maximum recursion depth for PST folder traversal
 MAX_FOLDER_DEPTH = 50
@@ -349,7 +352,7 @@ def _is_email_folder(folder) -> bool:
         return True
     try:
         container_class = entry.data_as_string
-        return container_class.startswith(EMAIL_CONTAINER_CLASS_PREFIX)
+        return container_class.startswith(EMAIL_CONTAINER_CLASS_PREFIXES)
     except Exception:
         logger.debug("Failed to read container class for folder")
     return True

--- a/src/backend/core/tests/importer/test_pst_import.py
+++ b/src/backend/core/tests/importer/test_pst_import.py
@@ -1227,6 +1227,46 @@ class TestFolderIdentification:
         count = count_pst_messages(pst, {})
         assert count == 1
 
+    def test_process_imap_folder(self):
+        """IMAP-archived PSTs tag mail folders IPF.Imap — they must be counted."""
+        msg = _make_message(delivery_time=datetime(2025, 1, 1, tzinfo=timezone.utc))
+        folder = _make_folder(
+            name="Boîte de réception",
+            messages=[msg],
+            container_class="IPF.Imap",
+        )
+        root = _make_folder(name="Root", subfolders=[folder])
+
+        pst = Mock()
+        pst.get_root_folder.return_value = root
+        pst.get_message_store.return_value = Mock(number_of_record_sets=0)
+
+        count = count_pst_messages(pst, {})
+        assert count == 1
+
+    def test_walk_yields_messages_from_imap_folder(self):
+        """walk_pst_messages (the import path) must yield IPF.Imap messages."""
+        msg = _make_message(
+            subject="IMAP message",
+            transport_headers="From: a@example.com\r\nTo: b@example.com\r\n",
+            delivery_time=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+        folder = _make_folder(
+            name="Boîte de réception",
+            messages=[msg],
+            container_class="IPF.Imap",
+        )
+        root = _make_folder(name="Root", subfolders=[folder])
+
+        pst = Mock()
+        pst.get_root_folder.return_value = root
+        pst.get_message_store.return_value = Mock(number_of_record_sets=0)
+        pst.get_name_to_id_map.side_effect = Exception("no named props")
+
+        results = list(walk_pst_messages(pst, {}))
+        assert len(results) == 1
+        assert results[0][4] is not None  # eml_bytes reconstructed
+
     def test_sent_folder_identification_via_entry_id(self):
         """Test identifying Sent Items via message store folder identifier."""
         special_map = {100: FOLDER_TYPE_SENT}

--- a/src/backend/core/tests/importer/test_pst_import.py
+++ b/src/backend/core/tests/importer/test_pst_import.py
@@ -4,6 +4,7 @@
 # pylint: disable=too-many-lines, too-many-arguments, broad-exception-caught
 
 import email
+import email.policy
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, Mock, patch
 
@@ -11,6 +12,7 @@ from django.core.files.storage import storages
 
 import pytest
 
+from core.mda.rfc5322 import parse_email_message
 from core.models import Mailbox, MailDomain, Message
 from core.services.importer.pst import (
     FLAG_STATUS_FOLLOWUP,
@@ -261,6 +263,7 @@ def _make_folder(
 # --- reconstruct_eml tests ---
 
 
+# pylint: disable=too-many-public-methods
 class TestReconstructEml:
     """Tests for EML reconstruction from pypff messages."""
 
@@ -587,6 +590,105 @@ class TestReconstructEml:
         ]
         assert len(att_parts) == 1
         assert att_parts[0].get_content_type() == "application/octet-stream"
+
+    def test_reconstruct_delivery_status_attachment_does_not_crash(self):
+        """A DSN delivery-status part imports without crashing the composer.
+
+        Regression: bounce/read-receipt reports in a PST carry the
+        delivery-status body as a flat-bytes MAPI attachment. Fed to the strict
+        composer as message/delivery-status, email.generator walked the base64
+        string character by character and raised "'str' object has no attribute
+        'policy'", dropping the whole message. The composer now relabels the
+        part to text/plain (content preserved, readable), so reconstructing the
+        report no longer crashes.
+        """
+        dsn = (
+            b"Reporting-MTA: dns; mx.example.com\r\n"
+            b"Final-Recipient: rfc822; nobody@example.com\r\n"
+            b"Action: failed\r\nStatus: 5.1.1\r\n"
+        )
+        att = _make_attachment(
+            data=dsn,
+            long_filename="details.txt",
+            mime_type="message/delivery-status",
+        )
+        msg = _make_message(
+            transport_headers="From: daemon@example.com\r\n",
+            plain_text_body="Delivery failed",
+            num_attachments=1,
+            attachments=[att],
+        )
+        eml_bytes = reconstruct_eml(msg)
+        parsed = email.message_from_bytes(eml_bytes, policy=email.policy.default)
+
+        part = next(p for p in parsed.walk() if p.get_filename() == "details.txt")
+        # Relabelled to a safe leaf type; content preserved verbatim.
+        assert part.get_content_type() == "text/plain"
+        assert part.get_payload(decode=True) == dsn
+        # The original message/delivery-status type is never emitted.
+        assert b"message/delivery-status" not in eml_bytes
+
+    def test_reconstruct_skips_empty_attachment(self):
+        """Blank/whitespace-only attachments (e.g. empty DSN parts) are dropped.
+
+        libpff surfaces empty diagnostic report parts as attachments; importing
+        them produces 0-byte attachments that render as broken in the UI while
+        carrying no information.
+        """
+        empty = _make_attachment(
+            data=b"\r\n",
+            long_filename="empty.txt",
+            mime_type="text/rfc822-headers",
+        )
+        msg = _make_message(
+            transport_headers="From: a@b.com\r\n",
+            plain_text_body="body",
+            num_attachments=1,
+            attachments=[empty],
+        )
+        eml_bytes = reconstruct_eml(msg)
+        parsed = email.message_from_bytes(eml_bytes)
+
+        att_parts = [
+            p for p in parsed.walk() if p.get_content_disposition() == "attachment"
+        ]
+        assert att_parts == []
+
+    def test_reconstruct_rfc822_headers_attachment_is_displayable(self):
+        """text/rfc822-headers is relabelled so it doesn't show as 0 bytes.
+
+        Regression: the original-headers part of a DSN composes fine, but the
+        display parser (flanker) silently drops the body of text/rfc822-headers
+        on re-parse, so the UI showed a 0-byte attachment. The importer
+        normalizes it to text/plain, which round-trips with its content intact.
+        """
+
+        headers = (
+            b"Return-Path: <sender@example.com>\r\n"
+            b"From: Sender <sender@example.com>\r\n"
+            b"To: Recipient <rcpt@example.com>\r\n"
+            b"Subject: original\r\n"
+        )
+        att = _make_attachment(
+            data=headers,
+            long_filename="Message Headers.txt",
+            mime_type="text/rfc822-headers",
+        )
+        msg = _make_message(
+            transport_headers="From: daemon@example.com\r\n",
+            plain_text_body="Delivered",
+            num_attachments=1,
+            attachments=[att],
+        )
+        eml_bytes = reconstruct_eml(msg)
+
+        # Re-parse the stored .eml the way the message view does.
+        parsed = parse_email_message(eml_bytes)
+        headers_att = next(
+            a for a in parsed["attachments"] if a["name"] == "Message Headers.txt"
+        )
+        assert headers_att["type"] == "text/plain"
+        assert headers_att["size"] == len(headers)
 
     def test_reconstruct_empty_message(self):
         """Test EML reconstruction with no body."""

--- a/src/backend/core/tests/mda/test_rfc5322_composer.py
+++ b/src/backend/core/tests/mda/test_rfc5322_composer.py
@@ -618,6 +618,78 @@ class TestEmailComposition:
 
         assert attachment_found, "PDF attachment not found in the email"
 
+    def test_compose_with_delivery_status_attachment_does_not_crash(self):
+        """A message/delivery-status attachment is composed safely.
+
+        Regression: composed as message/delivery-status, the flat byte payload
+        drove email.generator's _handle_message_delivery_status to iterate the
+        base64 string character by character, raising "'str' object has no
+        attribute 'policy'" and failing the whole compose (and any send/import
+        carrying such a part). The composer relabels the part to text/plain —
+        the bytes are RFC822-style text, so they stay readable and intact.
+        """
+        dsn = (
+            b"Reporting-MTA: dns; mx.example.com\r\n"
+            b"Final-Recipient: rfc822; nobody@example.com\r\n"
+            b"Action: failed\r\nStatus: 5.1.1\r\n"
+        )
+        jmap_data = {
+            "from": {"name": "Mailer Daemon", "email": "daemon@example.com"},
+            "to": [{"email": "sender@example.com"}],
+            "subject": "Undelivered Mail Returned to Sender",
+            "textBody": [{"content": "Delivery failed."}],
+            "attachments": [
+                {
+                    "type": "message/delivery-status",
+                    "name": "details.txt",
+                    "content": base64.b64encode(dsn).decode("ascii"),
+                    "disposition": "attachment",
+                }
+            ],
+        }
+
+        raw_email = compose_email(jmap_data, keep_bcc=True)
+
+        msg = email.message_from_bytes(raw_email, policy=policy.default)
+        part = next(p for p in msg.walk() if p.get_filename() == "details.txt")
+        assert part.get_content_type() == "text/plain"
+        assert part.get_payload(decode=True) == dsn
+        assert b"message/delivery-status" not in raw_email
+
+    def test_compose_with_mixed_case_delivery_status_attachment(self):
+        """The relabel guard is case-insensitive, per RFC 2045.
+
+        A "Message/Delivery-Status" content type (any casing) must be relabeled
+        to text/plain just like the lowercase form, otherwise it escapes the
+        guard and crashes the compose pipeline.
+        """
+        dsn = (
+            b"Reporting-MTA: dns; mx.example.com\r\n"
+            b"Final-Recipient: rfc822; nobody@example.com\r\n"
+            b"Action: failed\r\nStatus: 5.1.1\r\n"
+        )
+        jmap_data = {
+            "from": {"name": "Mailer Daemon", "email": "daemon@example.com"},
+            "to": [{"email": "sender@example.com"}],
+            "subject": "Undelivered Mail Returned to Sender",
+            "textBody": [{"content": "Delivery failed."}],
+            "attachments": [
+                {
+                    "type": "Message/Delivery-Status",
+                    "name": "details.txt",
+                    "content": base64.b64encode(dsn).decode("ascii"),
+                    "disposition": "attachment",
+                }
+            ],
+        }
+
+        raw_email = compose_email(jmap_data, keep_bcc=True)
+
+        msg = email.message_from_bytes(raw_email, policy=policy.default)
+        part = next(p for p in msg.walk() if p.get_filename() == "details.txt")
+        assert part.get_content_type() == "text/plain"
+        assert part.get_payload(decode=True) == dsn
+
     def test_compose_with_empty_subject(self):
         """Test composing an email with an empty subject."""
         jmap_data = {


### PR DESCRIPTION
## Purpose

- Consider `IPF.Imap` as container with emails.
- Manage message/delivery-status and text/rfc822-headers to prevent issues on PST import


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoids crashes when composing messages with message/delivery-status attachments by treating them as plain text (case-insensitive) and preserving payload bytes.
  * Skips empty or whitespace-only attachments during PST import and normalizes RFC822-headers parts to display correctly.

* **New Features**
  * Recognizes and imports PST folders archived as IMAP so their messages are processed.

* **Tests**
  * Added regression tests for the above attachment handling and IMAP-folder import behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->