### PR TITLE
🔧(deps) install jmap-email from pypi

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,11 +26,6 @@ name: Build and Push Container Image
         required: false
         default: ""
         description: "Build arg name to pass first amd64 tag to arm64 build (skips arch-independent build steps)"
-      build_contexts:
-        type: string
-        required: false
-        default: ""
-        description: "Newline-separated BuildKit named build contexts (e.g. ``jmap-email=src/jmap-email``)."
 
 # see https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
 jobs:
@@ -88,7 +83,6 @@ jobs:
           provenance: false
           tags: ${{ steps.platform-tags.outputs.amd64 }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-contexts: ${{ inputs.build_contexts }}
       - name: Build and push (arm64)
         uses: docker/build-push-action@v6
         with:
@@ -99,7 +93,6 @@ jobs:
           provenance: false
           tags: ${{ steps.platform-tags.outputs.arm64 }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-contexts: ${{ inputs.build_contexts }}
           build-args: |
             ${{ inputs.arm64_reuse_amd64_build_arg && format('{0}={1}', inputs.arm64_reuse_amd64_build_arg, steps.platform-tags.outputs.amd64_first) || '' }}
       - name: Create multi-arch manifests

--- a/.github/workflows/messages-ghcr.yml
+++ b/.github/workflows/messages-ghcr.yml
@@ -73,11 +73,6 @@ jobs:
       image_name: "backend"
       context: "src/backend"
       target: runtime-prod
-      # Sibling jmap-email package plumbed in as a BuildKit named context.
-      # The Dockerfile pulls it in via ``COPY --from=jmap-email``; keeping
-      # the primary context narrow at ``src/backend`` preserves cache locality.
-      build_contexts: |
-        jmap-email=src/jmap-email
 
   docker-publish-keycloak:
     uses: ./.github/workflows/docker-publish.yml

--- a/Makefile
+++ b/Makefile
@@ -114,13 +114,8 @@ build: ## build the project containers
 .PHONY: build
 
 build-back-distroless: ## build the distroless production image
-	# Sibling jmap-email package is plumbed via BuildKit named context
-	# (see src/backend/Dockerfile ``COPY --from=jmap-email``). Use buildx
-	# explicitly so ``--build-context`` is available even on hosts where
-	# ``docker build`` still resolves to the legacy builder.
 	@docker buildx build --load --target runtime-distroless-prod -t messages-distroless \
 		-f src/backend/Dockerfile \
-		--build-context jmap-email=src/jmap-email \
 		src/backend/
 .PHONY: build-back-distroless
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -83,8 +83,6 @@ services:
   backend-base:
     build:
       context: src/backend
-      additional_contexts:
-        jmap-email: ./src/jmap-email
       target: runtime-dev
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
@@ -92,11 +90,13 @@ services:
     volumes:
       - ./src/backend:/app
       - ./data/static:/data/static
-      # Live-mount the jmap-email package over the frozen install so
-      # source edits propagate without a rebuild. The wheel installed
-      # at ``/venv/lib/${PYTHON_VERSION}/site-packages/jmap_email`` is
-      # overlaid with the editable source. Override ``PYTHON_VERSION``
-      # in the environment when the backend's Python floor moves.
+      # Dev-only override: live-mount the jmap-email working tree over the
+      # package installed from PyPI so local source edits propagate without a
+      # rebuild. The wheel installed at
+      # ``/venv/lib/${PYTHON_VERSION}/site-packages/jmap_email`` is overlaid
+      # with the working-tree source. Override ``PYTHON_VERSION`` in the
+      # environment when the backend's Python floor moves. Comment this mount
+      # out to run exactly what CI/prod install from PyPI.
       - ./src/jmap-email/jmap_email:/venv/lib/${PYTHON_VERSION:-python3.14}/site-packages/jmap_email
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request as u; u.urlopen('http://localhost:8000/__heartbeat__/', timeout=1)"]
@@ -150,24 +150,14 @@ services:
       - tools
     volumes:
       - ./src/backend:/app
-      # Sibling package for path-based uv dependency. Both `backend`
-      # and `jmap-email` must be visible at the SAME relative path
-      # from /app as they are on the host (../jmap-email), so the
-      # ``[tool.uv.sources]`` declaration in src/backend/pyproject.toml
-      # resolves correctly inside the container.
-      - ./src/jmap-email:/jmap-email
     build:
       context: src/backend
-      additional_contexts:
-        jmap-email: ./src/jmap-email
       target: uv
     pull_policy: build
 
   worker-dev:
     build:
       context: src/backend
-      additional_contexts:
-        jmap-email: ./src/jmap-email
       target: runtime-dev
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
@@ -188,8 +178,6 @@ services:
   worker-ui:
     build:
       context: src/backend
-      additional_contexts:
-        jmap-email: ./src/jmap-email
       target: runtime-dev
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -48,14 +48,6 @@ RUN uv python install 3.14.5
 FROM uv AS base-with-deps
 
 COPY pyproject.toml uv.lock ./
-# Path-based sibling dependency from src/jmap-email — uv's sync needs
-# the directory on disk at the same relative path the source tree uses
-# (``../jmap-email``). The sibling package is plumbed in as a named
-# build context (BuildKit's ``additional_contexts`` — see compose.yaml
-# ``backend-base``) so the primary build context stays narrow at
-# ``src/backend`` and Docker only re-scans the jmap-email tree when it
-# actually changes.
-COPY --from=jmap-email . /jmap-email
 
 ENV PATH="/venv/bin:$PATH"
 

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "factory_boy==3.3.3",
     "gunicorn==25.1.0",
     "icalendar==7.0.3",
-    "jmap-email",
+    "jmap-email==0.1.0",
     "jsonschema==4.26.0",
     "nested-multipart-parser==1.6.0",
     "openai==2.21.0",
@@ -105,12 +105,6 @@ build-backend = "uv_build"
 module-root = ""
 source-include = ["core/**"]
 source-exclude = ["core/tests/**"]
-
-# Path-based dependency on the jmap-email package while it lives in
-# this monorepo. After publishing to PyPI, replace with a normal
-# version pin in the ``dependencies`` list above.
-[tool.uv.sources]
-jmap-email = { path = "../jmap-email", editable = true }
 
 [tool.ruff]
 # Pin ruff at py313 even though our runtime floor is py314.5 (chosen for

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -946,18 +946,11 @@ wheels = [
 [[package]]
 name = "jmap-email"
 version = "0.1.0"
-source = { editable = "../jmap-email" }
-
-[package.metadata]
-requires-dist = [
-    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.151.0" },
-    { name = "pylint", marker = "extra == 'dev'", specifier = ">=4.0.4" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
-    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.44" },
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/65/86143692dc38e57ea950d85f6a7d66ea9df9a3b64debd8d258cb8ba2cb4d/jmap_email-0.1.0.tar.gz", hash = "sha256:04d906c22aff25ac62819bda04f467bc9f65e041be4a1f96bb5439a54c4d2de1", size = 149817, upload-time = "2026-06-09T13:41:36.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/bf/41fd7b86859391bc112114162ae9d21d1a98c09986dfdc0872132e19dbf7/jmap_email-0.1.0-py3-none-any.whl", hash = "sha256:a32d8b49f5f33ae27de1279a1d402c1714c85c35a1b55844251c985a32ff1498", size = 59633, upload-time = "2026-06-09T13:41:34.395Z" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "jmespath"
@@ -1201,7 +1194,7 @@ requires-dist = [
     { name = "gunicorn", specifier = "==25.1.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.151.9" },
     { name = "icalendar", specifier = "==7.0.3" },
-    { name = "jmap-email", editable = "../jmap-email" },
+    { name = "jmap-email", specifier = "==0.1.0" },
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "libpff-python", specifier = "==20231205" },
     { name = "nested-multipart-parser", specifier = "==1.6.0" },


### PR DESCRIPTION
## Purpose

Now that jmap-email 0.1.0 is available on pypi we install it from this registry and remove all tweaks to install the deps from local folder. We keep the volume override for backend services in order to be able to work on jmap-email and test it with ease in local development environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Docker build configuration and CI/CD workflows by removing unused context dependencies.
  * Updated the jmap-email dependency to a pinned version 0.1.0 for more predictable and reproducible builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->