### PR TITLE
🐛(rsvp) fix order and default calendar selection when RSVPing

### DIFF
--- a/src/backend/core/services/calendar/service.py
+++ b/src/backend/core/services/calendar/service.py
@@ -10,7 +10,7 @@ import logging
 import re
 import uuid
 from datetime import datetime, timezone
-from urllib.parse import quote, urljoin, urlparse
+from urllib.parse import quote, unquote, urljoin, urlparse
 
 from django.conf import settings as django_settings
 
@@ -33,6 +33,11 @@ CALDAV_TIMEOUT = 20
 DAV_NS = "DAV:"
 CALDAV_NS = "urn:ietf:params:xml:ns:caldav"
 APPLE_ICAL_NS = "http://apple.com/ns/ical/"
+CS_NS = "http://calendarserver.org/ns/"
+# suitenumerique/calendars custom extension. Currently exposes
+# ``calendar-owner-type`` (MAILBOX vs. user's own) so we don't have to
+# infer it from the principal URL shape.
+LASUITE_NS = "http://lasuite.numerique.gouv.fr/ns/"
 
 # Accept only #RRGGBB / #RGB hex from the calendar server's color property —
 # anything else is treated as no color (defensive against attacker-controlled
@@ -253,10 +258,15 @@ class CalDAVService:  # pylint: disable=too-many-instance-attributes
         body = (
             '<?xml version="1.0"?>'
             '<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"'
-            ' xmlns:a="http://apple.com/ns/ical/">'
+            ' xmlns:a="http://apple.com/ns/ical/"'
+            ' xmlns:cs="http://calendarserver.org/ns/"'
+            ' xmlns:ls="http://lasuite.numerique.gouv.fr/ns/">'
             "<d:prop>"
             "<d:displayname/><d:resourcetype/><a:calendar-color/>"
+            "<a:calendar-order/>"
             "<d:current-user-privilege-set/>"
+            "<cs:invite/>"
+            "<ls:calendar-owner-type/>"
             "</d:prop>"
             "</d:propfind>"
         )
@@ -276,14 +286,84 @@ class CalDAVService:  # pylint: disable=too-many-instance-attributes
             color = self._parse_color(
                 response.findtext(f".//{_q(APPLE_ICAL_NS, 'calendar-color')}")
             )
+            order = self._parse_order(
+                response.findtext(f".//{_q(APPLE_ICAL_NS, 'calendar-order')}")
+            )
+            owner_email, owner_type = self._parse_owner(response)
             result.append(
                 {
                     "id": urljoin(self.url, href),
                     "name": displayname.strip(),
                     "color": color,
+                    "order": order,
+                    "owner_email": owner_email,
+                    "owner_type": owner_type,
                 }
             )
+        # Honour the user's manual ordering from the Calendars UI (Apple's
+        # ``calendar-order`` property, written via PROPPATCH by the
+        # suitenumerique/calendars frontend). Calendars without an order
+        # value go after the ordered ones, in original server order — so
+        # adding a new calendar doesn't push it ahead of explicitly-ranked
+        # ones. Python's ``sorted`` is stable, which preserves server
+        # order within each bucket.
+        result.sort(key=lambda c: (c["order"] is None, c["order"] or 0))
         return result
+
+    @staticmethod
+    def _parse_owner(response):
+        """Extract (owner_email, owner_type) from a calendar PROPFIND response.
+
+        Owner type comes from the suitenumerique
+        ``ls:calendar-owner-type`` extension: ``MAILBOX`` for shared-mailbox
+        calendars, absent (404 in the propstat) for the user's own
+        calendars — which we report as ``USER``. We deliberately avoid
+        guessing the type from the principal URL shape; the extension is
+        authoritative.
+
+        The owner's email is the last non-empty path segment of
+        ``cs:invite/cs:organizer/d:href`` — the suite emits a principal
+        href like ``/.../principals/users/<email>`` or
+        ``/.../principals/mailboxes/<email>``, and the trailing segment is
+        the address. URL-decoded so percent-encoded ``@`` (RFC-legal but
+        emitted by some servers) matches the plain mailto: addresses in
+        event ATTENDEE entries.
+
+        Returns ``(None, None)`` for CalDAV servers that don't expose
+        ``cs:invite`` (non-suitenumerique implementations) — callers should
+        treat that as "owner unknown" and fall back to mailbox-email
+        matching.
+        """
+        organizer_href = response.findtext(
+            f".//{_q(CS_NS, 'invite')}/{_q(CS_NS, 'organizer')}/{_q(DAV_NS, 'href')}"
+        )
+        if not organizer_href:
+            return None, None
+        last_segment = organizer_href.strip().rstrip("/").rsplit("/", 1)[-1]
+        if not last_segment:
+            return None, None
+        owner_email = unquote(last_segment)
+
+        raw_type = response.findtext(f".//{_q(LASUITE_NS, 'calendar-owner-type')}")
+        owner_type = "MAILBOX" if (raw_type or "").strip() == "MAILBOX" else "USER"
+        return owner_email, owner_type
+
+    @staticmethod
+    def _parse_order(raw):
+        """Parse Apple ``calendar-order`` (integer sort key) defensively.
+
+        The property is written by the suitenumerique/calendars frontend
+        as a decimal integer, but the value flows through user input
+        (PROPPATCH from the browser) so we must not trust the format.
+        Returns None for missing/malformed values — those calendars sort
+        last while preserving server order among themselves.
+        """
+        if not raw:
+            return None
+        try:
+            return int(raw.strip())
+        except (ValueError, TypeError):
+            return None
 
     @staticmethod
     def _parse_color(raw):
@@ -489,17 +569,41 @@ class CalDAVService:  # pylint: disable=too-many-instance-attributes
         ``PARTSTAT=DECLINED``. The user can re-accept later by changing
         PARTSTAT on the same event.
 
-        Raises ``CalDAVError`` if the responding mailbox is not in the
-        ATTENDEE list — without that, the iTIP REPLY would never reach
-        the organizer (the broker uses ATTENDEE matching to decide who
-        to notify) and the user would see a "Response saved" toast for
-        a no-op write.
+        When ``calendar_id`` points to a calendar whose owner principal is
+        itself an ATTENDEE on the event, the PARTSTAT update targets that
+        owner address rather than ``attendee_email``. This is how a user
+        viewing an invite from their *personal* mailbox can RSVP on behalf
+        of a *shared mailbox* by picking the mailbox calendar: the iTIP
+        REPLY is then sent from the right identity (the mailbox, not the
+        personal address). Falls back to ``attendee_email`` when the
+        calendar's owner is not on the invite or the CalDAV server doesn't
+        expose owner info.
+
+        Raises ``CalDAVError`` if neither candidate is on the ATTENDEE
+        list — without that, the iTIP REPLY would never reach the
+        organizer (the broker uses ATTENDEE matching to decide who to
+        notify) and the user would see a "Response saved" toast for a
+        no-op write.
         """
         cal = ICalendar.from_ical(ics_data)
+        calendar = self._pick_calendar(calendar_id)
+
+        # Prefer the selected calendar's owner address — that's the identity
+        # this RSVP speaks for. Fall back to the mailbox address passed in
+        # by the viewset for backends that don't expose owner info.
+        candidates = []
+        owner = calendar.get("owner_email")
+        if owner:
+            candidates.append(owner)
+        if attendee_email and attendee_email not in candidates:
+            candidates.append(attendee_email)
+
         # Update PARTSTAT on the input first, then rebuild — the rebuild
         # preserves ATTENDEE entries (with our updated PARTSTAT) and
         # drops everything else.
-        if not self._update_partstat(cal, attendee_email, response):
+        if not any(
+            self._update_partstat(cal, candidate, response) for candidate in candidates
+        ):
             raise CalDAVError(
                 "Mailbox is not an attendee of this event; "
                 "RSVP would not notify the organizer."
@@ -508,7 +612,7 @@ class CalDAVService:  # pylint: disable=too-many-instance-attributes
         cal = rebuild_for_storage(cal)
 
         self._put_event(
-            self._pick_calendar_url(calendar_id),
+            calendar["id"],
             cal.to_ical().decode("utf-8"),
         )
         return True
@@ -566,7 +670,13 @@ class CalDAVService:  # pylint: disable=too-many-instance-attributes
                 updated = True
         return updated
 
-    def _pick_calendar_url(self, calendar_id):
+    def _pick_calendar(self, calendar_id):
+        """Resolve ``calendar_id`` to the matching calendar dict.
+
+        Used by both add_event (needs the URL) and respond_to_event (also
+        needs ``owner_email`` to know which identity the RSVP speaks for).
+        Returns the full calendar dict from ``list_calendars(writable_only=True)``.
+        """
         if calendar_id and not self._same_origin(calendar_id):
             raise CalDAVError(
                 "Calendar URL host does not match the configured CalDAV server."
@@ -579,13 +689,14 @@ class CalDAVService:  # pylint: disable=too-many-instance-attributes
         if not calendars:
             raise CalDAVError("No writable calendars available on this CalDAV server.")
         if calendar_id:
-            valid_ids = {c["id"] for c in calendars}
-            if calendar_id not in valid_ids:
-                raise CalDAVError(
-                    "Calendar is not in this user's writable calendar list."
-                )
-            return calendar_id
-        return calendars[0]["id"]
+            for cal in calendars:
+                if cal["id"] == calendar_id:
+                    return cal
+            raise CalDAVError("Calendar is not in this user's writable calendar list.")
+        return calendars[0]
+
+    def _pick_calendar_url(self, calendar_id):
+        return self._pick_calendar(calendar_id)["id"]
 
     def _same_origin(self, candidate_url):
         """Whether ``candidate_url`` shares scheme + host + port with ``self.url``.

--- a/src/backend/core/tests/api/test_calendar.py
+++ b/src/backend/core/tests/api/test_calendar.py
@@ -2008,6 +2008,381 @@ class TestListCalendarsWritableFilter:
 
 
 # ---------------------------------------------------------------------------
+# Owner email / type parsing from PROPFIND cs:invite/cs:organizer
+# ---------------------------------------------------------------------------
+
+
+def _make_propfind_with_owner(entries):
+    """Build a multistatus body that mirrors suitenumerique/calendars output.
+
+    Each entry is (href, displayname, organizer_href, owner_type) where:
+      - ``organizer_href`` can be None to omit the cs:invite block
+        (simulating a non-suite CalDAV server)
+      - ``owner_type`` can be None to omit the ls:calendar-owner-type
+        extension (suitenumerique emits it only for MAILBOX calendars;
+        the user's own calendars don't carry it)
+    Privileges aren't emitted — the writable-only path is exercised by
+    the dedicated filter tests above.
+    """
+    parts = [
+        '<?xml version="1.0"?>',
+        '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"'
+        ' xmlns:cs="http://calendarserver.org/ns/"'
+        ' xmlns:ls="http://lasuite.numerique.gouv.fr/ns/">',
+    ]
+    for entry in entries:
+        # Backwards-compatible tuple shape: 3-tuple still works (treats
+        # owner_type as absent) so older test cases don't have to grow
+        # an extra field.
+        if len(entry) == 3:
+            href, name, organizer_href = entry
+            owner_type = None
+        else:
+            href, name, organizer_href, owner_type = entry
+        parts.append(f"<d:response><d:href>{href}</d:href><d:propstat><d:prop>")
+        parts.append(f"<d:displayname>{name}</d:displayname>")
+        parts.append("<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>")
+        if organizer_href is not None:
+            parts.append(
+                "<cs:invite><cs:organizer>"
+                f"<d:href>{organizer_href}</d:href>"
+                "</cs:organizer></cs:invite>"
+            )
+        if owner_type is not None:
+            parts.append(
+                f"<ls:calendar-owner-type>{owner_type}</ls:calendar-owner-type>"
+            )
+        parts.append("</d:prop></d:propstat></d:response>")
+    parts.append("</d:multistatus>")
+    return "".join(parts)
+
+
+class TestListCalendarsOwnerParsing:
+    """Unit tests for cs:invite/cs:organizer parsing in list_calendars."""
+
+    def _service_with_body(self, body):
+        service = CalDAVService(url="https://caldav.example.com/home/")
+        service._home_set = "https://caldav.example.com/home/"
+
+        class _FakeResp:
+            text = body
+
+        service._propfind = lambda *a, **kw: _FakeResp()  # type: ignore[method-assign]
+        return service
+
+    def test_personal_calendar_owner_is_user(self):
+        body = _make_propfind_with_owner(
+            [
+                (
+                    "/home/cal/",
+                    "Personal",
+                    "/caldav/principals/users/alice@example.com",
+                ),
+            ]
+        )
+        service = self._service_with_body(body)
+        [cal] = service.list_calendars()
+        assert cal["owner_email"] == "alice@example.com"
+        assert cal["owner_type"] == "USER"
+
+    def test_mailbox_calendar_owner_is_mailbox(self):
+        body = _make_propfind_with_owner(
+            [
+                (
+                    "/home/team/",
+                    "Team",
+                    "/caldav/principals/mailboxes/team@example.com",
+                    "MAILBOX",
+                ),
+            ]
+        )
+        service = self._service_with_body(body)
+        [cal] = service.list_calendars()
+        assert cal["owner_email"] == "team@example.com"
+        assert cal["owner_type"] == "MAILBOX"
+
+    def test_missing_invite_block_yields_none(self):
+        """Non-suitenumerique CalDAV servers omit cs:invite — owner stays None
+        so the frontend can fall back to mailbox-email matching instead of
+        silently hiding RSVP buttons everywhere."""
+        body = _make_propfind_with_owner([("/home/cal/", "Plain", None)])
+        service = self._service_with_body(body)
+        [cal] = service.list_calendars()
+        assert cal["owner_email"] is None
+        assert cal["owner_type"] is None
+
+    def test_owner_type_defaults_to_user_when_extension_absent(self):
+        """suitenumerique emits ``ls:calendar-owner-type`` only for MAILBOX
+        calendars; the user's own calendars omit it (404 propstat). When
+        cs:invite is present but the extension is absent we report USER —
+        the extension's absence is itself the signal."""
+        body = _make_propfind_with_owner(
+            [
+                (
+                    "/home/mine/",
+                    "Mine",
+                    "/caldav/principals/users/alice@example.com",
+                    None,
+                ),
+            ]
+        )
+        service = self._service_with_body(body)
+        [cal] = service.list_calendars()
+        assert cal["owner_email"] == "alice@example.com"
+        assert cal["owner_type"] == "USER"
+
+    def test_owner_email_is_last_path_segment(self):
+        """The principal href's trailing segment is taken verbatim as the
+        owner email — no pattern matching on intermediate path bits, so
+        custom CalDAV URL layouts (different prefix, longer path) still
+        parse correctly."""
+        body = _make_propfind_with_owner(
+            [
+                (
+                    "/home/cal/",
+                    "Custom",
+                    "/some/custom/dav/principals/users/alice@example.com/",
+                    None,
+                ),
+            ]
+        )
+        service = self._service_with_body(body)
+        [cal] = service.list_calendars()
+        assert cal["owner_email"] == "alice@example.com"
+
+    def test_owner_email_returns_none_when_href_has_no_segments(self):
+        """A bare slash or empty href yields no segment to use — return None
+        instead of an empty string (which would match an attendee with an
+        empty email field on garbage input)."""
+        body = _make_propfind_with_owner([("/home/cal/", "Empty", "/", None)])
+        service = self._service_with_body(body)
+        [cal] = service.list_calendars()
+        assert cal["owner_email"] is None
+        assert cal["owner_type"] is None
+
+    def test_calendar_order_respected(self):
+        """Apple ``calendar-order`` is written by the Calendars frontend so
+        users can reorder calendars; messages must honour the same order
+        instead of falling back to server iteration order."""
+        body = (
+            '<?xml version="1.0"?>'
+            '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"'
+            ' xmlns:a="http://apple.com/ns/ical/">'
+            "<d:response><d:href>/home/a/</d:href><d:propstat><d:prop>"
+            "<d:displayname>A-third</d:displayname>"
+            "<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>"
+            "<a:calendar-order>30</a:calendar-order>"
+            "</d:prop></d:propstat></d:response>"
+            "<d:response><d:href>/home/b/</d:href><d:propstat><d:prop>"
+            "<d:displayname>B-first</d:displayname>"
+            "<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>"
+            "<a:calendar-order>10</a:calendar-order>"
+            "</d:prop></d:propstat></d:response>"
+            "<d:response><d:href>/home/c/</d:href><d:propstat><d:prop>"
+            "<d:displayname>C-second</d:displayname>"
+            "<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>"
+            "<a:calendar-order>20</a:calendar-order>"
+            "</d:prop></d:propstat></d:response>"
+            "</d:multistatus>"
+        )
+        service = self._service_with_body(body)
+        names = [c["name"] for c in service.list_calendars()]
+        assert names == ["B-first", "C-second", "A-third"]
+
+    def test_unordered_calendars_sort_after_ordered_ones(self):
+        """A calendar without an order value goes after ordered ones, and
+        unordered calendars keep their relative server order (stable sort)
+        — so a fresh, unranked calendar doesn't jump ahead of explicitly
+        ranked ones."""
+        body = (
+            '<?xml version="1.0"?>'
+            '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"'
+            ' xmlns:a="http://apple.com/ns/ical/">'
+            "<d:response><d:href>/home/u1/</d:href><d:propstat><d:prop>"
+            "<d:displayname>Unordered-1</d:displayname>"
+            "<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>"
+            "</d:prop></d:propstat></d:response>"
+            "<d:response><d:href>/home/o/</d:href><d:propstat><d:prop>"
+            "<d:displayname>Ordered</d:displayname>"
+            "<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>"
+            "<a:calendar-order>5</a:calendar-order>"
+            "</d:prop></d:propstat></d:response>"
+            "<d:response><d:href>/home/u2/</d:href><d:propstat><d:prop>"
+            "<d:displayname>Unordered-2</d:displayname>"
+            "<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>"
+            "</d:prop></d:propstat></d:response>"
+            "</d:multistatus>"
+        )
+        service = self._service_with_body(body)
+        names = [c["name"] for c in service.list_calendars()]
+        assert names == ["Ordered", "Unordered-1", "Unordered-2"]
+
+    def test_malformed_order_treated_as_unordered(self):
+        """The order property comes from user input via PROPPATCH; a
+        non-integer must not crash the listing — treat as unordered."""
+        body = (
+            '<?xml version="1.0"?>'
+            '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"'
+            ' xmlns:a="http://apple.com/ns/ical/">'
+            "<d:response><d:href>/home/g/</d:href><d:propstat><d:prop>"
+            "<d:displayname>Garbage</d:displayname>"
+            "<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>"
+            "<a:calendar-order>not-a-number</a:calendar-order>"
+            "</d:prop></d:propstat></d:response>"
+            "</d:multistatus>"
+        )
+        service = self._service_with_body(body)
+        [cal] = service.list_calendars()
+        assert cal["order"] is None
+        assert cal["name"] == "Garbage"
+
+    def test_percent_encoded_email_is_decoded(self):
+        """Sabre/DAV happens to emit literal ``@`` but the spec lets a server
+        URL-encode it. Without decoding, attendee matching would silently
+        miss on those deployments — owner_email here must equal what
+        appears in ATTENDEE:mailto:..."""
+        body = _make_propfind_with_owner(
+            [
+                (
+                    "/home/cal/",
+                    "Encoded",
+                    "/caldav/principals/mailboxes/team%40example.com",
+                    "MAILBOX",
+                ),
+            ]
+        )
+        service = self._service_with_body(body)
+        [cal] = service.list_calendars()
+        assert cal["owner_email"] == "team@example.com"
+        assert cal["owner_type"] == "MAILBOX"
+
+
+# ---------------------------------------------------------------------------
+# respond_to_event: per-calendar owner_email targeting
+# ---------------------------------------------------------------------------
+
+
+class TestRespondToEventOwnerTargeting:
+    """When the selected calendar's owner is itself an attendee, the PARTSTAT
+    update must target that owner — so the iTIP REPLY is sent as the right
+    identity (e.g. responding as a shared mailbox from a personal session)."""
+
+    @staticmethod
+    def _ics(*attendees):
+        attendee_lines = "".join(
+            f"ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:mailto:{e}\r\n"
+            for e in attendees
+        )
+        return (
+            "BEGIN:VCALENDAR\r\n"
+            "VERSION:2.0\r\n"
+            "PRODID:-//Test//Test//EN\r\n"
+            "METHOD:REQUEST\r\n"
+            "BEGIN:VEVENT\r\n"
+            "UID:owner-target@example.com\r\n"
+            "DTSTAMP:20260101T000000Z\r\n"
+            "DTSTART:20260601T100000Z\r\n"
+            "DTEND:20260601T110000Z\r\n"
+            "SUMMARY:Test\r\n"
+            "ORGANIZER:mailto:org@example.com\r\n"
+            f"{attendee_lines}"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+
+    def _service_with_calendars(self, calendars):
+        service = CalDAVService(url="https://caldav.example.com/")
+        service.list_calendars = lambda **_kw: calendars  # type: ignore[method-assign]
+        captured = {}
+
+        def _fake_put(url, ics_data):
+            captured["url"] = url
+            captured["ics"] = ics_data
+
+        service._put_event = _fake_put  # type: ignore[method-assign]
+        return service, captured
+
+    def test_uses_calendar_owner_when_on_attendee_list(self):
+        """Calendar owner ``team@x`` is on the invite; PARTSTAT updates target
+        it, not the mailbox fallback."""
+        service, captured = self._service_with_calendars(
+            [
+                {
+                    "id": "https://caldav.example.com/u/personal/",
+                    "name": "Personal",
+                    "owner_email": "alice@example.com",
+                    "owner_type": "USER",
+                },
+                {
+                    "id": "https://caldav.example.com/u/team/",
+                    "name": "Team",
+                    "owner_email": "team@example.com",
+                    "owner_type": "MAILBOX",
+                },
+            ]
+        )
+        service.respond_to_event(
+            ics_data=self._ics("team@example.com", "external@example.com"),
+            response="ACCEPTED",
+            attendee_email="alice@example.com",  # mailbox fallback (not in event)
+            calendar_id="https://caldav.example.com/u/team/",
+        )
+        assert captured["url"] == "https://caldav.example.com/u/team/"
+        cal = ICalendar.from_ical(captured["ics"])
+        team_attendee = next(
+            a
+            for a in cal.walk("VEVENT")[0].get("ATTENDEE")
+            if "team@example.com" in str(a).lower()
+        )
+        assert str(team_attendee.params.get("PARTSTAT")) == "ACCEPTED"
+
+    def test_falls_back_to_attendee_email_when_owner_unknown(self):
+        """No owner_email on the calendar (older backend) — RSVP must still
+        work via the legacy mailbox-email path."""
+        service, captured = self._service_with_calendars(
+            [
+                {
+                    "id": "https://caldav.example.com/u/cal/",
+                    "name": "Cal",
+                    # owner_email absent on purpose
+                },
+            ]
+        )
+        service.respond_to_event(
+            ics_data=self._ics("alice@example.com"),
+            response="ACCEPTED",
+            attendee_email="alice@example.com",
+            calendar_id="https://caldav.example.com/u/cal/",
+        )
+        cal = ICalendar.from_ical(captured["ics"])
+        att = cal.walk("VEVENT")[0].get("ATTENDEE")
+        assert str(att.params.get("PARTSTAT")) == "ACCEPTED"
+
+    def test_falls_back_to_attendee_email_when_owner_not_on_invite(self):
+        """The selected calendar's owner isn't an attendee — fall back to the
+        mailbox email so the user isn't silently blocked when both identities
+        are valid candidates."""
+        service, captured = self._service_with_calendars(
+            [
+                {
+                    "id": "https://caldav.example.com/u/cal/",
+                    "name": "Personal",
+                    "owner_email": "personal@example.com",
+                    "owner_type": "USER",
+                },
+            ]
+        )
+        service.respond_to_event(
+            ics_data=self._ics("mailbox@example.com"),
+            response="DECLINED",
+            attendee_email="mailbox@example.com",
+            calendar_id="https://caldav.example.com/u/cal/",
+        )
+        cal = ICalendar.from_ical(captured["ics"])
+        att = cal.walk("VEVENT")[0].get("ATTENDEE")
+        assert str(att.params.get("PARTSTAT")) == "DECLINED"
+
+
+# ---------------------------------------------------------------------------
 # Credential contract: Basic Auth user = OIDC identity email, password = setting
 # ---------------------------------------------------------------------------
 

--- a/src/frontend/src/features/layouts/components/thread-view/components/calendar-invite/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-view/components/calendar-invite/_index.scss
@@ -354,6 +354,20 @@
     gap: var(--c--globals--spacings--xs);
 }
 
+.calendar-invite__rsvp-hint {
+    flex-basis: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--c--globals--spacings--3xs);
+    margin: 0;
+    color: var(--c--contextuals--content--semantic--neutral--secondary);
+    font-size: var(--c--globals--font--sizes--xs);
+
+    .material-icon {
+        font-size: 16px;
+    }
+}
+
 .calendar-invite__calendar-chooser {
     display: flex;
     align-items: center;

--- a/src/frontend/src/features/layouts/components/thread-view/components/calendar-invite/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/calendar-invite/index.tsx
@@ -46,6 +46,19 @@ type CalendarInfo = {
     id: string;
     name: string;
     color?: string | null;
+    // User-controlled sort order from Apple's ``calendar-order`` property —
+    // the backend already sorts the list, so this is informational only.
+    // Null when the CalDAV server doesn't expose it.
+    order?: number | null;
+    // Email of the principal that owns this calendar (the OIDC user for a
+    // personal calendar, the shared mailbox address for a MAILBOX calendar).
+    // Used to match the calendar against the event's ATTENDEE list so RSVP
+    // buttons are only shown for a calendar that can credibly speak for an
+    // attendee. Null when the CalDAV server doesn't expose it.
+    owner_email?: string | null;
+    // "USER" or "MAILBOX" — matches suitenumerique's calendar-owner-type
+    // extension. Null when the CalDAV server doesn't expose it.
+    owner_type?: string | null;
 };
 
 type ConflictInfo = {
@@ -701,9 +714,6 @@ export const CalendarInvite = ({
     // layout shift) but not show the final controls yet.
     const isCalendarsPending = !!mailboxId && isCalendarsLoading;
 
-    // Set default calendar when calendars load
-    const effectiveCalendarId = selectedCalendarId ?? (calendars.length > 0 ? calendars[0].id : null);
-
     // A recurring invite arrives as a master VEVENT plus one VEVENT per
     // modified occurrence, all sharing a UID. Collapse them so the series
     // renders as a single card instead of one card per occurrence.
@@ -716,19 +726,67 @@ export const CalendarInvite = ({
     // Conflict detection for the first event
     const firstEvent = events[0];
 
-    // RSVP semantics only apply when the mailbox is actually on the
-    // ATTENDEE list. Without this gate, clicking Accept on a forwarded
-    // invite (where the mailbox isn't an attendee) would PUT a stored
-    // copy with no PARTSTAT change for the user — the backend already
-    // refuses such RSVPs (see ``respond_to_event``), but the buttons
-    // shouldn't appear in the UI in the first place.
-    const isMailboxAttendee = useMemo(() => {
-        if (!firstEvent || !mailboxEmail) return false;
-        const target = mailboxEmail.toLowerCase();
-        return (firstEvent.attendees ?? []).some(
-            (a) => (a.email ?? "").toLowerCase() === target,
-        );
-    }, [firstEvent, mailboxEmail]);
+    // Lowercased ATTENDEE email set for the first event. Used to test
+    // whether a given calendar (by its owner) can credibly RSVP — and to
+    // pick a default selection that already speaks for an attendee.
+    const attendeeEmails = useMemo(() => {
+        const set = new Set<string>();
+        for (const a of firstEvent?.attendees ?? []) {
+            if (a.email) set.add(a.email.toLowerCase());
+        }
+        return set;
+    }, [firstEvent]);
+
+    // Whether a given calendar speaks for an attendee on the invite. Uses
+    // the calendar's owner_email when the CalDAV server exposes it
+    // (suitenumerique/calendars); otherwise falls back to the acting
+    // mailbox email so backends without owner metadata still behave like
+    // before this feature.
+    const calendarMatchesAttendee = useCallback(
+        (cal: CalendarInfo): boolean => {
+            if (cal.owner_email) {
+                return attendeeEmails.has(cal.owner_email.toLowerCase());
+            }
+            if (mailboxEmail) {
+                return attendeeEmails.has(mailboxEmail.toLowerCase());
+            }
+            return false;
+        },
+        [attendeeEmails, mailboxEmail],
+    );
+
+    // Default to the first calendar that actually represents an attendee
+    // on this invite — so opening a mailbox-addressed invite while
+    // sitting on your personal mailbox auto-selects the mailbox calendar.
+    // Falls back to ``calendars[0]`` when no calendar matches (the user
+    // can still "Add to calendar"; RSVP buttons stay hidden).
+    const defaultCalendarId = useMemo(() => {
+        if (calendars.length === 0) return null;
+        const match = calendars.find(calendarMatchesAttendee);
+        return (match ?? calendars[0]).id;
+    }, [calendars, calendarMatchesAttendee]);
+    const effectiveCalendarId = selectedCalendarId ?? defaultCalendarId;
+
+    const selectedCalendar = useMemo(
+        () => calendars.find((c) => c.id === effectiveCalendarId) ?? null,
+        [calendars, effectiveCalendarId],
+    );
+
+    // Only show RSVP when the *selected* calendar's identity is on the
+    // ATTENDEE list — picking a different calendar from the dropdown
+    // hides the buttons and surfaces a help text. "Add to calendar"
+    // stays available either way.
+    const canRsvpFromSelected = useMemo(
+        () => (selectedCalendar ? calendarMatchesAttendee(selectedCalendar) : false),
+        [selectedCalendar, calendarMatchesAttendee],
+    );
+    // Whether *any* calendar in the list represents an attendee. When
+    // none do, the "pick another calendar" hint would be misleading —
+    // we suppress it and just expose "Add to calendar".
+    const anyCalendarMatchesAttendee = useMemo(
+        () => calendars.some(calendarMatchesAttendee),
+        [calendars, calendarMatchesAttendee],
+    );
     const eventStart = firstEvent?.start?.date;
     const eventEnd = getEventEnd(firstEvent);
     const eventUid = firstEvent?.uid;
@@ -1018,6 +1076,15 @@ export const CalendarInvite = ({
                 </div>
             );
         }
+        // Only nudge the user toward a different calendar when there *is*
+        // one that could RSVP — otherwise the hint would point at a
+        // non-existent option. ``canRsvpFromSelected`` already excludes
+        // cancellations via the unmount of ``RsvpButtons``; here we also
+        // skip the hint on cancellations since RSVP isn't meaningful.
+        const showRsvpHint =
+            !canRsvpFromSelected
+            && anyCalendarMatchesAttendee
+            && !isCancellation;
         return (
             <div className="calendar-invite__connection">
                 <CalendarChooser
@@ -1027,7 +1094,7 @@ export const CalendarInvite = ({
                     calendarsWebUrl={calendarsWebUrl}
                 />
                 <div className="calendar-invite__connection-actions">
-                    {isMailboxAttendee && (
+                    {canRsvpFromSelected && (
                         <RsvpButtons
                             onRespond={handleRsvp}
                             isPending={isPending || !icsContent}
@@ -1051,6 +1118,16 @@ export const CalendarInvite = ({
                         {t("Add to calendar")}
                     </Button>
                 </div>
+                {showRsvpHint && (
+                    <p className="calendar-invite__rsvp-hint" role="note">
+                        <Icon name="info" type={IconType.OUTLINED} />
+                        <span>
+                            {t(
+                                "Pick a calendar that matches one of the invitees to respond.",
+                            )}
+                        </span>
+                    </p>
+                )}
             </div>
         );
     };

--- a/src/frontend/src/features/layouts/components/thread-view/components/calendar-invite/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-view/components/calendar-invite/index.tsx
@@ -765,7 +765,15 @@ export const CalendarInvite = ({
         const match = calendars.find(calendarMatchesAttendee);
         return (match ?? calendars[0]).id;
     }, [calendars, calendarMatchesAttendee]);
-    const effectiveCalendarId = selectedCalendarId ?? defaultCalendarId;
+    // Ignore ``selectedCalendarId`` when it no longer matches any calendar
+    // in the current list — otherwise a stale id (mailbox switch, calendar
+    // deleted server-side) would flow into the RSVP/add-to-calendar POST
+    // and the chooser display.
+    const effectiveCalendarId =
+        selectedCalendarId &&
+        calendars.some((c) => c.id === selectedCalendarId)
+            ? selectedCalendarId
+            : defaultCalendarId;
 
     const selectedCalendar = useMemo(
         () => calendars.find((c) => c.id === effectiveCalendarId) ?? null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Calendars now respect server-configured ordering
  * RSVP responses now target the correct identity, especially for shared mailbox calendars
  * Calendar selection automatically matches available invitees when possible
  * Added guidance hint when the selected calendar cannot RSVP to an event

* **Tests**
  * Extended test coverage for calendar metadata extraction and RSVP targeting logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->