### PR TITLE
🐛(frontend) make thread-item select checkbox non interactive

### DIFF
--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/_index.scss
@@ -94,6 +94,10 @@
 .thread-item__checkbox-wrapper {
     display: inline-flex;
     flex-shrink: 0;
+    // The checkbox is presentational only; let clicks reach the Link so
+    // handleItemClick handles selection (and the checkbox stays in sync via
+    // its `checked` prop instead of fighting the click's preventDefault).
+    pointer-events: none;
 }
 
 .thread-item__checkbox {

--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/index.tsx
@@ -76,17 +76,6 @@ export const ThreadItem = ({ thread, isSelected, onToggle, onSelectRange, select
     );
     const hasEditableInDrag = useCanEditThreads(dragThreadIds);
 
-    const handleCheckboxClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        e.preventDefault();
-        onFocusItem();
-        if (e.shiftKey) {
-            onSelectRange(thread.id);
-        } else {
-            onToggle(thread.id);
-        }
-    };
-
     const handleItemClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
         onFocusItem();
         // Keyboard activation (Enter on the focused option) fires a click
@@ -177,13 +166,18 @@ export const ThreadItem = ({ thread, isSelected, onToggle, onSelectRange, select
             >
                 <div>
                     {showCheckbox && (
-                        // Mouse-only affordance: the option itself carries the
-                        // selection state (aria-selected), a focusable checkbox
-                        // would add a second tab stop inside the option.
+                        // Mouse-only affordance, purely presentational: the option
+                        // itself carries the selection state (aria-selected) and a
+                        // focusable checkbox would add a second tab stop, hence
+                        // aria-hidden + tabIndex=-1. pointer-events:none (see SCSS)
+                        // lets the click fall through to the Link, where
+                        // handleItemClick owns the selection logic; the checkbox
+                        // only reflects `checked`. Driving it from its own click
+                        // handler would fight handleItemClick's preventDefault and
+                        // leave it visually out of sync.
                         <span aria-hidden="true" className="thread-item__checkbox-wrapper">
                             <Checkbox
                                 checked={isSelected}
-                                onClick={handleCheckboxClick}
                                 tabIndex={-1}
                                 className="thread-item__checkbox"
                             />


### PR DESCRIPTION
## Purpose

When a user clicks on the checkbox of the thread-item to select it, the preventDefault call prevent the checkbox to update its state so under the hood the thread was well added to the selection but the user has a wrong state. Now we make the checkbox fully controlled and non-interactive, in this way, user always interact with the thread-item link and the selection state is used to set the checkbox state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved thread item selection interaction handling to ensure clicks are properly routed through the item link, providing more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->