### PR TITLE
🐛(frontend) fix premature line wrapping in composer

### DIFF
--- a/src/frontend/src/features/blocknote/blocknote-view-field/_index.scss
+++ b/src/frontend/src/features/blocknote/blocknote-view-field/_index.scss
@@ -126,6 +126,11 @@
                 color: var(--c--globals--colors--gray-550);
                 border-color: var(--c--globals--colors--gray-550);
             }
+            
+            // Undo text-wrap: pretty; and text-wrap: balance; from reset.scss to avoid breaking long words in the editor
+            p {
+                text-wrap: wrap;
+            }
         }
 
         .tiptap > .bn-block-group {


### PR DESCRIPTION
## Purpose

Fixes #735 — text in the compose field wraps long before the available width (only a few words per line), making writing frustrating.

## Root cause

The global CSS reset (`src/frontend/src/styles/reset.scss`) applies `p { text-wrap: pretty; }` to every paragraph, including the BlockNote editor's. Safari 26 [changed `text-wrap: pretty`](https://webkit.org/blog/16547/better-typography-with-text-wrap-pretty/) from a last-lines tweak to a full-paragraph re-optimization, so the editor re-balances line breaks on every keystroke and wraps lines prematurely. Other browsers are adopting the same richer behavior, which matches the reports from non-Safari users.

Not caused by the BlockNote 0.49 → 0.51 upgrade — the CSS diff between those versions is clean, and the `85ch` max-block-width cap predates the reports.

## Proposal

Restore `text-wrap: wrap` on paragraphs inside `.bn-editor` (scoped in `blocknote-view-field/_index.scss`), which covers the message, signature and template composers. Paragraphs are edited there, so `pretty` brings no benefit and actively hurts; the rest of the app keeps the reset's behavior. Received messages render inside an iframe and are not affected by the reset.

## Testing

- `npm run build` passes.
- CSS-only change; no unit test can capture line-wrapping behavior (jsdom does no layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed premature line wrapping in the composer on Safari 26, improving text entry behavior while typing.
  - Adjusted editor paragraph wrapping so content displays more consistently across browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->