### PR TITLE
🐛(frontend) fix compose line break issue on chrome android

### DIFF
--- a/src/frontend/src/features/forms/components/message-form/index.tsx
+++ b/src/frontend/src/features/forms/components/message-form/index.tsx
@@ -668,9 +668,10 @@ export const MessageForm = forwardRef<MessageFormHandle, MessageFormProps>(({
      * Prevent the Enter key press to trigger onClick on input children (like file input)
      */
     const handleKeyDown = (event: React.KeyboardEvent) => {
-        if (event.key === 'Enter') {
-            event.preventDefault();
-        }
+        if (event.key !== 'Enter') return;
+        const target = event.target as HTMLElement;
+        if (target.isContentEditable || target.tagName === 'TEXTAREA') return;
+        event.preventDefault();
     }
 
     // The periodic auto-save only runs while a draft exists. Before that, the


### PR DESCRIPTION
## Purpose

In message form, we prevent the user to press "Enter" to submit the form by error when composing message. But this logic breaks the line-break on chrome for android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling in message forms so the Enter key behaves more consistently when entering text, while preserving support for multi-line editing areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->