### PR TITLE
🐛(frontend) unpin threads on draft deletion

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -8,9 +8,9 @@
       "name": "st-messages",
       "version": "0.7.0",
       "dependencies": {
-        "@blocknote/core": "0.49.0",
-        "@blocknote/mantine": "0.49.0",
-        "@blocknote/react": "0.49.0",
+        "@blocknote/core": "0.51.4",
+        "@blocknote/mantine": "0.51.4",
+        "@blocknote/react": "0.51.4",
         "@gouvfr-lasuite/cunningham-react": "4.3.0",
         "@gouvfr-lasuite/drive-sdk": "0.0.2",
         "@gouvfr-lasuite/ui-kit": "0.23.2",
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@blocknote/core": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@blocknote/core/-/core-0.49.0.tgz",
-      "integrity": "sha512-WrkJ9DubvjfMP7+bfrKfp4Oe1SSYpVhojqSORHqh1IjU/qx7CWhwG62k2yyAJdr9K63aoVnS9c6p+xxbuW0PWA==",
+      "version": "0.51.4",
+      "resolved": "https://registry.npmjs.org/@blocknote/core/-/core-0.51.4.tgz",
+      "integrity": "sha512-uR7/BlW6VVlCx/JzfGbkaLGz7O5uI3bu2tbNIdzGTfSloiEp8Qc14if36Dy7DDs+dVWfZgwds0jWiGfE3AzJiw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",
@@ -662,7 +662,6 @@
         "@tiptap/pm": "^3.13.0",
         "emoji-mart": "^5.6.0",
         "fast-deep-equal": "^3.1.3",
-        "hast-util-from-dom": "^5.0.1",
         "lib0": "^0.2.99",
         "prosemirror-highlight": "^0.15.1",
         "prosemirror-model": "^1.25.4",
@@ -670,46 +669,35 @@
         "prosemirror-tables": "^1.8.3",
         "prosemirror-transform": "^1.11.0",
         "prosemirror-view": "^1.41.4",
-        "rehype-format": "^5.0.1",
-        "rehype-parse": "^9.0.1",
-        "rehype-remark": "^10.0.1",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.5",
-        "unist-util-visit": "^5.0.0",
         "y-prosemirror": "^1.3.7",
         "y-protocols": "^1.0.6",
         "yjs": "^13.6.27"
       }
     },
     "node_modules/@blocknote/mantine": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@blocknote/mantine/-/mantine-0.49.0.tgz",
-      "integrity": "sha512-MdR6WHk1yJsemhWw3d8ZDiuIigiit7DhBvbtG0XSceBU01jWJca5OYq/W4QMNS9aDEOML83a0sn7aU9dRhp8MQ==",
+      "version": "0.51.4",
+      "resolved": "https://registry.npmjs.org/@blocknote/mantine/-/mantine-0.51.4.tgz",
+      "integrity": "sha512-Ka7QjzhgB/T2ekwtXgwa9zIiiixAm4dob3FklJIedu+9j/eO4auokmRnWAhZQmNJsOdE7mQTUmnv6X4k/lHyCQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "0.49.0",
-        "@blocknote/react": "0.49.0",
+        "@blocknote/core": "0.51.4",
+        "@blocknote/react": "0.51.4",
         "react-icons": "^5.5.0"
       },
       "peerDependencies": {
-        "@mantine/core": "^8.3.11",
-        "@mantine/hooks": "^8.3.11",
-        "@mantine/utils": "^6.0.22",
+        "@mantine/core": "^8.3.11 || ^9.0.2",
+        "@mantine/hooks": "^8.3.11 || ^9.0.2",
         "react": "^18.0 || ^19.0 || >= 19.0.0-rc",
         "react-dom": "^18.0 || ^19.0 || >= 19.0.0-rc"
       }
     },
     "node_modules/@blocknote/react": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@blocknote/react/-/react-0.49.0.tgz",
-      "integrity": "sha512-yqThZhMuxbyejWXWc4/gIRiOzNnhtZeoQqlqwGRwexPuSeZLYV/HvmquN98KAiBCYn2ORN5k37O5VerKG2dfcw==",
+      "version": "0.51.4",
+      "resolved": "https://registry.npmjs.org/@blocknote/react/-/react-0.51.4.tgz",
+      "integrity": "sha512-tWe039t/Gkj9YDoEXruclXQvI+toI0ctcyikbHa8dm3Q6zTgy24+T/P1t1fYSNPBkSnhq+ILz2fLLnCK994qkA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "0.49.0",
+        "@blocknote/core": "0.51.4",
         "@emoji-mart/data": "^1.2.1",
         "@floating-ui/react": "^0.27.18",
         "@floating-ui/utils": "^0.2.10",
@@ -728,6 +716,111 @@
         "react": "^18.0 || ^19.0 || >= 19.0.0-rc",
         "react-dom": "^18.0 || ^19.0 || >= 19.0.0-rc"
       }
+    },
+    "node_modules/@blocknote/react/node_modules/@tiptap/core": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.0.tgz",
+      "integrity": "sha512-X53TQUq2xYn21FOC526GlVIycnDkiN9XPYO/NEsg3hXS/SUs1Q6ZLtaM8y3Ox7d+bnTW6CpWKlfyvUWp3scKEw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.27.0"
+      }
+    },
+    "node_modules/@blocknote/react/node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.27.0.tgz",
+      "integrity": "sha512-cy52iePYfzaUUBg3S+00KN+18KMZH+UIlE4wRTEBW/c7OA6M/nkrVkxHYfKeJ3OEbZsRYv+GiRzASchDJVVTZg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.0",
+        "@tiptap/pm": "3.27.0"
+      }
+    },
+    "node_modules/@blocknote/react/node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.27.0.tgz",
+      "integrity": "sha512-S9NV/3f1IFkPtIUClLUsJj98AOL3PrYMhPAH/b7SFtsvvfp2QXfL+I12ykPqOcPmj4KXw0Zc40E0QKg67M3pjw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.27.0",
+        "@tiptap/pm": "3.27.0"
+      }
+    },
+    "node_modules/@blocknote/react/node_modules/@tiptap/pm": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.0.tgz",
+      "integrity": "sha512-cWuyaY19SoTOGwdPzhNrUuFMMILuR7mq/Ec02FO+y5jUnQiJYOy9pVx4RUIjBT24LYXrvA9YRhxL1v+KQKTz3A==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.7",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.0",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@blocknote/react/node_modules/@tiptap/react": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.27.0.tgz",
+      "integrity": "sha512-C7FSa5yNPKaCll/Bvm0GmlJh2VLVJXNpKxC9I/L5BJdeVWXV3Prbt56U9FFYd8hjydFZ32GF3jUYQlVYHxnwHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.27.0",
+        "@tiptap/extension-floating-menu": "^3.27.0"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.0",
+        "@tiptap/pm": "3.27.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@blocknote/react/node_modules/@tiptap/react/node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@croct/json": {
       "version": "2.1.0",
@@ -3018,16 +3111,6 @@
       "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
-      }
-    },
-    "node_modules/@mantine/utils": {
-      "version": "6.0.22",
-      "resolved": "https://registry.npmjs.org/@mantine/utils/-/utils-6.0.22.tgz",
-      "integrity": "sha512-RSKlNZvxhMCkOFZ6slbYvZYbWjHUM+PxDQnupIOxIdsTZQQjx/BFfrfJ7kQFOP+g7MtpOds8weAetEs5obwMOQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -10564,24 +10647,6 @@
         "@tiptap/core": "3.25.0"
       }
     },
-    "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.25.0.tgz",
-      "integrity": "sha512-IL6WRTMS0X6szJ1F9qrAbslbet8awUcQ4cJEJLL2lxDgcxpxDHcKxIQRsX5A7qmrWnHxo0tCIpsXKvJ6toaSCQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.25.0",
-        "@tiptap/pm": "3.25.0"
-      }
-    },
     "node_modules/@tiptap/extension-code": {
       "version": "3.25.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.25.0.tgz",
@@ -10593,22 +10658,6 @@
       },
       "peerDependencies": {
         "@tiptap/core": "3.25.0"
-      }
-    },
-    "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.25.0.tgz",
-      "integrity": "sha512-ZUC+89Kggg4zxRcb8NxyMwErnGxwp5GDVqjxrqo7DReYiOuKeKF/tqvxxa/x+ADJ0Hsy36hVUJqd6gzoi02njA==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.25.0",
-        "@tiptap/pm": "3.25.0"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
@@ -10728,39 +10777,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       }
-    },
-    "node_modules/@tiptap/react": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.25.0.tgz",
-      "integrity": "sha512-S0KhuF+Vs/bJeKc2oxgCA33C3q5rMFOqleQCSx18W80jygeGnLaQ6c8yVUlbR1YQJwVk2gm1X15719580kBYIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "fast-equals": "^5.3.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.25.0",
-        "@tiptap/extension-floating-menu": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.25.0",
-        "@tiptap/pm": "3.25.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@tiptap/react/node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -14855,225 +14871,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-embedded": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
-      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-is-element": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-format": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
-      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-minify-whitespace": "^1.0.0",
-        "hast-util-phrasing": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-whitespace-sensitive-tag-names": "^3.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-dom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
-      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
-      "license": "ISC",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hastscript": "^9.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-html/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/hast-util-from-html/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-has-property": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
-      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-is-body-ok-link": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
-      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-is-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-minify-whitespace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
-      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-phrasing": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
-      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-has-property": "^3.0.0",
-        "hast-util-is-body-ok-link": "^3.0.0",
-        "hast-util-is-element": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -15101,48 +14898,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-mdast": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
-      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-phrasing": "^3.0.0",
-        "hast-util-to-html": "^9.0.0",
-        "hast-util-to-text": "^4.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "mdast-util-phrasing": "^4.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-minify-whitespace": "^6.0.0",
-        "trim-trailing-lines": "^2.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-text": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "unist-util-find-after": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -15150,23 +14905,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15254,26 +14992,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
       "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/html-whitespace-sensitive-tag-names": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
-      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -17082,16 +16800,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/markdown-table": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/marked": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -17114,34 +16822,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
@@ -17160,107 +16840,6 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-gfm-autolink-literal": "^2.0.0",
-        "mdast-util-gfm-footnote": "^2.0.0",
-        "mdast-util-gfm-strikethrough": "^2.0.0",
-        "mdast-util-gfm-table": "^2.0.0",
-        "mdast-util-gfm-task-list-item": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-find-and-replace": "^3.0.0",
-        "micromark-util-character": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.1.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -17517,127 +17096,6 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-gfm-autolink-literal": "^2.0.0",
-        "micromark-extension-gfm-footnote": "^2.0.0",
-        "micromark-extension-gfm-strikethrough": "^2.0.0",
-        "micromark-extension-gfm-table": "^2.0.0",
-        "micromark-extension-gfm-tagfilter": "^2.0.0",
-        "micromark-extension-gfm-task-list-item": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -21121,99 +20579,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rehype-format": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
-      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-format": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-minify-whitespace": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
-      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-minify-whitespace": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-remark": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
-      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "hast-util-to-mdast": "^10.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-stringify": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
-      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-to-html": "^9.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-gfm": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
-      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-gfm": "^3.0.0",
-        "micromark-extension-gfm": "^3.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -21241,21 +20606,6 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-stringify": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22578,16 +21928,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/trim-trailing-lines": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
-      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -23147,20 +22487,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-find-after": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -23464,20 +22790,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -23721,16 +23033,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "@viselect/react": "3.9.0",
         "clsx": "2.1.1",
         "date-fns": "4.1.0",
-        "dompurify": "3.3.1",
+        "dompurify": "3.4.11",
         "downshift": "9.2.0",
         "i18next": "25.7.4",
         "i18next-http-backend": "3.0.2",
@@ -13391,9 +13391,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -26,9 +26,9 @@
     "analyze": "ANALYZE=1 vite build && node ./scripts/print-bundle-stats.mjs"
   },
   "dependencies": {
-    "@blocknote/core": "0.49.0",
-    "@blocknote/mantine": "0.49.0",
-    "@blocknote/react": "0.49.0",
+    "@blocknote/core": "0.51.4",
+    "@blocknote/mantine": "0.51.4",
+    "@blocknote/react": "0.51.4",
     "@gouvfr-lasuite/cunningham-react": "4.3.0",
     "@gouvfr-lasuite/drive-sdk": "0.0.2",
     "@gouvfr-lasuite/ui-kit": "0.23.2",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -43,7 +43,7 @@
     "@viselect/react": "3.9.0",
     "clsx": "2.1.1",
     "date-fns": "4.1.0",
-    "dompurify": "3.3.1",
+    "dompurify": "3.4.11",
     "downshift": "9.2.0",
     "i18next": "25.7.4",
     "i18next-http-backend": "3.0.2",

--- a/src/frontend/src/features/blocknote/blocknote-view-field/_index.scss
+++ b/src/frontend/src/features/blocknote/blocknote-view-field/_index.scss
@@ -85,12 +85,8 @@
             flex-shrink: 0;
             min-height: var(--toolbar-height);
 
-            // Override the max-height set by the Floating UI `size` middleware
-            // on toolbar select dropdowns. Without portal rendering, the dropdown
-            // is constrained to the available space inside the toolbar container,
-            // which becomes too small when the toolbar wraps onto multiple lines.
             .mantine-Menu-dropdown {
-                max-height: none !important;
+                max-height: 250px !important;
             }
 
             .bn-toolbar-separator {

--- a/src/frontend/src/features/blocknote/blocknote-view-field/index.tsx
+++ b/src/frontend/src/features/blocknote/blocknote-view-field/index.tsx
@@ -1,10 +1,8 @@
 import { BlockSchema, InlineContentSchema, StyleSchema } from "@blocknote/core";
 import { BlockNoteView } from "@blocknote/mantine";
-import { FilePanelController } from "@blocknote/react";
 import { Field, FieldProps } from "@gouvfr-lasuite/cunningham-react";
 import clsx from "clsx";
 import { PropsWithChildren } from "react";
-import { createPortal } from "react-dom";
 
 import { CustomSideMenuController } from "../custom-side-menu";
 import { CustomSlashMenu } from "../custom-slash-menu";
@@ -24,30 +22,20 @@ export const BlockNoteViewField = <BSchema extends BlockSchema, ISchema extends 
                 sideMenu={false}
                 slashMenu={false}
                 formattingToolbar={false}
-                filePanel={false}
                 {...composerProps}
                 className={clsx(composerProps.className, "composer-field-input")}
                 editable={!disabled}
+                portalElements={{
+                    // Render BlockNote floating UI (slash menu, file panel…) in a
+                    // body-level portal so popovers escape the editor overflow
+                    // context instead of being clipped (e.g. inside modal scrollers).
+                    default: document.body,
+                }}
             >
                 <CustomSideMenuController />
                 <CustomSlashMenu />
-                <PortalledFilePanel />
                 {children}
             </BlockNoteView>
         </Field>
     )
-}
-
-/**
- * Renders the BlockNote file panel (image upload popover) in a React portal
- * at document.body level. This prevents the popover from being clipped by
- * ancestor overflow containers (e.g. modal scrollers).
- */
-const PortalledFilePanel = () => {
-    return createPortal(
-        <div className="bn-container bn-mantine" data-mantine-color-scheme="light">
-            <FilePanelController />
-        </div>,
-        document.body,
-    );
 }

--- a/src/frontend/src/features/blocknote/hooks/use-base64-composer.tsx
+++ b/src/frontend/src/features/blocknote/hooks/use-base64-composer.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useUploadImageAsBase64 } from '@/features/blocknote/image-block/use-upload-image-as-base64';
 import { useImageObjectUrls } from '@/features/blocknote/image-block/use-image-object-urls';
 import { EmailExporter } from '@/features/blocknote/email-exporter';
+import { blocksToMarkdown } from '@/features/blocknote/markdown-exporter';
 import { useConfig } from '@/features/providers/config';
 import MailHelper from '@/features/utils/mail-helper';
 import { backfillTemplateVariableContent, createBlockNoteDictionary, createNonImageFileBlockers } from '@/features/blocknote/utils';
@@ -135,7 +136,7 @@ export const useBase64Composer = <
     }, [editor, form, resolveObjectUrls]);
 
     const exportContent = useCallback(async () => {
-        const markdown = await editor.blocksToMarkdownLossy(editor.document);
+        const markdown = await blocksToMarkdown(editor, editor.document);
         const html = emailExporter.exportBlocks(editor.document, editor.domElement ?? null);
         return {
             htmlBody: resolveObjectUrls(html),

--- a/src/frontend/src/features/blocknote/markdown-exporter.test.ts
+++ b/src/frontend/src/features/blocknote/markdown-exporter.test.ts
@@ -1,20 +1,22 @@
 /**
- * Regression net for `BlockNoteEditor.blocksToMarkdownLossy()`.
+ * Regression net for `blocksToMarkdown()`, our wrapper around the BlockNote
+ * built-in `blocksToMarkdownLossy()`.
  *
- * This serializer is a BlockNote built-in (no source in this repo) used in
- * `message-composer/index.tsx` to produce the email text body. A silent
- * regression here breaks plain-text recipients. These tests pin a contract
- * per block type against the production schema (`BLOCKNOTE_SCHEMA`), so a
- * BlockNote upgrade that changes the markdown shape is caught at CI time.
+ * This serializer produces the email text body (see `use-base64-composer.tsx`),
+ * so a silent regression breaks plain-text recipients. These tests pin a
+ * contract per block type against the production schema (`BLOCKNOTE_SCHEMA`),
+ * so a BlockNote upgrade that changes the markdown shape is caught at CI time.
  *
  * Note: snapshots are deliberately structural (`toContain`) rather than full
- * inline snapshots to absorb cosmetic differences (trailing newlines, bullet
- * marker, etc.) across BlockNote patch versions. The only inline snapshot is
- * the empty-document case, which should never produce noise.
+ * inline snapshots to absorb cosmetic differences (bullet marker, etc.) across
+ * BlockNote patch versions. The only inline snapshot is the empty-document
+ * case: BlockNote >=0.51 emits a trailing "\n" there, which the wrapper trims
+ * back to '' — that contract is what this case guards.
  */
 import { BlockNoteEditor } from '@blocknote/core';
 import type { PartialBlock } from '@blocknote/core';
 import { BLOCKNOTE_SCHEMA } from '@/features/forms/components/message-composer';
+import { blocksToMarkdown } from './markdown-exporter';
 
 // jsdom 27 ships without matchMedia/ResizeObserver/IntersectionObserver, which
 // BlockNote/TipTap probe when an editor is instantiated. The schema import
@@ -63,10 +65,10 @@ function createHeadlessEditor(): EditorType {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function toMarkdown(blocks: PartialBlock<any, any, any>[]): Promise<string> {
   const editor = createHeadlessEditor();
-  return editor.blocksToMarkdownLossy(blocks);
+  return blocksToMarkdown(editor, blocks);
 }
 
-describe('blocksToMarkdownLossy', () => {
+describe('blocksToMarkdown', () => {
   it('returns an empty string for an empty document', async () => {
     const md = await toMarkdown([]);
     expect(md).toBe('');

--- a/src/frontend/src/features/blocknote/markdown-exporter.ts
+++ b/src/frontend/src/features/blocknote/markdown-exporter.ts
@@ -1,0 +1,26 @@
+import type {
+    BlockNoteEditor,
+    BlockSchema,
+    InlineContentSchema,
+    PartialBlock,
+    StyleSchema,
+} from '@blocknote/core';
+
+/**
+ * Serializes BlockNote blocks to plain-text markdown for the email text body.
+ *
+ * Thin wrapper over BlockNote's `blocksToMarkdownLossy` that trims surrounding
+ * whitespace. Since BlockNote >=0.51 it emits a trailing "\n" even for an empty
+ * document; trimming preserves our contract of returning '' for empty content.
+ */
+export const blocksToMarkdown = async <
+    BSchema extends BlockSchema,
+    ISchema extends InlineContentSchema,
+    SSchema extends StyleSchema,
+>(
+    editor: BlockNoteEditor<BSchema, ISchema, SSchema>,
+    blocks: PartialBlock<BSchema, ISchema, SSchema>[],
+): Promise<string> => {
+    const markdown = await editor.blocksToMarkdownLossy(blocks);
+    return markdown.trim();
+};

--- a/src/frontend/src/features/forms/components/message-composer/index.tsx
+++ b/src/frontend/src/features/forms/components/message-composer/index.tsx
@@ -5,6 +5,8 @@ import { BlockNoteEditor, BlockNoteEditorOptions, BlockNoteSchema, defaultBlockS
 import { MessageTemplateSelector } from '@/features/blocknote/message-template-block';
 import { imageBlockSpec, ALLOWED_IMAGE_MIME_TYPES } from '@/features/blocknote/image-block';
 import { EmailExporter } from '@/features/blocknote/email-exporter';
+import { blocksToMarkdown } from '@/features/blocknote/markdown-exporter';
+
 import { FieldProps } from '@gouvfr-lasuite/cunningham-react';
 import { useFormContext } from 'react-hook-form';
 import React, { useEffect, useImperativeHandle, useRef } from 'react';
@@ -257,7 +259,7 @@ export const MessageComposer = React.forwardRef<MessageComposerHandle, MessageCo
     useImperativeHandle(ref, () => ({
         exportContent: async () => {
             const blocks = editor.document;
-            const textBody = await editor.blocksToMarkdownLossy(blocks);
+            const textBody = await blocksToMarkdown(editor, blocks);
             const htmlBody = emailExporter.exportBlocks(blocks, editor.domElement ?? null);
             return { htmlBody, textBody };
         },
@@ -477,4 +479,3 @@ export const MessageComposer = React.forwardRef<MessageComposerHandle, MessageCo
 });
 
 MessageComposer.displayName = 'MessageComposer';
-

--- a/src/frontend/src/features/hooks/use-restore-focus-on-nested-modal-close.tsx
+++ b/src/frontend/src/features/hooks/use-restore-focus-on-nested-modal-close.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+
+// react-modal tags every open modal's content with `--after-open` and mounts
+// each modal in a `.ReactModalPortal` appended directly under <body>. We rely on
+// both: the portal lets us see a modal being removed via a (cheap) body-level
+// childList observer, the `--after-open` class lets us tell which modals are
+// still open (and find the one on top).
+const OPEN_MODAL_SELECTOR = ".ReactModal__Content--after-open";
+
+/**
+ * Restores keyboard focus to a Cunningham modal when a modal stacked above it
+ * closes.
+ *
+ * react-modal is supposed to hand focus back to the opener on close
+ * (`shouldReturnFocusAfterClose`), but with stacked modals the restore is
+ * unreliable and focus ends up stranded on `<body>`. A modal with no focus is a
+ * dead end for keyboard and screen-reader users, and it also kills Escape, whose
+ * handler react-modal binds to the (now unfocused) modal content.
+ *
+ * While `isOpen`, this watches for a stacked modal being unmounted and, only when
+ * focus was left outside every modal, moves it into the topmost remaining one —
+ * mirroring react-modal's own open-time `focusContent`. Leaving focus untouched
+ * whenever react-modal restored it correctly keeps this a safety net, not an
+ * override.
+ */
+export const useRestoreFocusOnNestedModalClose = (isOpen: boolean) => {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    let openModalCount = document.querySelectorAll(OPEN_MODAL_SELECTOR).length;
+    let rafId = 0;
+
+    const observer = new MutationObserver(() => {
+      const previousCount = openModalCount;
+      openModalCount = document.querySelectorAll(OPEN_MODAL_SELECTOR).length;
+
+      // Only react when a stacked modal was just removed, leaving at least one
+      // modal still open to hand focus back to.
+      if (openModalCount >= previousCount || openModalCount === 0) {
+        return;
+      }
+
+      // Defer past react-modal's own focus restoration, then step in only if it
+      // failed and left focus stranded outside every modal.
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        const openModals =
+          document.querySelectorAll<HTMLElement>(OPEN_MODAL_SELECTOR);
+        const activeElement = document.activeElement;
+
+        // react-modal already restored focus to a still-open modal: leave it.
+        // We only step in when focus is stranded outside every open modal (e.g.
+        // on `<body>`, or inside a modal still mid-close-animation).
+        if (
+          activeElement &&
+          Array.from(openModals).some((modal) => modal.contains(activeElement))
+        ) {
+          return;
+        }
+        openModals[openModals.length - 1]?.focus({ preventScroll: true });
+      });
+    });
+
+    // react-modal portals are direct children of <body>, so a shallow childList
+    // observer is enough to catch a nested modal mounting or unmounting.
+    observer.observe(document.body, { childList: true });
+
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(rafId);
+    };
+  }, [isOpen]);
+};

--- a/src/frontend/src/features/layouts/components/mailbox-settings/modal-mailbox-settings/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-settings/modal-mailbox-settings/index.tsx
@@ -13,6 +13,7 @@ import {
   useConfirmBeforeClose,
   useConfirmUnsavedChanges,
 } from "@/features/hooks/use-confirm-before-close";
+import { useRestoreFocusOnNestedModalClose } from "@/features/hooks/use-restore-focus-on-nested-modal-close";
 import { MailboxSettingsGeneralTab } from "./general-tab";
 import { MailboxSettingsAccessTab } from "./access-tab";
 import { MailboxSettingsSignaturesTab } from "./signatures-tab";
@@ -87,6 +88,11 @@ export const ModalMailboxSettings = ({
   const [isActiveTabDirty, setIsActiveTabDirty] = useState(false);
   const confirmUnsavedChanges = useConfirmUnsavedChanges();
   const guardedOnClose = useConfirmBeforeClose(isActiveTabDirty, onClose);
+
+  // The unsaved-changes confirmation (a stacked Cunningham modal) strands focus
+  // on <body> when it closes; hand it back to this modal so keyboard/SR users
+  // keep a focus anchor and Escape keeps working.
+  useRestoreFocusOnNestedModalClose(isOpen);
 
   const settingsMailbox =
     settingsMailboxes.find((mailbox) => mailbox.id === selectedMailboxId) ??

--- a/src/frontend/src/features/message/use-delete.tsx
+++ b/src/frontend/src/features/message/use-delete.tsx
@@ -1,6 +1,7 @@
 import { useThreadsBulkDeleteCreate } from "@/features/api/gen";
 import { Message, ScopeEnum, Thread } from "@/features/api/gen/models";
 import { addToast, ToasterItem } from "../ui/components/toaster";
+import { useMailboxContext } from "../providers/mailbox";
 
 type DeleteOnSuccess = (deletedCount?: number) => void;
 
@@ -30,10 +31,12 @@ const extractDeletedCount = (response: { data: unknown }): number | undefined =>
  * !!! Do not use this hook directly, use the specialized hooks instead !!!
  */
 const useDelete = (scope: ScopeEnum, options?: UseDeleteOptions) => {
+    const { unpinThreads } = useMailboxContext();
     const { mutate, status } = useThreadsBulkDeleteCreate({
         mutation: {
             onSuccess: (response, { data }) => {
                 const deletedCount = extractDeletedCount(response);
+                unpinThreads(data.thread_ids ?? []);
                 options?.onSuccess?.(deletedCount);
                 if (options?.showToast !== false && options?.toastMessage) {
                     const submittedCount =


### PR DESCRIPTION
## Purpose

We recently add draft deletion but we forgot to unpin threads on this mutation so in some they could remain in the list until a refresh is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After bulk hard-deletion, affected threads are automatically unpinned to keep pinned state consistent.
  * Improved message markdown export for more consistent text output, including empty-document behavior.
* **New Features**
  * Added automatic keyboard focus restoration when nested confirmation modals close.
* **UI Improvements**
  * Improved editor toolbar dropdown sizing for better in-context rendering.
  * Refreshed the editor’s floating UI rendering approach to improve panel behavior.
* **Tests**
  * Updated markdown exporter tests to validate the new markdown export behavior.
* **Chores**
  * Bumped editor and sanitization library dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->