### PR TITLE
👔(backend) use builtin method to generate message-id

### DIFF
--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -14,6 +14,7 @@ from faker import Faker
 
 from core import enums, models
 from core.enums import UserEventTypeChoices
+from core.mda.utils import generate_mime_id
 from core.services.blob_gc import upload_and_reserve_blob
 
 fake = Faker()
@@ -235,7 +236,7 @@ class MessageFactory(factory.django.DjangoModelFactory):
     subject = factory.Faker("sentence")
     sender = factory.SubFactory(ContactFactory)
     created_at = factory.LazyAttribute(lambda o: timezone.now())
-    mime_id = factory.Sequence(lambda n: f"message{n!s}@_lst.test.example.com")
+    mime_id = factory.LazyFunction(lambda: generate_mime_id("test.example.com"))
 
     @factory.post_generation
     def raw_mime(self, create, extracted, **kwargs):

--- a/src/backend/core/management/commands/send_mail.py
+++ b/src/backend/core/management/commands/send_mail.py
@@ -5,18 +5,16 @@ This command does not write to the database and works even without any mailboxes
 Usage examples:
     # Send a simple email (works without any mailboxes)
     python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World"
-    
+
     # Send with custom sender
     python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World" \
         --from sender@mydomain.com
-    
+
     # Dry run to see what would be sent
     python manage.py send_mail --to recipient@example.com --subject "Test" --body "Hello World" --dry-run
 """
 
-import base64
 import logging
-import uuid
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -25,7 +23,7 @@ from jmap_email import compose_email, parse_address
 from core import models
 from core.mda.outbound import send_outbound_email
 from core.mda.signing import sign_message_dkim
-from core.mda.utils import current_sent_at
+from core.mda.utils import current_sent_at, generate_mime_id
 
 logger = logging.getLogger(__name__)
 
@@ -125,11 +123,7 @@ class Command(BaseCommand):
         )
         logger.info("Subject length: %d", len(subject or ""))
 
-        # Generate MIME ID
-        mime_id = (
-            base64.urlsafe_b64encode(uuid.uuid4().bytes).rstrip(b"=").decode("ascii")
-        )
-        mime_id = f"{mime_id}@_lst.{from_email.split('@')[1]}"
+        mime_id = generate_mime_id(from_email.split("@")[1])
 
         mime_data = {
             "from": [{"name": from_name, "email": from_email}],

--- a/src/backend/core/mda/utils.py
+++ b/src/backend/core/mda/utils.py
@@ -18,6 +18,7 @@ Three groups of helpers live here:
 import re
 import shlex
 from collections import defaultdict
+from email.utils import make_msgid
 
 from django.utils import timezone
 
@@ -26,6 +27,7 @@ from jmap_email import JmapEmail, body_part_text, decode_rfc2047_header
 __all__ = [
     "SNIPPET_MAX_LENGTH",
     "current_sent_at",
+    "generate_mime_id",
     "gmail_labels",
     "headers_blocks",
     "thread_snippet",
@@ -49,6 +51,19 @@ def current_sent_at() -> str:
     is uniform — currently ``timezone.now().isoformat()``.
     """
     return timezone.now().isoformat()
+
+
+def generate_mime_id(domain: str) -> str:
+    """Return a fresh Message-ID in bare JMAP form (no angle brackets).
+
+    `make_msgid` yields the wire form `<id@domain>`; we strip the
+    brackets so the value matches the JMAP convention used everywhere
+    else — inbound parsing strips them (see `jmap_email.first_msgid`)
+    and :func:`jmap_email.compose_email` re-adds them on the wire. Every
+    backend path that mints a Message-ID routes through this helper so
+    the stored shape stays uniform.
+    """
+    return make_msgid(domain=domain).strip("<>")
 
 
 # ────────────────────────────────────────────────────────────────────

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -3,7 +3,6 @@ Declare and configure the models for the messages core application
 """
 # pylint: disable=too-many-lines,too-many-instance-attributes
 
-import base64
 import hashlib
 import json
 import re
@@ -56,6 +55,7 @@ from core.enums import (
     user_event_type_choices,
 )
 from core.mda.signing import generate_dkim_key as _generate_dkim_key
+from core.mda.utils import generate_mime_id
 from core.services.tiered_storage import TieredStorageService, sha256_advisory_lock
 from core.utils import validate_json_schema
 
@@ -2067,9 +2067,12 @@ class Message(BaseModel):
         return result
 
     def generate_mime_id(self) -> str:
-        """Get the RFC 5322 Message-ID of the message."""
-        _id = base64.urlsafe_b64encode(uuid.uuid4().bytes).rstrip(b"=").decode("ascii")
-        return f"{_id}@_lst.{self.sender.email.split('@')[1]}"
+        """Generate this message's Message-ID in bare JMAP form.
+
+        Delegates to :func:`core.mda.utils.generate_mime_id` so the format
+        stays uniform across every Message-ID minting path.
+        """
+        return generate_mime_id(self.sender.email.split("@")[1])
 
     def get_all_recipient_contacts(self) -> Dict[str, List[Contact]]:
         """Get all recipients of the message."""


### PR DESCRIPTION
## Purpose

With some mail providers, your current message-id could cause rejection
so we migrate to the standard email.utils.make_msgid method.
