### PR TITLE
🩹(frontend) remove useless perspective attribute

### DIFF
--- a/src/frontend/src/styles/globals.scss
+++ b/src/frontend/src/styles/globals.scss
@@ -16,7 +16,6 @@ body {
   margin: 0;
   background-color: var(--c--contextuals--background--surface--tertiary);
   color: var(--c--contextuals--content--semantic--neutral--primary);
-  perspective: 9000px;
 }
 
 * {


### PR DESCRIPTION
## Purpose

In previous work we forgot to remove a css property that was a test but create a scroll issue..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the 3D perspective effect that was previously applied globally across the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->