### PR TITLE
🐛(frontend) fix silent paste failure in composer on Chromium ≤ 109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(frontend) fix silent paste failure in composer on Chromium ≤ 109 #741
 - 🐛(mta-out) fix relay block indentation breaking SASL auth #733
 
 ## [0.8.0] - 2026-06-18

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,3 +1,7 @@
+// Must stay first: shims APIs missing from Chromium <= 109 (Windows 7)
+// that dependencies below rely on.
+import "./polyfills";
+
 import "@blocknote/mantine/style.css";
 import "./styles/main.scss";
 import "./features/i18n/initI18n";

--- a/src/frontend/src/polyfills.test.ts
+++ b/src/frontend/src/polyfills.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// The test runtime (modern Node) already ships the ES2023 change-array-by-copy
+// methods, so we delete them first to emulate Chromium <= 109 (last Chrome/Edge
+// on Windows 7), then load the polyfill and check it restores them.
+
+const METHODS = ["toReversed", "toSorted", "toSpliced", "with"] as const;
+
+beforeAll(async () => {
+    for (const method of METHODS) {
+        delete (Array.prototype as any)[method];
+    }
+    await import("./polyfills");
+});
+
+describe("Array change-by-copy polyfills (Chromium <= 109)", () => {
+    it.each(METHODS)("defines %s as non-enumerable", (method) => {
+        expect(typeof (Array.prototype as any)[method]).toBe("function");
+        expect(Object.keys([]).includes(method)).toBe(false);
+        // for..in over arrays must not pick up the polyfill either
+        const seen: string[] = [];
+        for (const key in [1, 2]) seen.push(key);
+        expect(seen).toEqual(["0", "1"]);
+    });
+
+    it("toReversed returns a reversed copy without mutating", () => {
+        const marks = [1, 2, 3];
+        expect(marks.toReversed()).toEqual([3, 2, 1]);
+        expect(marks).toEqual([1, 2, 3]);
+        expect([].toReversed()).toEqual([]);
+    });
+
+    it("toSorted returns a sorted copy without mutating", () => {
+        const values = [3, 1, 2];
+        expect(values.toSorted()).toEqual([1, 2, 3]);
+        expect(values.toSorted((a, b) => b - a)).toEqual([3, 2, 1]);
+        expect(values).toEqual([3, 1, 2]);
+    });
+
+    it("toSpliced returns a spliced copy without mutating", () => {
+        const values = [1, 2, 3, 4];
+        expect(values.toSpliced(1, 2, 9)).toEqual([1, 9, 4]);
+        // single-argument form deletes through to the end, like splice(start)
+        expect(values.toSpliced(2)).toEqual([1, 2]);
+        expect(values).toEqual([1, 2, 3, 4]);
+    });
+
+    it("with returns a copy with one index replaced, supporting negatives", () => {
+        const values = [1, 2, 3];
+        expect(values.with(1, 9)).toEqual([1, 9, 3]);
+        expect(values.with(-1, 9)).toEqual([1, 2, 9]);
+        expect(values).toEqual([1, 2, 3]);
+        expect(() => values.with(3, 9)).toThrow(RangeError);
+    });
+});

--- a/src/frontend/src/polyfills.ts
+++ b/src/frontend/src/polyfills.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// ES2023 "change array by copy" methods are missing from Chromium <= 109 —
+// the last Chrome/Edge versions available on Windows 7, still in use in some
+// collectivités. BlockNote's paste pipeline calls `marks.toReversed()` on
+// every pasted text node (after having already called `preventDefault()`),
+// so without these shims pasting into the composer is a silent no-op there.
+// See https://github.com/suitenumerique/messages/issues — "Paste does nothing
+// in the message composer on Chromium <= 109".
+
+const defineIfMissing = (name: string, value: (...args: any[]) => unknown) => {
+    if (!(name in Array.prototype)) {
+        // Non-enumerable, like the native methods, so for..in stays clean.
+        Object.defineProperty(Array.prototype, name, {
+            value,
+            writable: true,
+            configurable: true,
+        });
+    }
+};
+
+defineIfMissing("toReversed", function toReversed(this: unknown[]) {
+    return [...this].reverse();
+});
+
+defineIfMissing("toSorted", function toSorted(
+    this: unknown[],
+    compareFn?: (a: unknown, b: unknown) => number,
+) {
+    return [...this].sort(compareFn);
+});
+
+defineIfMissing("toSpliced", function toSpliced(
+    this: unknown[],
+    start: number,
+    deleteCount?: number,
+    ...items: unknown[]
+) {
+    const copy = [...this];
+    // splice(start) and splice(start, undefined) differ: the one-argument
+    // form deletes through to the end, and toSpliced mirrors that.
+    if (arguments.length === 1) {
+        copy.splice(start);
+    } else {
+        copy.splice(start, deleteCount as number, ...items);
+    }
+    return copy;
+});
+
+defineIfMissing("with", function with_(this: unknown[], index: number, value: unknown) {
+    const actualIndex = index < 0 ? this.length + index : index;
+    if (actualIndex < 0 || actualIndex >= this.length) {
+        throw new RangeError(`Invalid index : ${index}`);
+    }
+    const copy = [...this];
+    copy[actualIndex] = value;
+    return copy;
+});
+
+export {};


### PR DESCRIPTION
## Purpose

Pasting external content into the message composer is a **silent no-op on Chromium ≤ 109** — the last Chrome/Edge versions available on Windows 7, still in use in some collectivités. Both `Ctrl+V` and right-click → paste do nothing, with no visible error. Reported by a user on Windows 7 (Chrome 109.0.5414.120 / Edge 109.0.1518.140), confirmed by a DevTools trace from the affected machine.

Root cause: BlockNote's paste pipeline calls `Array.prototype.toReversed()` (ES2023, Chrome 110+, Feb 2023) on **every pasted text node**, *after* having already suppressed the native paste with `event.preventDefault()`. The chain in `@blocknote/core` 0.51.4 (identical in 0.49, so not a regression from the June upgrade):

1. `pasteExtension.ts` — `handleDOMEvents.paste` calls `event.preventDefault()` as its first statement;
2. `text/html` → `editor.pasteHTML` → `ExportManager.pasteHTML` → parse, then **re-serialize** via `blocksToFullHTML`;
3. `serializeBlocksInternalHTML.ts:100` — `for (const mark of node.marks.toReversed())` → `TypeError` on Chromium ≤ 109 (the method is missing from the prototype, so it throws even with zero marks);
4. insertion aborts after native paste was already cancelled → nothing happens.

Trace captured on the reporter's machine (matches the chain frame for frame):

```
Uncaught TypeError: t.marks.toReversed is not a function or its return value is not iterable
    at Object.serializeBlocks (comments-….js)
    at WI.blocksToFullHTML
    at WI.pasteHTML
    at Object.defaultPasteHandler
    at V.paste
```

Copying **from** the composer is broken the same way (`serializeBlocksExternalHTML.ts:127`, same call).

## Proposal

- [x] Add `src/polyfills.ts` shimming the four ES2023 change-array-by-copy methods (`toReversed`, `toSorted`, `toSpliced`, `with`) — non-enumerable, defined only when missing;
- [x] Import it as the **first statement** of `main.tsx`, before BlockNote loads;
- [x] Unit tests (8) that delete the native methods to emulate Chromium ≤ 109, then verify the shims (behavior, immutability, non-enumerability, negative indices, `RangeError`);
- [x] CHANGELOG entry.

Notes for reviewers:

- A build-target change would **not** fix this: esbuild transpiles syntax but never polyfills runtime methods. Alternatives considered: `@vitejs/plugin-legacy` + `modernPolyfills` (heavier, principled if Chromium 109 support becomes official), and an upstream BlockNote PR (`.slice().reverse()`) which would only help long-term.
- A sweep of the built bundle found no other unguarded post-Chrome-109 API in the main path; `Promise.withResolvers` / `Promise.try` / `AbortSignal.any` appear only in the lazy-loaded pdf.js chunk, so PDF preview remains broken on these browsers (separate issue).
- Easy repro on any modern Chrome: run `delete Array.prototype.toReversed` in the console, then paste into the composer.
- Open product question: Windows 7 / Chromium 109 is EOL everywhere but demonstrably real among small collectivités — worth an explicit browser-support policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed silent paste failures in the composer on older Chromium browsers.
  * Added browser compatibility support for newer array operations needed by the frontend.
* **Tests**
  * Added coverage to verify the new browser compatibility behavior and array method handling.
* **Chores**
  * Updated the changelog with the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->