### PR TITLE
🚸(frontend) reset search on mailbox switch

### DIFF
--- a/src/frontend/src/features/layouts/components/mailbox-panel/index.tsx
+++ b/src/frontend/src/features/layouts/components/mailbox-panel/index.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useUrlSearchParams } from "@/hooks/use-url-search-params";
 import { useLayoutContext } from "@/features/layouts/components/layout-context";
 import { MailboxLabels } from "./components/mailbox-labels";
+import { MAILBOX_FOLDERS } from "./components/mailbox-list";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { MailboxSelector } from "@/features/layouts/components/mailbox-selector";
 
@@ -31,7 +32,10 @@ export const MailboxPanel = () => {
                             selectedMailbox={selectedMailbox}
                             onSelect={(mailboxId) => {
                                 closeLeftPanel();
-                                navigate({ to: '/mailbox/$mailboxId', params: { mailboxId }, search: Object.fromEntries(searchParams) });
+                                const search = searchParams.has("search")
+                                    ? MAILBOX_FOLDERS()[0].filter
+                                    : Object.fromEntries(searchParams);
+                                navigate({ to: '/mailbox/$mailboxId', params: { mailboxId }, search });
                             }}
                         />
                     </div>


### PR DESCRIPTION
## Purpose

When the user switches to anoter mailbox while it is on a search view, we reset search params and go to to the inbox as it does not make sens to keep search params on the new mailbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mailbox navigation so the selected mailbox preserves search behavior more consistently.
  * When a search is already present, mailbox switching now uses the first folder’s filter value; otherwise, it keeps the current query parameters intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->