### PR TITLE
🔖(minor) release version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-18
+
+### Added
+
+- Allow permanently deleting drafts and improve draft edition
+- Allow passwordless mailbox creation when identity sync is off #707
+- Gather mailbox settings into a dialog
+- Translate template placeholder and add `user_name` builtin variable
+- Report selfcheck status to Sentry crons #694
+
+### Changed
+
+- Drop Next.js for Vite + TanStack Router #675
+- Move email parser & composer to new `jmap-email` library #700
+- Add PyPI release scripts for `jmap-email`
+- Use `LaGaufreV2` component
+- Improve thread navigation a11y and multiselect UX #708
+- Refine mailbox dropdown menu #705
+- New homepage illustration #702
+- Internationalize missing strings
+- Wrap autoreply date column
+- Bump `dompurify` to 3.4.11
+- Bump `django-lasuite` to 0.0.26 #689
+
+### Fixed
+
+- Fix composer issues
+- Add `To` header to outbound mails missing one #712
+- Manage message/delivery-status attachments at compose
+- Persist mailbox name when contact is missing
+- Fix order and default calendar selection when RSVPing #699
+- Fix display of recurring events with exceptions #686
+- Fix opportunistic TLS against MXes with mismatched certs #687
+- Fix mbox detection as `text/html` with some libmagic versions #696
+- Complete PST email folder prefixes list
+- Fix milter socket permission race on startup #693
+
+### Security
+
+- Add some defense-in-depth bits #706
+- Harden SMTP connection & proxies config
+- Harden inbound email parsing #695
+
 ## [0.7.0] - 2026-05-28
 
 ### Added
@@ -246,7 +289,8 @@ and this project adheres to
 - Exclude `is_trashed` and `is_spam` threads from search results by default
 - `to` search modifier now looks for messages where recipient fields (to, cc, bcc) contain the given email address.
 
-[unreleased]: https://github.com/suitenumerique/messages/compare/v0.7.0...main
+[unreleased]: https://github.com/suitenumerique/messages/compare/v0.8.0...main
+[0.8.0]: https://github.com/suitenumerique/messages/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/suitenumerique/messages/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/suitenumerique/messages/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/suitenumerique/messages/compare/v0.4.0...v0.5.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "messages-backend"
-version = "0.7.0"
+version = "0.8.0"
 authors = [{ "name" = "ANCT", "email" = "contact@suite.anct.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -1092,7 +1092,7 @@ wheels = [
 
 [[package]]
 name = "messages-backend"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/e2e/package-lock.json
+++ b/src/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "st-messages-e2e",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "st-messages-e2e",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/src/e2e/package.json
+++ b/src/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "st-messages-e2e",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "End-to-end tests for Messages application",
   "engines": {
     "node": ">=22.0.0 <23.0.0",

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "st-messages",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "st-messages",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@blocknote/core": "0.51.4",
         "@blocknote/mantine": "0.51.4",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st-messages",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/jmap-email/pyproject.toml
+++ b/src/jmap-email/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jmap-email"
-version = "0.1.0"
+version = "0.8.0"
 description = "A strict-JMAP RFC 8621 Email object library for Python 3.14+ with lenient RFC 5322 / MIME parsing and strict-by-design composition. Zero runtime dependencies."
 readme = "README.md"
 license = "MIT"

--- a/src/mta-in/pyproject.toml
+++ b/src/mta-in/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "st-messages-mta-in"
-version = "0.7.0"
+version = "0.8.0"
 authors = [{ "name" = "ANCT", "email" = "suiteterritoriale@anct.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/mta-in/uv.lock
+++ b/src/mta-in/uv.lock
@@ -378,7 +378,7 @@ wheels = [
 
 [[package]]
 name = "st-messages-mta-in"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyjwt" },

--- a/src/mta-out/pyproject.toml
+++ b/src/mta-out/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "st-messages-mta-out"
-version = "0.7.0"
+version = "0.8.0"
 authors = [{ "name" = "ANCT", "email" = "suiteterritoriale@anct.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/mta-out/uv.lock
+++ b/src/mta-out/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "st-messages-mta-out"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Purpose

Update all version files and changelog for minor release.

### Added

- Allow permanently deleting drafts and improve draft edition
- Allow passwordless mailbox creation when identity sync is off #707
- Gather mailbox settings into a dialog
- Translate template placeholder and add `user_name` builtin variable
- Report selfcheck status to Sentry crons #694

### Changed

- Drop Next.js for Vite + TanStack Router #675
- Move email parser & composer to new `jmap-email` library #700
- Add PyPI release scripts for `jmap-email`
- Use `LaGaufreV2` component
- Improve thread navigation a11y and multiselect UX #708
- Refine mailbox dropdown menu #705
- New homepage illustration #702
- Internationalize missing strings
- Wrap autoreply date column
- Bump `dompurify` to 3.4.11
- Bump `django-lasuite` to 0.0.26 #689

### Fixed

- Fix composer issues
- Add `To` header to outbound mails missing one #712
- Manage message/delivery-status attachments at compose
- Persist mailbox name when contact is missing
- Fix order and default calendar selection when RSVPing #699
- Fix display of recurring events with exceptions #686
- Fix opportunistic TLS against MXes with mismatched certs #687
- Fix mbox detection as `text/html` with some libmagic versions #696
- Complete PST email folder prefixes list
- Fix milter socket permission race on startup #693

### Security

- Add some defense-in-depth bits #706
- Harden SMTP connection & proxies config
- Harden inbound email parsing #695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.8.0 across all components. This release includes new features, behavioral improvements, bug fixes, and security hardening as documented in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->