### PR TITLE
(chore) bump keycloak to 26.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to
 ## [Unreleased]
 
 - Bump keycloak to 26.6.3
+- Bump keycloak to 26.6.4
 
 ## [0.8.0] - 2026-06-18
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -342,7 +342,7 @@ services:
     pull_policy: build
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.6.3
+    image: quay.io/keycloak/keycloak:26.6.4
     volumes:
       - ./src/keycloak/realm.json:/opt/keycloak/data/import/realm.json:ro
       - ./src/keycloak/themes/dsfr-2.2.1.jar:/opt/keycloak/providers/keycloak-theme.jar:ro

--- a/src/keycloak/Dockerfile
+++ b/src/keycloak/Dockerfile
@@ -14,7 +14,7 @@ fi
 zip -r /custom-scripts.jar META-INF *.js
 EOR
 
-FROM quay.io/keycloak/keycloak:26.6.3 AS builder
+FROM quay.io/keycloak/keycloak:26.6.4 AS builder
 
 WORKDIR /opt/keycloak
 COPY --chown=keycloak:keycloak --chmod=644 themes/dsfr-2.2.1.jar /opt/keycloak/providers/dsfr.jar
@@ -32,7 +32,7 @@ ARG KC_DB=postgres
 
 RUN /opt/keycloak/bin/kc.sh build
 
-FROM quay.io/keycloak/keycloak:26.6.3
+FROM quay.io/keycloak/keycloak:26.6.4
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/src/keycloak/buildpack/scalingo_postcompile.sh
+++ b/src/keycloak/buildpack/scalingo_postcompile.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-KEYCLOAK_VERSION="26.6.3"
+KEYCLOAK_VERSION="26.6.4"
 KEYCLOAK_DIST="https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.tar.gz"
 
 echo "-----> Downloading Keycloak $KEYCLOAK_VERSION"

--- a/src/keycloak/bulk-role-membership/pom.xml
+++ b/src/keycloak/bulk-role-membership/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <keycloak.version>26.6.3</keycloak.version>
+        <keycloak.version>26.6.4</keycloak.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://www.cert.ssi.gouv.fr/avis/CERTFR-2026-AVI-0815/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Keycloak from 26.6.3 to 26.6.4 across the project.
  * Aligned the app’s container image, Docker build, buildpack install step, and module dependency to the new version.
  * Recorded the version update in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->