### PR TITLE
Apply inbound iTIP METHOD:REPLY to the organizer's calendar

### DIFF
--- a/src/backend/core/mda/inbound_auth.py
+++ b/src/backend/core/mda/inbound_auth.py
@@ -229,6 +229,19 @@ def get_inbound_auth_mode(spam_config: dict[str, Any]) -> str:
     return (spam_config.get("inbound_auth") or "").strip().lower()
 
 
+_SUPPORTED_INBOUND_AUTH_MODES = frozenset({"native", "rspamd", "authentication-results"})
+
+
+def inbound_auth_enabled(spam_config: dict[str, Any]) -> bool:
+    """Whether inbound auth is configured with a *supported* mode.
+
+    Stricter than ``get_inbound_auth_mode`` truthiness: an unknown value (a
+    typo like ``"nativ"``) makes ``check_inbound_authentication`` return None
+    (= verified), so callers gating on "did auth run" must exclude it.
+    """
+    return get_inbound_auth_mode(spam_config) in _SUPPORTED_INBOUND_AUTH_MODES
+
+
 def check_inbound_authentication(
     raw_data: bytes,
     parsed_email: JmapEmail,

--- a/src/backend/core/mda/inbound_tasks.py
+++ b/src/backend/core/mda/inbound_tasks.py
@@ -20,6 +20,8 @@ from celery.utils.log import get_task_logger
 from jmap_email import JmapEmail, first_address_email, parse_email
 
 from core import models
+from core.mda import itip
+from core.mda.inbound_auth import inbound_auth_enabled
 from core.mda.dispatch_webhooks import (
     dispatch_recorded_webhooks,
     load_cached_webhook_results,
@@ -45,6 +47,9 @@ from core.mda.inbound_pipeline import (
 from messages.celery_app import app as celery_app
 
 logger = get_task_logger(__name__)
+
+# Max CalDAV apply tasks fanned out per inbound iTIP REPLY (one per mailbox user).
+_ITIP_FANOUT_CAP = 50
 
 
 # Hard ceiling on one inbound task's wall-clock (Celery kills the task here).
@@ -201,6 +206,91 @@ def _retry_or_abandon(
         "error": "abandoned",
         "reason": reason,
     }
+
+
+def _caldav_configured(mailbox: models.Mailbox) -> bool:
+    """Whether a CalDAV backend is reachable: instance-default or per-mailbox."""
+    from core.enums import ChannelTypes  # pylint: disable=import-outside-toplevel
+
+    if settings.CALDAV_DEFAULT_URL and settings.CALDAV_DEFAULT_PASSWORD:
+        return True
+    return models.Channel.objects.filter(
+        mailbox=mailbox, type=ChannelTypes.CALDAV
+    ).exists()
+
+
+def _enqueue_itip_reply(
+    mailbox: models.Mailbox, ics_data: str, attendee_email: str
+) -> None:
+    """Fan an authorized inbound iTIP REPLY out to CalDAV apply tasks.
+
+    Prefers a per-mailbox CalDAV channel; else one task per mailbox user. The
+    fan-out is intentional for shared mailboxes: the organizer event lives on
+    whichever member's principal created it (not recorded here), so every
+    principal is tried and ``apply_reply`` no-ops where the UID isn't present.
+    ``attendee_email`` is the verified sender — the only ATTENDEE apply may
+    touch. Lazy imports avoid a task-module import cycle.
+
+    TODO(itip-ratelimit): a sender with their own DMARC-passing domain can still
+    drive one time-range REPORT per writable calendar per crafted reply. If a
+    per-(sender-domain, mailbox) rate-limit primitive lands, apply it here; there
+    is no reusable one for the inbound-task path today.
+    """
+    from core.enums import (  # pylint: disable=import-outside-toplevel
+        ChannelTypes,
+    )
+    from core.services.calendar.tasks import (  # pylint: disable=import-outside-toplevel
+        calendar_apply_reply_task,
+    )
+
+    organizer_email = str(mailbox)
+    channel_ids = list(
+        models.Channel.objects.filter(
+            mailbox=mailbox, type=ChannelTypes.CALDAV
+        ).values_list("id", flat=True)
+    )
+    if channel_ids:
+        # The organizer's event may live on any of the mailbox's CalDAV channels;
+        # apply_reply no-ops on the ones that don't hold the UID.
+        for channel_id in channel_ids:
+            calendar_apply_reply_task.delay(
+                channel_id=str(channel_id),
+                user_email=str(mailbox),
+                ics_data=ics_data,
+                attendee_email=attendee_email,
+                organizer_email=organizer_email,
+            )
+        return
+
+    emails = list(
+        mailbox.accesses.exclude(user__email="")
+        .values_list("user__email", flat=True)
+        .distinct()[: _ITIP_FANOUT_CAP + 1]
+    )
+    if not emails:
+        logger.info(
+            "iTIP REPLY for %s: no CalDAV channel and no user identity; skipping",
+            mailbox,
+        )
+        return
+    if len(emails) > _ITIP_FANOUT_CAP:
+        # Bound the per-reply fan-out. Full per-(sender,mailbox) rate limiting is
+        # still TODO; this just stops a pathological access count from spraying
+        # apply tasks. Legitimate mailboxes are far below the cap.
+        logger.warning(
+            "iTIP REPLY for %s: capping fan-out at %d of many users",
+            mailbox,
+            _ITIP_FANOUT_CAP,
+        )
+        emails = emails[:_ITIP_FANOUT_CAP]
+    for email in emails:
+        calendar_apply_reply_task.delay(
+            channel_id=None,
+            user_email=email,
+            ics_data=ics_data,
+            attendee_email=attendee_email,
+            organizer_email=organizer_email,
+        )
 
 
 def _stamp_processing_failed(ctx: InboundContext) -> None:
@@ -375,6 +465,32 @@ def process_inbound_message_task(self, inbound_message_id: str):
             ctx.parsed_email,
         )
 
+        itip_reply_ics = None
+        itip_reply_attendee = None
+        if (
+            settings.CALENDAR_ITIP_REPLY_ENABLED
+            and not ctx.is_spam
+            and not deferral_expired
+        ):
+            # Absent verdict = "verified" ONLY when inbound auth actually ran
+            # with a supported mode. check_inbound_authentication also returns
+            # nothing when DKIM/DMARC is disabled (or the mode is a typo) —
+            # downgrade to unverifiable so such a deployment can't be spoofed.
+            auth_verdict = ctx.postmark.get("auth")
+            if auth_verdict is None and not inbound_auth_enabled(ctx.spam_config):
+                auth_verdict = "none"
+            ics, itip_flag, attendee = itip.evaluate_inbound_reply(
+                ctx.parsed_email,
+                auth_verdict,
+                settings.CALENDAR_ITIP_REPLY_APPLY_UNVERIFIED,
+            )
+            # Only stamp provenance + enqueue when a calendar backend exists —
+            # else the flag would claim an update that never happened.
+            if ics and _caldav_configured(mailbox):
+                itip_reply_ics = ics
+                itip_reply_attendee = attendee
+                ctx.postmark["itip-reply"] = itip_flag
+
         with transaction.atomic():
             inbound_msg = _create_message_from_inbound(
                 recipient_email=ctx.recipient_email,
@@ -473,6 +589,14 @@ def process_inbound_message_task(self, inbound_message_id: str):
                     ctx.pending_webhooks,
                     lambda: dispatch_recorded_webhooks(
                         inbound_msg, mailbox, ctx.pending_webhooks
+                    ),
+                )
+                _safe_finalize(
+                    "itip-reply",
+                    inbound_message_id,
+                    itip_reply_ics,
+                    lambda: _enqueue_itip_reply(
+                        mailbox, itip_reply_ics, itip_reply_attendee
                     ),
                 )
 

--- a/src/backend/core/mda/itip.py
+++ b/src/backend/core/mda/itip.py
@@ -1,0 +1,162 @@
+"""Inbound iTIP (RFC 5546) ``METHOD:REPLY`` detection and trust gating."""
+
+import logging
+
+from icalendar import Calendar as ICalendar
+from jmap_email import body_part_text, first_address_email
+
+logger = logging.getLogger(__name__)
+
+_VERDICT_UNVERIFIED = "none"
+_VERDICT_FORGED = "fail"
+
+FLAG_VERIFIED = "verified"
+FLAG_UNVERIFIED = "unverified"
+
+_CALENDAR_TYPE = "text/calendar"
+
+# Cap a calendar part before it rides through the Celery broker or the parser.
+# A legitimate single-event REPLY is a few KB; this is a generous abuse bound.
+_MAX_REPLY_ICS_CHARS = 512 * 1024
+
+
+def _iter_calendar_parts(parsed_email):
+    """Yield every ``text/calendar`` EmailBodyPart in the message tree."""
+    root = parsed_email.get("bodyStructure")
+    if root:
+        stack = [root]
+        while stack:
+            part = stack.pop()
+            if not isinstance(part, dict):
+                continue
+            sub = part.get("subParts")
+            if sub:
+                stack.extend(sub)
+                continue
+            if (part.get("type") or "").lower() == _CALENDAR_TYPE:
+                yield part
+        return
+    for key in ("attachments", "textBody"):
+        for part in parsed_email.get(key) or []:
+            if isinstance(part, dict) and (part.get("type") or "").lower() == (
+                _CALENDAR_TYPE
+            ):
+                yield part
+
+
+def _part_ics_text(parsed_email, part):
+    """Decode a calendar part to text across both parser projections."""
+    text = body_part_text(parsed_email, part)
+    if text:
+        return text
+    raw = part.get("content")
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+    return ""
+
+
+def find_reply_ics(parsed_email):
+    """Return the ICS text of the first ``METHOD:REPLY`` calendar part, or None."""
+    for part in _iter_calendar_parts(parsed_email):
+        ics = _part_ics_text(parsed_email, part)
+        if not ics:
+            continue
+        if len(ics) > _MAX_REPLY_ICS_CHARS:
+            logger.info("Skipping oversized text/calendar part (%d chars)", len(ics))
+            continue
+        try:
+            cal = ICalendar.from_ical(ics)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("Skipping unparseable text/calendar part", exc_info=True)
+            continue
+        if str(cal.get("METHOD") or "").upper() == "REPLY":
+            return ics
+    return None
+
+
+def reply_partstat(ics_text, addr):
+    """The PARTSTAT the ATTENDEE matching ``addr`` gives itself, or None.
+
+    Never returns another attendee's PARTSTAT — a REPLY may list several.
+    """
+    target = (addr or "").strip().lower()
+    if not target:
+        return None
+    try:
+        cal = ICalendar.from_ical(ics_text)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+    for comp in cal.walk("VEVENT"):
+        attendees = comp.get("ATTENDEE")
+        if attendees is None:
+            continue
+        if not isinstance(attendees, list):
+            attendees = [attendees]
+        matched = None
+        for att in attendees:
+            a = str(att).strip().lower()
+            if a.startswith("mailto:"):
+                a = a[len("mailto:") :]
+            if a == target:
+                ps = att.params.get("PARTSTAT")
+                matched = str(ps) if ps else None
+                break  # first address match wins, mirroring _parse_reply
+        if matched:
+            return matched
+    return None
+
+
+def reply_is_recurrence_instance(ics_text):
+    """True if any VEVENT carries a RECURRENCE-ID (single-instance reply)."""
+    try:
+        cal = ICalendar.from_ical(ics_text)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return False
+    return any(c.get("RECURRENCE-ID") is not None for c in cal.walk("VEVENT"))
+
+
+def decide(auth_verdict, apply_unverified):
+    """Trust decision from the sender-auth verdict → ``(should_apply, flag)``.
+
+    ``fail`` never applies; ``none`` applies only with ``apply_unverified``
+    (flagged unverified); absent verdict = verified.
+    """
+    if auth_verdict == _VERDICT_FORGED:
+        return False, None
+    if auth_verdict == _VERDICT_UNVERIFIED:
+        if not apply_unverified:
+            return False, None
+        return True, FLAG_UNVERIFIED
+    return True, FLAG_VERIFIED
+
+
+def evaluate_inbound_reply(parsed_email, auth_verdict, apply_unverified):
+    """Detect + gate an inbound REPLY → ``(ics, flag, attendee)`` or all-None.
+
+    ``attendee`` is the DMARC-verified From — the only identity the apply path
+    may act on. Requiring it to be an ATTENDEE with a PARTSTAT blocks a crafted
+    reply whose aligned From is PARTSTAT-less while another ATTENDEE carries one.
+    """
+    ics = find_reply_ics(parsed_email)
+    if ics is None:
+        return None, None, None
+    from_addr = (first_address_email(parsed_email.get("from")) or "").strip().lower()
+    if not from_addr:
+        return None, None, None
+    if reply_partstat(ics, from_addr) is None:
+        logger.info(
+            "iTIP REPLY From %r is not an RSVPing attendee; skipping", from_addr
+        )
+        return None, None, None
+    # Reject recurrence-instance replies at the gate (no flag, no fan-out); the
+    # service keeps its own check as defense in depth.
+    if reply_is_recurrence_instance(ics):
+        logger.info("iTIP REPLY targets a recurrence instance; skipping")
+        return None, None, None
+    should_apply, flag = decide(auth_verdict, apply_unverified)
+    if not should_apply:
+        return None, None, None
+    return ics, flag, from_addr

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -2093,6 +2093,8 @@ class Message(BaseModel):
     #   "processing": "fail"            force-delivered past the deferral window
     #   "rcpt_to":    "<addr>"          envelope RCPT TO, only when it diverges
     #                                   from the MIME To/Cc (BCC / alias / catch-all)
+    #   "itip-reply": "verified" | "unverified"  inbound iTIP REPLY trust-gated
+    #                                   and dispatched (async apply may still no-op)
     # Immutable ingest-time facts (ip/helo/hostname, MAIL FROM, widget referer)
     # live in headers in the blob instead — see the ingest paths. Keep values
     # small and bounded; large/regenerated data (e.g. AI summaries) belongs in
@@ -2211,6 +2213,9 @@ class Message(BaseModel):
             # The divergent envelope RCPT TO (alias/BCC/catch-all) recorded by
             # ``_record_divergent_rcpt`` — surfaces the recipient's own alias.
             result["rcpt_to"] = postmark["rcpt_to"]
+        if postmark.get("itip-reply"):
+            # Inbound iTIP REPLY trust-gated + dispatched (async apply may no-op).
+            result["itip-reply"] = postmark["itip-reply"]
         return result
 
     def generate_mime_id(self) -> str:

--- a/src/backend/core/services/calendar/ics_rebuild.py
+++ b/src/backend/core/services/calendar/ics_rebuild.py
@@ -75,6 +75,7 @@ _PARAM_KEEP = {
             "LANGUAGE",
             "SCHEDULE-AGENT",
             "SCHEDULE-STATUS",
+            "X-STMSG-REPLY-DTSTAMP",
         }
     ),
     "ORGANIZER": frozenset(

--- a/src/backend/core/services/calendar/service.py
+++ b/src/backend/core/services/calendar/service.py
@@ -6,10 +6,12 @@ events, add event, RSVP) directly over HTTP using ``requests`` and
 library's dependency surface.
 """
 
+# pylint: disable=too-many-lines
+
 import logging
 import re
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from urllib.parse import quote, unquote, urljoin, urlparse
 
 from django.conf import settings as django_settings
@@ -511,6 +513,72 @@ class CalDAVService:  # pylint: disable=too-many-instance-attributes
             if (data := r.findtext(data_key))
         ]
 
+    def _calendar_query_detailed(self, calendar_url, start, end):
+        """Like ``_calendar_query`` but yields ``(href, etag, calendar_data)``.
+
+        The href is the event's real resource path and the etag its version —
+        both needed to write back to the right resource with If-Match.
+        """
+        body = (
+            '<?xml version="1.0"?>'
+            '<c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+            "<d:prop><d:getetag/><c:calendar-data/></d:prop>"
+            "<c:filter>"
+            '<c:comp-filter name="VCALENDAR">'
+            '<c:comp-filter name="VEVENT">'
+            f'<c:time-range start="{_format_utc(start)}" end="{_format_utc(end)}"/>'
+            "</c:comp-filter>"
+            "</c:comp-filter>"
+            "</c:filter>"
+            "</c:calendar-query>"
+        )
+        resp = self._request(
+            "REPORT",
+            calendar_url,
+            data=body.encode("utf-8"),
+            headers={
+                "Depth": "1",
+                "Content-Type": "application/xml; charset=utf-8",
+            },
+        )
+        root = ET.fromstring(resp.text)
+        data_key = f".//{_q(CALDAV_NS, 'calendar-data')}"
+        etag_key = f".//{_q(DAV_NS, 'getetag')}"
+        out = []
+        for r in root.findall(_q(DAV_NS, "response")):
+            href = r.findtext(_q(DAV_NS, "href"))
+            data = r.findtext(data_key)
+            if href and data:
+                # REPORT hrefs are relative to the request URI; resolve against
+                # the queried calendar URL (absolute hrefs pass through unchanged)
+                # so the follow-up GET/PUT hits the right resource.
+                resource_url = urljoin(calendar_url, href.strip())
+                out.append((resource_url, (r.findtext(etag_key) or "").strip(), data))
+        return out
+
+    def _put_resource(self, resource_url, ics_data, etag=None):
+        """PUT to an existing resource URL, optionally If-Match ``etag``.
+
+        Raises ``CalDAVError(status_code=412)`` when the precondition fails.
+        """
+        data = ics_data.encode("utf-8") if isinstance(ics_data, str) else ics_data
+        headers = {"Content-Type": "text/calendar; charset=utf-8"}
+        if etag:
+            headers["If-Match"] = etag
+        self._request("PUT", resource_url, data=data, headers=headers)
+
+    def _get_resource(self, resource_url):
+        """Return ``(ics_text, etag)`` for a resource, or ``(None, None)`` if gone."""
+        try:
+            resp = self._request(
+                "GET", resource_url, headers={"Accept": "text/calendar"}
+            )
+        except CalDAVError as exc:
+            if exc.status_code == 404:
+                return None, None
+            raise
+        return resp.text, (resp.headers.get("ETag") or "").strip()
+
     @staticmethod
     def _summarize_event(ics_text, calendar_name):
         try:
@@ -622,6 +690,310 @@ class CalDAVService:  # pylint: disable=too-many-instance-attributes
             cal.to_ical().decode("utf-8"),
         )
         return True
+
+    _REPLY_DTSTAMP_PARAM = "X-STMSG-REPLY-DTSTAMP"
+
+    # How far a recorded reply DTSTAMP may sit in the future (clock skew) before
+    # it's clamped — stops a far-future DTSTAMP bricking that attendee's updates.
+    _REPLY_DTSTAMP_SKEW = timedelta(minutes=5)
+
+    # Max span of the (attacker-controlled) reply time-range REPORT window.
+    _MAX_QUERY_SPAN_DAYS = 366
+
+    @staticmethod
+    def _parse_reply(ics_data, attendee_email):
+        """Reply fields for the verified attendee → ``(dict, None)``, else
+        ``(None, reason)``.
+
+        Reads the PARTSTAT of the ATTENDEE matching ``attendee_email`` (never
+        another line), + UID/time/SEQUENCE/DTSTAMP and whether it's a recurrence
+        instance. reason is ``unparseable-reply`` (bad ICS or no VEVENT with a
+        UID) or ``attendee-mismatch`` (a UID event exists but that attendee has
+        no PARTSTAT there).
+        """
+        target = (attendee_email or "").strip().lower()
+        if not target:
+            return None, "attendee-mismatch"
+        try:
+            cal = ICalendar.from_ical(ics_data)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("Could not parse inbound iTIP REPLY", exc_info=True)
+            return None, "unparseable-reply"
+        saw_uid = False
+        for comp in cal.walk("VEVENT"):
+            uid = comp.get("UID")
+            if not uid:
+                continue
+            saw_uid = True
+            attendees = comp.get("ATTENDEE")
+            if attendees is None:
+                continue
+            if not isinstance(attendees, list):
+                attendees = [attendees]
+            partstat = None
+            for att in attendees:
+                addr = str(att).strip().lower()
+                if addr.startswith("mailto:"):
+                    addr = addr[len("mailto:") :]
+                if addr == target:
+                    ps = att.params.get("PARTSTAT")
+                    if ps:
+                        partstat = str(ps)
+                    break
+            if partstat is None:
+                continue
+            dtstart = comp.get("DTSTART")
+            if dtstart is None:
+                # RFC 5546 makes DTSTART optional in a REPLY, but in practice
+                # every mainstream client echoes it; without it we can't bound
+                # the calendar-query REPORT, so reject rather than scan every
+                # calendar over an unbounded window. If minimal replies ever turn
+                # up in the field, a bounded (~±60 day) fallback is the escape
+                # hatch.
+                return None, "unparseable-reply"
+            dtend = comp.get("DTEND")
+            seq = comp.get("SEQUENCE")
+            dtstamp = comp.get("DTSTAMP")
+            if dtstamp is None:
+                # DTSTAMP is required in every iTIP component (RFC 5546). Without
+                # it the per-attendee staleness guard can't record anything, so
+                # a same-SEQUENCE redelivery could overwrite a newer PARTSTAT.
+                return None, "unparseable-reply"
+            return {
+                "uid": str(uid),
+                "attendee": target,
+                "partstat": partstat,
+                "start": dtstart.dt,
+                "end": dtend.dt if dtend is not None else None,
+                "sequence": int(seq) if seq is not None else 0,
+                "dtstamp": dtstamp.dt,
+                "is_recurrence_instance": comp.get("RECURRENCE-ID") is not None,
+            }, None
+        return None, ("attendee-mismatch" if saw_uid else "unparseable-reply")
+
+    def apply_reply(self, ics_data, attendee_email, organizer_email=None):
+        """Apply an inbound iTIP ``METHOD:REPLY`` to the organizer's stored event.
+
+        Mirror of ``respond_to_event``. Only ever modifies the ATTENDEE matching
+        ``attendee_email`` (the caller's DMARC-verified sender), reading its
+        PARTSTAT from that same entry — so a crafted multi-ATTENDEE payload can't
+        move a third party. When ``organizer_email`` is given, only a stored copy
+        whose ORGANIZER matches it is updated — so a same-UID copy on which the
+        mailbox is merely an ATTENDEE (not the organizer) is skipped. Stamps
+        ``SCHEDULE-AGENT=CLIENT`` to stop server-side iTIP re-fanout. Returns
+        ``{"applied": bool, "reason": str}``; never raises for expected no-ops.
+        """
+        reply, reason = self._parse_reply(ics_data, attendee_email)
+        if reply is None:
+            return {"applied": False, "reason": reason}
+
+        if reply["is_recurrence_instance"]:
+            # TODO(itip-recurrence): applying a single-instance REPLY against the
+            # master VEVENT (matched by UID) would flip the whole series. No-op.
+            logger.info(
+                "iTIP REPLY for %s targets a recurrence instance; skipping",
+                reply["uid"],
+            )
+            return {"applied": False, "reason": "recurrence-not-supported"}
+
+        organizer_norm = (organizer_email or "").strip().lower()
+        start, end = self._reply_query_window(reply)
+
+        for calendar in self.list_calendars(writable_only=True):
+            for resource_url, etag, stored_ics in self._calendar_query_detailed(
+                calendar["id"], start, end
+            ):
+                try:
+                    stored = ICalendar.from_ical(stored_ics)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    logger.debug("Skipping unparseable stored event", exc_info=True)
+                    continue
+                if not self._event_has_uid(stored, reply["uid"]):
+                    continue
+                # Only touch the copy the mailbox actually organizes — skip a
+                # same-UID copy where it's merely an attendee, keep searching.
+                if organizer_norm and self._event_organizer(stored) != organizer_norm:
+                    continue
+                return self._apply_reply_to_resource(
+                    resource_url, stored, etag, reply
+                )
+
+        logger.info("No stored event matches iTIP REPLY UID %s", reply["uid"])
+        return {"applied": False, "reason": "no-matching-event"}
+
+    @staticmethod
+    def _event_organizer(cal):
+        """Bare (mailto-stripped, lower-cased) ORGANIZER of the first VEVENT."""
+        for comp in cal.walk("VEVENT"):
+            org = comp.get("ORGANIZER")
+            if org is None:
+                continue
+            addr = str(org).strip().lower()
+            if addr.startswith("mailto:"):
+                addr = addr[len("mailto:") :]
+            return addr
+        return ""
+
+    def _apply_reply_to_resource(self, resource_url, stored, etag, reply):
+        """Mutate ``stored`` for the reply and conditional-PUT to its resource.
+
+        If-Match on ``etag`` guards the lost-update race (concurrent replies, or
+        a reply racing the organizer's own edit). On 412 the resource is
+        re-fetched and the mutation re-applied once, then it gives up with
+        ``concurrent-modification``.
+        """
+        if not etag:
+            # The REPORT returned no etag; fetch one so the write stays
+            # conditional. Never PUT unconditionally — that would silently drop
+            # lost-update protection.
+            fresh_ics, etag = self._get_resource(resource_url)
+            if not etag or fresh_ics is None:
+                logger.warning(
+                    "No etag for %s; refusing unconditional iTIP write", resource_url
+                )
+                return {"applied": False, "reason": "no-etag"}
+            try:
+                stored = ICalendar.from_ical(fresh_ics)
+            except Exception:  # pylint: disable=broad-exception-caught
+                return {"applied": False, "reason": "no-etag"}
+        for attempt in (1, 2):
+            stale = self._reply_is_stale(stored, reply)
+            if stale:
+                return {"applied": False, "reason": stale}
+            if not self._update_partstat(
+                stored, reply["attendee"], reply["partstat"]
+            ):
+                return {"applied": False, "reason": "attendee-not-on-event"}
+            self._record_reply_dtstamp(stored, reply)
+            self._set_schedule_agent_client(stored)
+            body = rebuild_for_storage(stored).to_ical().decode("utf-8")
+            try:
+                self._put_resource(resource_url, body, etag)
+                return {"applied": True, "reason": "applied"}
+            except CalDAVError as exc:
+                if exc.status_code != 412:
+                    raise
+                if attempt == 2:
+                    return {"applied": False, "reason": "concurrent-modification"}
+                fresh_ics, etag = self._get_resource(resource_url)
+                if fresh_ics is None:
+                    return {"applied": False, "reason": "concurrent-modification"}
+                try:
+                    stored = ICalendar.from_ical(fresh_ics)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    return {"applied": False, "reason": "concurrent-modification"}
+        return {"applied": False, "reason": "concurrent-modification"}
+
+    @staticmethod
+    def _event_has_uid(cal, uid):
+        for comp in cal.walk("VEVENT"):
+            if str(comp.get("UID") or "") == uid:
+                return True
+        return False
+
+    def _reply_query_window(self, reply):
+        """(start, end) TZ-aware UTC window (± a day) around the reply's event
+        time. DTSTART is guaranteed present by ``_parse_reply``.
+
+        DTSTART/DTEND are attacker-controlled, so the window is normalized
+        (inverted ranges collapsed), the span capped, and the ± day padding
+        clamped to safe absolute bounds to avoid datetime over/underflow.
+        """
+        start = self._as_utc(reply["start"])
+        end = self._as_utc(reply["end"] or reply["start"])
+        if end < start:
+            end = start
+        max_span = timedelta(days=self._MAX_QUERY_SPAN_DAYS)
+        if end - start > max_span:
+            end = start + max_span
+        floor = datetime(1, 1, 2, tzinfo=timezone.utc)
+        ceil = datetime(9999, 12, 30, tzinfo=timezone.utc)
+        start = max(min(start, ceil), floor) - timedelta(days=1)
+        end = min(max(end, floor), ceil) + timedelta(days=1)
+        return start, end
+
+    @staticmethod
+    def _as_utc(dt):
+        if not isinstance(dt, datetime):
+            dt = datetime(dt.year, dt.month, dt.day, tzinfo=timezone.utc)
+        elif dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    def _reply_is_stale(self, stored, reply):
+        """Stale-reason string if the REPLY is older than any stored VEVENT
+        (SEQUENCE, then per-attendee DTSTAMP), else None.
+
+        All components are evaluated so a multi-VEVENT object isn't order-
+        dependent. The DTSTAMP guard only protects against replay when the prior
+        state was recorded by this path; a DKIM replay of an old signed reply can
+        still land when the newer state arrived via another channel.
+        """
+        reply_seq = reply["sequence"]
+        reply_stamp = reply["dtstamp"]
+        for comp in stored.walk("VEVENT"):
+            stored_seq = comp.get("SEQUENCE")
+            stored_seq = int(stored_seq) if stored_seq is not None else 0
+            if reply_seq < stored_seq:
+                return "stale-sequence"
+            if reply_seq == stored_seq:
+                last = self._stored_reply_dtstamp(comp, reply["attendee"])
+                if (
+                    last is not None
+                    and reply_stamp is not None
+                    and self._as_utc(reply_stamp) < self._as_utc(last)
+                ):
+                    return "stale-dtstamp"
+        return None
+
+    @classmethod
+    def _stored_reply_dtstamp(cls, comp, attendee_email):
+        """Last-applied REPLY DTSTAMP for ``attendee_email`` on this VEVENT."""
+        attendees = comp.get("ATTENDEE")
+        if attendees is None:
+            return None
+        if not isinstance(attendees, list):
+            attendees = [attendees]
+        email_lower = attendee_email.lower()
+        for att in attendees:
+            addr = str(att).strip().lower()
+            if addr.startswith("mailto:"):
+                addr = addr[len("mailto:") :]
+            if addr != email_lower:
+                continue
+            raw = att.params.get(cls._REPLY_DTSTAMP_PARAM)
+            if not raw:
+                return None
+            try:
+                return datetime.strptime(str(raw), "%Y%m%dT%H%M%SZ").replace(
+                    tzinfo=timezone.utc
+                )
+            except ValueError:
+                return None
+        return None
+
+    @classmethod
+    def _record_reply_dtstamp(cls, stored, reply):
+        """Stamp the REPLY's DTSTAMP onto the attendee for future staleness checks."""
+        if reply["dtstamp"] is None:
+            return
+        # Clamp to now + skew so a far-future DTSTAMP can't permanently mark this
+        # attendee's later replies as stale.
+        ceiling = datetime.now(timezone.utc) + cls._REPLY_DTSTAMP_SKEW
+        stamp = min(cls._as_utc(reply["dtstamp"]), ceiling).strftime("%Y%m%dT%H%M%SZ")
+        email_lower = reply["attendee"].lower()
+        for comp in stored.walk("VEVENT"):
+            attendees = comp.get("ATTENDEE")
+            if attendees is None:
+                continue
+            if not isinstance(attendees, list):
+                attendees = [attendees]
+            for att in attendees:
+                addr = str(att).strip().lower()
+                if addr.startswith("mailto:"):
+                    addr = addr[len("mailto:") :]
+                if addr == email_lower:
+                    att.params[cls._REPLY_DTSTAMP_PARAM] = stamp
 
     @staticmethod
     def _set_schedule_agent_client(cal):

--- a/src/backend/core/services/calendar/tasks.py
+++ b/src/backend/core/services/calendar/tasks.py
@@ -19,6 +19,7 @@ logger = get_task_logger(__name__)
 # details we do not want to render in a toast.
 _RSVP_FAILURE = "Failed to send the RSVP."
 _ADD_FAILURE = "Failed to add the event to the calendar."
+_APPLY_REPLY_FAILURE = "Failed to apply the inbound RSVP reply."
 
 
 def _get_caldav_service(channel_id: str | None, user_email: str):
@@ -122,6 +123,82 @@ def calendar_rsvp_task(
             "status": "FAILURE",
             "result": None,
             "error": _RSVP_FAILURE,
+        }
+
+
+# ignore_result: this task is fire-and-forget from the inbound hook (never
+# polled), and its args carry the raw REPLY ICS + addresses — keeping them out
+# of the result backend avoids persisting that content there.
+@celery_app.task(bind=True, ignore_result=True)
+def calendar_apply_reply_task(
+    self,  # pylint: disable=unused-argument
+    channel_id: str | None,
+    user_email: str,
+    ics_data: str,
+    attendee_email: str,
+    organizer_email: str | None = None,
+) -> Dict[str, Any]:
+    """
+    Apply an inbound iTIP ``METHOD:REPLY`` to the organizer's calendar.
+
+    Mirror of ``calendar_rsvp_task`` for the reverse direction. Trust gating
+    happens in the inbound task before enqueue.
+
+    Args:
+        channel_id: UUID of the CalDAV channel, or None for instance config.
+        user_email: The organizer mailbox's CalDAV principal email (OIDC
+            identity / Basic Auth user for instance config).
+        ics_data: Raw REPLY ICS content.
+        attendee_email: The DMARC-verified sender (From) — the only ATTENDEE
+            ``apply_reply`` may modify.
+        organizer_email: The recipient mailbox address; only a stored copy whose
+            ORGANIZER matches it is updated.
+    """
+    try:
+        service = _get_caldav_service(channel_id, user_email)
+    except Channel.DoesNotExist as e:
+        capture_exception(e)
+        logger.warning(
+            "CalDAV channel %s vanished between enqueue and execute", channel_id
+        )
+        return {
+            "status": "FAILURE",
+            "result": None,
+            "error": "CalDAV channel not found.",
+        }
+    except ValueError as e:
+        logger.warning("CalDAV service unavailable: %s", e)
+        return {
+            "status": "FAILURE",
+            "result": None,
+            "error": "CalDAV service is not configured.",
+        }
+
+    try:
+        result = service.apply_reply(
+            ics_data=ics_data,
+            attendee_email=attendee_email,
+            organizer_email=organizer_email,
+        )
+        return {
+            "status": "SUCCESS",
+            "result": result,
+            "error": None,
+        }
+    except CalDAVError as e:
+        logger.warning("Apply-reply failed: %s", e)
+        return {
+            "status": "FAILURE",
+            "result": None,
+            "error": str(e),
+        }
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        capture_exception(e)
+        logger.exception("Error applying inbound iTIP REPLY")
+        return {
+            "status": "FAILURE",
+            "result": None,
+            "error": _APPLY_REPLY_FAILURE,
         }
 
 

--- a/src/backend/core/tests/api/test_calendar.py
+++ b/src/backend/core/tests/api/test_calendar.py
@@ -1,22 +1,32 @@
 """Tests for calendar API views using a real in-process Radicale CalDAV server."""
 # pylint: disable=redefined-outer-name, unused-argument, protected-access, missing-function-docstring, too-many-lines
 
+import base64
+import hashlib
 import shutil
 import tempfile
 import threading
+import uuid
 from datetime import datetime, timedelta, timezone
 from unittest import mock
+from urllib.parse import quote
 from wsgiref.simple_server import WSGIRequestHandler, make_server
 
+import datetime as _dt
+
+import jwt
 import pytest
 import radicale.app
 import radicale.config
 import requests
 import requests.adapters
+from django.conf import settings as django_settings
 from icalendar import Calendar as ICalendar
+from rest_framework.test import APIClient
 
-from core import factories
+from core import factories, models
 from core.enums import ChannelTypes, MailboxRoleChoices
+from core.mda.inbound_tasks import _enqueue_itip_reply
 from core.services.calendar.ics_rebuild import rebuild_for_storage
 from core.services.calendar.service import CalDAVError, CalDAVService
 
@@ -2493,3 +2503,691 @@ def test_instance_config_sends_oidc_email_as_basic_auth_user(settings):
     assert service.username == oidc_email
     assert service.password == "shared-secret-xyz"
     assert service.session.auth == (oidc_email, "shared-secret-xyz")
+
+
+_ORGANIZER_EVENT = """\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:{uid}
+DTSTAMP:20260101T000000Z
+DTSTART:20260601T100000Z
+DTEND:20260601T110000Z
+SEQUENCE:{seq}
+SUMMARY:Team Meeting
+ORGANIZER:mailto:organizer@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:mailto:{attendee}
+END:VEVENT
+END:VCALENDAR"""
+
+_REPLY_EVENT = """\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+METHOD:REPLY
+BEGIN:VEVENT
+UID:{uid}
+DTSTAMP:{dtstamp}
+DTSTART:20260601T100000Z
+DTEND:20260601T110000Z
+SEQUENCE:{seq}
+ORGANIZER:mailto:organizer@example.com
+ATTENDEE;PARTSTAT={partstat}:mailto:{attendee}
+END:VEVENT
+END:VCALENDAR"""
+
+
+def _attendee_partstat(vevent, target):
+    """PARTSTAT of the ATTENDEE exactly matching ``target`` (mailto-stripped,
+    lower-cased), or None."""
+    target = target.strip().lower()
+    attendees = vevent.get("ATTENDEE")
+    if attendees is None:
+        return None
+    if not isinstance(attendees, list):
+        attendees = [attendees]
+    for a in attendees:
+        addr = str(a).strip().lower()
+        if addr.startswith("mailto:"):
+            addr = addr[len("mailto:") :]
+        if addr == target:
+            return a.params.get("PARTSTAT")
+    return None
+
+
+@pytest.mark.django_db()
+class TestApplyReply:
+    """Service-level tests for CalDAVService.apply_reply against Radicale."""
+
+    ATTENDEE = "attendee@example.com"
+
+    def _seed(self, put_event, uid, seq=0, partstat="NEEDS-ACTION"):
+        ics = _ORGANIZER_EVENT.format(
+            uid=uid, seq=seq, attendee=self.ATTENDEE
+        ).replace("PARTSTAT=NEEDS-ACTION", f"PARTSTAT={partstat}")
+        put_event(uid, ics)
+
+    def _reply(self, uid, partstat="ACCEPTED", seq=0, dtstamp="20260102T000000Z",
+               attendee=None):
+        return _REPLY_EVENT.format(
+            uid=uid, seq=seq, dtstamp=dtstamp, partstat=partstat,
+            attendee=attendee or self.ATTENDEE,
+        )
+
+    def _fetch_partstat(self, calendar_url, uid, attendee=None):
+        resp = requests.get(
+            calendar_url.rstrip("/") + f"/{uid}.ics",
+            auth=(RADICALE_USER, RADICALE_PASSWORD),
+            timeout=5,
+        )
+        assert resp.status_code == 200, resp.text
+        vevent = ICalendar.from_ical(resp.text).walk("VEVENT")[0]
+        return _attendee_partstat(vevent, attendee or self.ATTENDEE)
+
+    def test_applies_partstat_to_organizer_event(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        calendar_url, put_event = radicale_with_calendar
+        uid = "apply-1@example.com"
+        self._seed(put_event, uid)
+        service = CalDAVService.from_channel(caldav_channel)
+
+        result = service.apply_reply(
+            self._reply(uid, "ACCEPTED"), attendee_email=self.ATTENDEE
+        )
+
+        assert result["applied"] is True
+        assert self._fetch_partstat(calendar_url, uid) == "ACCEPTED"
+
+    def test_sets_schedule_agent_client(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        calendar_url, put_event = radicale_with_calendar
+        uid = "apply-sa@example.com"
+        self._seed(put_event, uid)
+        service = CalDAVService.from_channel(caldav_channel)
+
+        service.apply_reply(self._reply(uid, "ACCEPTED"), attendee_email=self.ATTENDEE)
+
+        resp = requests.get(
+            calendar_url.rstrip("/") + f"/{uid}.ics",
+            auth=(RADICALE_USER, RADICALE_PASSWORD),
+            timeout=5,
+        )
+        vevent = ICalendar.from_ical(resp.text).walk("VEVENT")[0]
+        assert vevent.get("ORGANIZER").params.get("SCHEDULE-AGENT") == "CLIENT"
+
+    def test_attendee_not_on_event_is_noop(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        calendar_url, put_event = radicale_with_calendar
+        uid = "apply-stranger@example.com"
+        self._seed(put_event, uid)
+        service = CalDAVService.from_channel(caldav_channel)
+
+        result = service.apply_reply(
+            self._reply(uid, "ACCEPTED", attendee="stranger@example.com"),
+            attendee_email="stranger@example.com",
+        )
+
+        assert result["applied"] is False
+        assert result["reason"] == "attendee-not-on-event"
+        assert self._fetch_partstat(calendar_url, uid) == "NEEDS-ACTION"
+
+    def test_no_matching_uid_is_noop(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        _, put_event = radicale_with_calendar
+        self._seed(put_event, "seeded@example.com")
+        service = CalDAVService.from_channel(caldav_channel)
+
+        result = service.apply_reply(
+            self._reply("nonexistent@example.com"), attendee_email=self.ATTENDEE
+        )
+
+        assert result["applied"] is False
+        assert result["reason"] == "no-matching-event"
+
+    def test_stale_sequence_ignored(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        calendar_url, put_event = radicale_with_calendar
+        uid = "apply-seq@example.com"
+        self._seed(put_event, uid, seq=5)
+        service = CalDAVService.from_channel(caldav_channel)
+
+        result = service.apply_reply(
+            self._reply(uid, "ACCEPTED", seq=2), attendee_email=self.ATTENDEE
+        )
+
+        assert result["applied"] is False
+        assert result["reason"] == "stale-sequence"
+        assert self._fetch_partstat(calendar_url, uid) == "NEEDS-ACTION"
+
+    def test_stale_dtstamp_reorder_ignored(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        calendar_url, put_event = radicale_with_calendar
+        uid = "apply-reorder@example.com"
+        self._seed(put_event, uid)
+        service = CalDAVService.from_channel(caldav_channel)
+
+        assert service.apply_reply(
+            self._reply(uid, "ACCEPTED", dtstamp="20260102T000000Z"),
+            attendee_email=self.ATTENDEE,
+        )["applied"] is True
+        result = service.apply_reply(
+            self._reply(uid, "DECLINED", dtstamp="20260101T000000Z"),
+            attendee_email=self.ATTENDEE,
+        )
+
+        assert result["applied"] is False
+        assert result["reason"] == "stale-dtstamp"
+        assert self._fetch_partstat(calendar_url, uid) == "ACCEPTED"
+
+    def test_crafted_two_attendee_payload_leaves_victim_untouched(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        calendar_url, put_event = radicale_with_calendar
+        uid = "apply-attack@example.com"
+        victim = "victim@corp.example"
+        event = _ORGANIZER_EVENT.format(uid=uid, seq=0, attendee=victim)
+        put_event(uid, event)
+        service = CalDAVService.from_channel(caldav_channel)
+
+        # From=attacker (verified); the reply's only PARTSTAT is on victim.
+        reply = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//T//EN\r\nMETHOD:REPLY\r\n"
+            "BEGIN:VEVENT\r\n"
+            f"UID:{uid}\r\nDTSTAMP:20260102T000000Z\r\n"
+            "DTSTART:20260601T100000Z\r\nDTEND:20260601T110000Z\r\nSEQUENCE:0\r\n"
+            "ORGANIZER:mailto:organizer@example.com\r\n"
+            "ATTENDEE:mailto:attacker@corp.example\r\n"
+            f"ATTENDEE;PARTSTAT=DECLINED:mailto:{victim}\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+
+        result = service.apply_reply(
+            reply, attendee_email="attacker@corp.example"
+        )
+
+        assert result["applied"] is False
+        assert result["reason"] == "attendee-mismatch"
+        assert self._fetch_partstat(calendar_url, uid, attendee=victim) == (
+            "NEEDS-ACTION"
+        )
+
+    def test_recurrence_instance_reply_is_noop(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        _, put_event = radicale_with_calendar
+        uid = "apply-recur@example.com"
+        self._seed(put_event, uid)
+        service = CalDAVService.from_channel(caldav_channel)
+
+        reply = self._reply(uid, "ACCEPTED").replace(
+            "SEQUENCE:0", "SEQUENCE:0\nRECURRENCE-ID:20260601T100000Z"
+        )
+        result = service.apply_reply(reply, attendee_email=self.ATTENDEE)
+
+        assert result["applied"] is False
+        assert result["reason"] == "recurrence-not-supported"
+
+    def test_unparseable_reply_reason(self, caldav_channel):
+        service = CalDAVService.from_channel(caldav_channel)
+        result = service.apply_reply("not a calendar", attendee_email=self.ATTENDEE)
+        assert result["applied"] is False
+        assert result["reason"] == "unparseable-reply"
+
+    def test_reply_without_dtstart_is_unparseable(self, caldav_channel):
+        service = CalDAVService.from_channel(caldav_channel)
+        reply = self._reply("no-dtstart@example.com").replace(
+            "DTSTART:20260601T100000Z\n", ""
+        )
+        result = service.apply_reply(reply, attendee_email=self.ATTENDEE)
+        assert result["applied"] is False
+        assert result["reason"] == "unparseable-reply"
+
+    def test_reply_without_dtstamp_is_unparseable(self, caldav_channel):
+        service = CalDAVService.from_channel(caldav_channel)
+        reply = self._reply("no-dtstamp@example.com").replace(
+            "DTSTAMP:20260102T000000Z\n", ""
+        )
+        result = service.apply_reply(reply, attendee_email=self.ATTENDEE)
+        assert result["applied"] is False
+        assert result["reason"] == "unparseable-reply"
+
+    def test_no_etag_refuses_unconditional_write(self, caldav_channel):
+        service = CalDAVService.from_channel(caldav_channel)
+        stored = ICalendar.from_ical(
+            _ORGANIZER_EVENT.format(uid="noetag", seq=0, attendee=self.ATTENDEE)
+        )
+        reply, _ = CalDAVService._parse_reply(
+            self._reply("noetag", "ACCEPTED"), self.ATTENDEE
+        )
+        put_calls = []
+
+        with mock.patch.object(service, "_get_resource", return_value=(None, "")), \
+            mock.patch.object(
+                service, "_put_resource", side_effect=lambda *a, **k: put_calls.append(1)
+            ):
+            result = service._apply_reply_to_resource(
+                "http://x/e.ics", stored, "", reply
+            )
+
+        assert result == {"applied": False, "reason": "no-etag"}
+        assert not put_calls  # never PUT without a precondition
+
+    def test_query_window_bounds_extreme_range(self, caldav_channel):
+        service = CalDAVService.from_channel(caldav_channel)
+        reply = {
+            "start": datetime(1, 1, 1, tzinfo=timezone.utc),
+            "end": datetime(9999, 12, 31, tzinfo=timezone.utc),
+        }
+        start, end = service._reply_query_window(reply)  # must not overflow
+        assert start < end
+        assert (end - start).days <= service._MAX_QUERY_SPAN_DAYS + 3
+
+    def test_skips_non_organizer_copy(self, caldav_channel):
+        # Two same-UID copies: one where the mailbox is merely an attendee
+        # (ORGANIZER=someone else), one it actually organizes. Only the latter
+        # may be written when organizer_email is enforced.
+        service = CalDAVService.from_channel(caldav_channel)
+        organizer = "boss@example.com"
+        attendee_copy = _ORGANIZER_EVENT.format(
+            uid="dup", seq=0, attendee=self.ATTENDEE
+        )  # ORGANIZER=organizer@example.com (not the recipient)
+        organizer_copy = attendee_copy.replace(
+            "mailto:organizer@example.com", f"mailto:{organizer}"
+        )
+        written = {}
+
+        with mock.patch.object(
+            service, "list_calendars", return_value=[{"id": service.url + "cal/"}]
+        ), mock.patch.object(
+            service,
+            "_calendar_query_detailed",
+            return_value=[
+                (service.url + "cal/attendee.ics", "e1", attendee_copy),
+                (service.url + "cal/organizer.ics", "e2", organizer_copy),
+            ],
+        ), mock.patch.object(
+            service,
+            "_put_resource",
+            side_effect=lambda url, body, etag=None: written.update(url=url),
+        ):
+            result = service.apply_reply(
+                self._reply("dup", "ACCEPTED"),
+                attendee_email=self.ATTENDEE,
+                organizer_email=organizer,
+            )
+
+        assert result["applied"] is True
+        assert written["url"].endswith("organizer.ics")  # not the attendee copy
+
+    def test_writes_to_resource_href_not_uid_filename(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        # Event stored at a filename that does NOT equal its UID.
+        calendar_url, _ = radicale_with_calendar
+        uid = "uid-differs@example.com"
+        filename = "random-filename-xyz"
+        _put_event(
+            calendar_url,
+            filename,
+            _ORGANIZER_EVENT.format(uid=uid, seq=0, attendee=self.ATTENDEE),
+            auth=(RADICALE_USER, RADICALE_PASSWORD),
+        )
+        service = CalDAVService.from_channel(caldav_channel)
+
+        result = service.apply_reply(
+            self._reply(uid, "ACCEPTED"), attendee_email=self.ATTENDEE
+        )
+
+        assert result["applied"] is True
+        # The real resource is updated in place.
+        resp = requests.get(
+            calendar_url.rstrip("/") + f"/{filename}.ics",
+            auth=(RADICALE_USER, RADICALE_PASSWORD),
+            timeout=5,
+        )
+        assert resp.status_code == 200
+        vevent = ICalendar.from_ical(resp.text).walk("VEVENT")[0]
+        assert _attendee_partstat(vevent, self.ATTENDEE) == "ACCEPTED"
+        # No duplicate created at the UID-derived filename.
+        dup = requests.get(
+            calendar_url.rstrip("/") + "/" + quote(uid, safe="") + ".ics",
+            auth=(RADICALE_USER, RADICALE_PASSWORD),
+            timeout=5,
+        )
+        assert dup.status_code == 404
+
+    def test_conditional_put_sends_if_match(
+        self, caldav_channel, radicale_with_calendar
+    ):
+        _, put_event = radicale_with_calendar
+        uid = "ifmatch@example.com"
+        self._seed(put_event, uid)
+        service = CalDAVService.from_channel(caldav_channel)
+        seen = []
+        real = service._request
+
+        def spy(method, url, **kw):
+            seen.append((method, dict(kw.get("headers") or {})))
+            return real(method, url, **kw)
+
+        with mock.patch.object(service, "_request", side_effect=spy):
+            result = service.apply_reply(
+                self._reply(uid, "ACCEPTED"), attendee_email=self.ATTENDEE
+            )
+
+        assert result["applied"] is True
+        put_headers = [h for m, h in seen if m == "PUT"]
+        assert put_headers
+        assert any("If-Match" in h for h in put_headers)
+
+    def test_conditional_put_retries_once_on_412(self, caldav_channel):
+        service = CalDAVService.from_channel(caldav_channel)
+        stored = ICalendar.from_ical(
+            _ORGANIZER_EVENT.format(uid="retry", seq=0, attendee=self.ATTENDEE)
+        )
+        reply, _ = CalDAVService._parse_reply(
+            self._reply("retry", "ACCEPTED"), self.ATTENDEE
+        )
+        fresh = _ORGANIZER_EVENT.format(uid="retry", seq=0, attendee=self.ATTENDEE)
+        puts = []
+
+        def put_side(url, body, etag=None):
+            puts.append(etag)
+            if len(puts) == 1:
+                raise CalDAVError("precondition failed", status_code=412)
+
+        with mock.patch.object(service, "_put_resource", side_effect=put_side), \
+            mock.patch.object(service, "_get_resource", return_value=(fresh, "etag-2")):
+            result = service._apply_reply_to_resource(
+                "http://x/retry.ics", stored, "etag-1", reply
+            )
+
+        assert result == {"applied": True, "reason": "applied"}
+        assert len(puts) == 2  # first 412, refetch + retry succeeded
+        assert puts[1] == "etag-2"  # retry used the freshly-fetched etag
+
+    def test_conditional_put_gives_up_after_second_412(self, caldav_channel):
+        service = CalDAVService.from_channel(caldav_channel)
+        stored = ICalendar.from_ical(
+            _ORGANIZER_EVENT.format(uid="retry", seq=0, attendee=self.ATTENDEE)
+        )
+        reply, _ = CalDAVService._parse_reply(
+            self._reply("retry", "ACCEPTED"), self.ATTENDEE
+        )
+        fresh = _ORGANIZER_EVENT.format(uid="retry", seq=0, attendee=self.ATTENDEE)
+
+        def always_412(url, body, etag=None):
+            raise CalDAVError("precondition failed", status_code=412)
+
+        with mock.patch.object(service, "_put_resource", side_effect=always_412), \
+            mock.patch.object(service, "_get_resource", return_value=(fresh, "etag-2")):
+            result = service._apply_reply_to_resource(
+                "http://x/retry.ics", stored, "etag-1", reply
+            )
+
+        assert result == {"applied": False, "reason": "concurrent-modification"}
+
+
+@pytest.mark.django_db()
+def test_enqueue_itip_reply_fans_out_to_mailbox_users(mailbox):
+    u1 = factories.UserFactory()
+    u2 = factories.UserFactory()
+    factories.MailboxAccessFactory(
+        mailbox=mailbox, user=u1, role=MailboxRoleChoices.ADMIN
+    )
+    factories.MailboxAccessFactory(
+        mailbox=mailbox, user=u2, role=MailboxRoleChoices.EDITOR
+    )
+
+    with mock.patch(
+        "core.services.calendar.tasks.calendar_apply_reply_task.delay"
+    ) as delay:
+        _enqueue_itip_reply(mailbox, "ICS", "alice@corp.example")
+
+    emails = {c.kwargs["user_email"] for c in delay.call_args_list}
+    assert emails == {u1.email, u2.email}
+    assert all(c.kwargs["channel_id"] is None for c in delay.call_args_list)
+    assert all(
+        c.kwargs["attendee_email"] == "alice@corp.example"
+        for c in delay.call_args_list
+    )
+    assert all(
+        c.kwargs["organizer_email"] == str(mailbox) for c in delay.call_args_list
+    )
+
+
+@pytest.mark.django_db()
+def test_enqueue_itip_reply_fans_out_across_all_caldav_channels(mailbox):
+    c1 = factories.ChannelFactory(
+        mailbox=mailbox,
+        type=ChannelTypes.CALDAV,
+        settings={"url": "https://cal.example/a/"},
+        encrypted_settings={"username": "u", "password": "p"},
+    )
+    c2 = factories.ChannelFactory(
+        mailbox=mailbox,
+        type=ChannelTypes.CALDAV,
+        settings={"url": "https://cal.example/b/"},
+        encrypted_settings={"username": "u", "password": "p"},
+    )
+
+    with mock.patch(
+        "core.services.calendar.tasks.calendar_apply_reply_task.delay"
+    ) as delay:
+        _enqueue_itip_reply(mailbox, "ICS", "alice@corp.example")
+
+    channel_ids = {c.kwargs["channel_id"] for c in delay.call_args_list}
+    assert channel_ids == {str(c1.id), str(c2.id)}
+
+
+def test_reply_dtstamp_clamped_to_now():
+    # A far-future reply DTSTAMP must be clamped so it can't brick later updates.
+    cal = ICalendar.from_ical(
+        _ORGANIZER_EVENT.format(uid="clamp", seq=0, attendee="a@b.example")
+    )
+    CalDAVService._record_reply_dtstamp(
+        cal,
+        {"dtstamp": datetime(2099, 1, 1, tzinfo=timezone.utc), "attendee": "a@b.example"},
+    )
+    recorded = CalDAVService._stored_reply_dtstamp(
+        cal.walk("VEVENT")[0], "a@b.example"
+    )
+    assert recorded is not None
+    # Clamped to ~now + skew, not the reply's far-future 2099 value.
+    now = datetime.now(timezone.utc)
+    assert recorded <= now + timedelta(minutes=6)
+
+
+_INBOUND_REPLY_EML = """\
+From: {attendee}
+To: {recipient}
+Subject: Accepted: Team Meeting
+Message-ID: <reply-{token}@example.com>
+MIME-Version: 1.0
+Content-Type: text/calendar; method=REPLY; charset="UTF-8"
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+METHOD:REPLY
+BEGIN:VEVENT
+UID:{uid}
+DTSTAMP:20260102T000000Z
+DTSTART:20260601T100000Z
+DTEND:20260601T110000Z
+SEQUENCE:0
+ORGANIZER:mailto:organizer@example.com
+ATTENDEE;PARTSTAT={partstat}:mailto:{attendee}
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+@pytest.mark.django_db()
+class TestApplyReplyInboundE2E:
+    """Full-stack: a REPLY email through the MTA deliver endpoint updates the
+    organizer's Radicale event via process_inbound_message_task."""
+
+    ATTENDEE = "attendee@corp.example"
+
+    def _seed(self, put_event, uid, organizer):
+        # ORGANIZER must be the recipient mailbox so apply_reply's organizer
+        # match (organizer_email = the mailbox) accepts this copy.
+        ics = _ORGANIZER_EVENT.format(
+            uid=uid, seq=0, attendee=self.ATTENDEE
+        ).replace("mailto:organizer@example.com", f"mailto:{organizer}")
+        put_event(uid, ics)
+
+    def _deliver(self, recipient, uid, partstat="ACCEPTED", attendee=None):
+        eml = _INBOUND_REPLY_EML.format(
+            attendee=attendee or self.ATTENDEE,
+            recipient=recipient,
+            token=uuid.uuid4().hex,
+            uid=uid,
+            partstat=partstat,
+        ).encode("utf-8")
+        token = jwt.encode(
+            {
+                "body_hash": hashlib.sha256(eml).hexdigest(),
+                "exp": datetime.now(_dt.UTC) + timedelta(seconds=30),
+                "original_recipients": [recipient],
+                "client_helo": "client.helo",
+                "client_hostname": "client.hostname",
+                "client_address": "127.1.2.3",
+            },
+            django_settings.MDA_API_SECRET,
+            algorithm="HS256",
+        )
+        resp = APIClient().post(
+            "/api/v1.0/inbound/mta/deliver/",
+            data=eml,
+            content_type="message/rfc822",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert resp.status_code == 200, resp.content
+        assert resp.json() == {"status": "ok", "delivered": 1}
+
+    def _partstat(self, calendar_url, uid):
+        resp = requests.get(
+            calendar_url.rstrip("/") + f"/{uid}.ics",
+            auth=(RADICALE_USER, RADICALE_PASSWORD),
+            timeout=5,
+        )
+        assert resp.status_code == 200, resp.text
+        vevent = ICalendar.from_ical(resp.text).walk("VEVENT")[0]
+        return _attendee_partstat(vevent, self.ATTENDEE)
+
+    def test_verified_reply_applies_and_flags(
+        self, settings, mailbox, caldav_channel, radicale_with_calendar
+    ):
+        settings.CALENDAR_ITIP_REPLY_ENABLED = True
+        # Inbound auth configured + a verified verdict (None) is a genuine pass.
+        settings.SPAM_CONFIG = {"inbound_auth": "native"}
+        calendar_url, put_event = radicale_with_calendar
+        uid = "e2e-verified@example.com"
+        self._seed(put_event, uid, str(mailbox))
+
+        with mock.patch(
+            "core.mda.inbound_pipeline.check_inbound_authentication",
+            return_value=None,
+        ):
+            self._deliver(str(mailbox), uid)
+
+        assert self._partstat(calendar_url, uid) == "ACCEPTED"
+        msg = models.Message.objects.filter(
+            thread__accesses__mailbox=mailbox
+        ).latest("created_at")
+        assert msg.get_stmsg_headers().get("itip-reply") == "verified"
+
+    def test_no_inbound_auth_configured_does_not_apply(
+        self, settings, mailbox, caldav_channel, radicale_with_calendar
+    ):
+        # Auth disabled instance-wide: an absent verdict must NOT count as
+        # verified, so the reply is not applied and not flagged.
+        settings.CALENDAR_ITIP_REPLY_ENABLED = True
+        settings.SPAM_CONFIG = {}
+        calendar_url, put_event = radicale_with_calendar
+        uid = "e2e-noauth@example.com"
+        self._seed(put_event, uid, str(mailbox))
+
+        self._deliver(str(mailbox), uid)
+
+        assert self._partstat(calendar_url, uid) == "NEEDS-ACTION"
+        msg = models.Message.objects.filter(
+            thread__accesses__mailbox=mailbox
+        ).latest("created_at")
+        assert msg.get_stmsg_headers().get("itip-reply") is None
+
+    def test_unknown_auth_mode_does_not_apply(
+        self, settings, mailbox, caldav_channel, radicale_with_calendar
+    ):
+        # A typo'd mode ("nativ") makes check_inbound_authentication return None;
+        # it must be treated as unverifiable, not verified.
+        settings.CALENDAR_ITIP_REPLY_ENABLED = True
+        settings.SPAM_CONFIG = {"inbound_auth": "nativ"}
+        calendar_url, put_event = radicale_with_calendar
+        uid = "e2e-typo@example.com"
+        self._seed(put_event, uid, str(mailbox))
+
+        self._deliver(str(mailbox), uid)
+
+        assert self._partstat(calendar_url, uid) == "NEEDS-ACTION"
+
+    def test_forged_reply_delivered_but_not_applied(
+        self, settings, mailbox, caldav_channel, radicale_with_calendar
+    ):
+        settings.CALENDAR_ITIP_REPLY_ENABLED = True
+        calendar_url, put_event = radicale_with_calendar
+        uid = "e2e-forged@example.com"
+        self._seed(put_event, uid, str(mailbox))
+
+        with mock.patch(
+            "core.mda.inbound_pipeline.check_inbound_authentication",
+            return_value="fail",
+        ):
+            self._deliver(str(mailbox), uid)
+
+        assert self._partstat(calendar_url, uid) == "NEEDS-ACTION"
+        msg = models.Message.objects.filter(
+            thread__accesses__mailbox=mailbox
+        ).latest("created_at")
+        assert msg.get_stmsg_headers().get("itip-reply") is None
+
+    def test_flag_off_does_not_apply(
+        self, settings, mailbox, caldav_channel, radicale_with_calendar
+    ):
+        settings.CALENDAR_ITIP_REPLY_ENABLED = False
+        calendar_url, put_event = radicale_with_calendar
+        uid = "e2e-flagoff@example.com"
+        self._seed(put_event, uid, str(mailbox))
+
+        self._deliver(str(mailbox), uid)
+
+        assert self._partstat(calendar_url, uid) == "NEEDS-ACTION"
+
+    def test_no_calendar_backend_skips(self, settings, mailbox):
+        # Verified reply, but no per-mailbox channel and no instance default:
+        # delivered, never flagged/applied. (auth configured + verified so the
+        # skip is the backend check, not the auth gate.)
+        settings.CALENDAR_ITIP_REPLY_ENABLED = True
+        settings.SPAM_CONFIG = {"inbound_auth": "native"}
+        settings.CALDAV_DEFAULT_URL = ""
+        settings.CALDAV_DEFAULT_PASSWORD = ""
+
+        with mock.patch(
+            "core.mda.inbound_pipeline.check_inbound_authentication",
+            return_value=None,
+        ):
+            self._deliver(str(mailbox), "e2e-nocaldav@example.com")
+
+        msg = models.Message.objects.filter(
+            thread__accesses__mailbox=mailbox
+        ).latest("created_at")
+        assert msg.get_stmsg_headers().get("itip-reply") is None

--- a/src/backend/core/tests/mda/test_inbound_auth.py
+++ b/src/backend/core/tests/mda/test_inbound_auth.py
@@ -14,6 +14,7 @@ from core.mda.inbound_auth import (
     VERDICT_FORGED,
     VERDICT_UNVERIFIED,
     check_inbound_authentication,
+    inbound_auth_enabled,
 )
 from core.mda.inbound_tasks import process_inbound_message_task
 
@@ -783,3 +784,14 @@ class TestProcessInboundMessageAuthIntegration:
             if h["name"].lower() == "x-stmsg-sender-auth"
         ]
         assert values == ["fail"]
+
+
+def test_inbound_auth_enabled_only_for_supported_modes():
+    assert inbound_auth_enabled({"inbound_auth": "native"}) is True
+    assert inbound_auth_enabled({"inbound_auth": "rspamd"}) is True
+    assert inbound_auth_enabled({"inbound_auth": "authentication-results"}) is True
+    # A typo or unknown mode is NOT "auth ran" — check_inbound_authentication
+    # returns None (= verified) for it, so callers must treat it as disabled.
+    assert inbound_auth_enabled({"inbound_auth": "nativ"}) is False
+    assert inbound_auth_enabled({"inbound_auth": ""}) is False
+    assert inbound_auth_enabled({}) is False

--- a/src/backend/core/tests/test_itip.py
+++ b/src/backend/core/tests/test_itip.py
@@ -1,0 +1,173 @@
+"""Unit tests for inbound iTIP REPLY detection + trust gating (core.mda.itip)."""
+# pylint: disable=missing-function-docstring,missing-class-docstring
+
+from core.mda import itip
+
+REPLY_ICS = """\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+METHOD:REPLY
+BEGIN:VEVENT
+UID:evt-1@example.com
+DTSTAMP:20260101T120000Z
+DTSTART:20260601T100000Z
+DTEND:20260601T110000Z
+SEQUENCE:0
+ORGANIZER:mailto:org@example.com
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:Alice@Corp.example
+END:VEVENT
+END:VCALENDAR"""
+
+REQUEST_ICS = REPLY_ICS.replace("METHOD:REPLY", "METHOD:REQUEST")
+
+# Crafted attack: the aligned From (attacker) is a PARTSTAT-less ATTENDEE, while
+# a *different* ATTENDEE (victim) carries the PARTSTAT. Must never move victim.
+TWO_ATTENDEE_ICS = """\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+METHOD:REPLY
+BEGIN:VEVENT
+UID:evt-1@example.com
+DTSTAMP:20260101T120000Z
+DTSTART:20260601T100000Z
+DTEND:20260601T110000Z
+SEQUENCE:0
+ORGANIZER:mailto:org@example.com
+ATTENDEE:mailto:attacker@corp.example
+ATTENDEE;PARTSTAT=DECLINED:mailto:victim@corp.example
+END:VEVENT
+END:VCALENDAR"""
+
+
+def _parsed(ics, from_email):
+    """Minimal JmapEmail-shaped dict with a single text/calendar leaf."""
+    return {
+        "from": [{"email": from_email}],
+        "bodyStructure": {
+            "type": "text/calendar",
+            "content": ics,
+            "subParts": None,
+        },
+    }
+
+
+class TestDecide:
+    def test_verified_applies_verified(self):
+        assert itip.decide(None, False) == (True, itip.FLAG_VERIFIED)
+
+    def test_forged_never_applies(self):
+        assert itip.decide("fail", False) == (False, None)
+        assert itip.decide("fail", True) == (False, None)
+
+    def test_unverified_skipped_by_default(self):
+        assert itip.decide("none", False) == (False, None)
+
+    def test_unverified_applied_when_opted_in(self):
+        assert itip.decide("none", True) == (True, itip.FLAG_UNVERIFIED)
+
+
+class TestReplyPartstat:
+    def test_returns_own_partstat(self):
+        assert itip.reply_partstat(REPLY_ICS, "alice@corp.example") == "ACCEPTED"
+
+    def test_case_insensitive(self):
+        assert itip.reply_partstat(REPLY_ICS, "Alice@Corp.Example") == "ACCEPTED"
+
+    def test_none_for_partstatless_attendee(self):
+        # attacker is an ATTENDEE but carries no PARTSTAT.
+        assert itip.reply_partstat(TWO_ATTENDEE_ICS, "attacker@corp.example") is None
+
+    def test_never_returns_another_attendees_partstat(self):
+        # asking for the victim returns victim's own; asking for attacker never
+        # leaks victim's DECLINED.
+        assert itip.reply_partstat(TWO_ATTENDEE_ICS, "victim@corp.example") == (
+            "DECLINED"
+        )
+        assert itip.reply_partstat(TWO_ATTENDEE_ICS, "attacker@corp.example") is None
+
+    def test_none_when_unparseable(self):
+        assert itip.reply_partstat("not an ics", "a@b.example") is None
+
+
+class TestFindReplyIcs:
+    def test_finds_reply_part(self):
+        assert itip.find_reply_ics(_parsed(REPLY_ICS, "alice@corp.example")) is not None
+
+    def test_ignores_request_method(self):
+        assert itip.find_reply_ics(_parsed(REQUEST_ICS, "org@example.com")) is None
+
+    def test_no_calendar_part(self):
+        parsed = {
+            "from": [{"email": "a@b.example"}],
+            "bodyStructure": {"type": "text/plain", "content": "hi", "subParts": None},
+        }
+        assert itip.find_reply_ics(parsed) is None
+
+    def test_finds_in_attachments_fallback(self):
+        parsed = {
+            "from": [{"email": "alice@corp.example"}],
+            "attachments": [{"type": "text/calendar", "content": REPLY_ICS}],
+        }
+        assert itip.find_reply_ics(parsed) is not None
+
+
+class TestEvaluateInboundReply:
+    def test_verified_sender_rsvping(self):
+        parsed = _parsed(REPLY_ICS, "alice@corp.example")
+        ics, flag, attendee = itip.evaluate_inbound_reply(parsed, None, False)
+        assert ics is not None
+        assert flag == itip.FLAG_VERIFIED
+        assert attendee == "alice@corp.example"
+
+    def test_from_not_an_rsvping_attendee_rejected(self):
+        # From is the organizer, not an ATTENDEE carrying a PARTSTAT.
+        parsed = _parsed(REPLY_ICS, "org@example.com")
+        assert itip.evaluate_inbound_reply(parsed, None, False) == (None, None, None)
+
+    def test_crafted_two_attendee_payload_rejected(self):
+        # From=attacker (aligned, DMARC-pass) but attacker has no PARTSTAT; the
+        # PARTSTAT belongs to victim. Gate must refuse — attacker isn't RSVPing.
+        parsed = _parsed(TWO_ATTENDEE_ICS, "attacker@corp.example")
+        assert itip.evaluate_inbound_reply(parsed, None, False) == (None, None, None)
+
+    def test_forged_rejected(self):
+        parsed = _parsed(REPLY_ICS, "alice@corp.example")
+        assert itip.evaluate_inbound_reply(parsed, "fail", True) == (None, None, None)
+
+    def test_unverified_skipped_by_default(self):
+        parsed = _parsed(REPLY_ICS, "alice@corp.example")
+        assert itip.evaluate_inbound_reply(parsed, "none", False) == (None, None, None)
+
+    def test_unverified_applied_when_opted_in(self):
+        parsed = _parsed(REPLY_ICS, "alice@corp.example")
+        ics, flag, attendee = itip.evaluate_inbound_reply(parsed, "none", True)
+        assert ics is not None
+        assert flag == itip.FLAG_UNVERIFIED
+        assert attendee == "alice@corp.example"
+
+    def test_no_reply_part(self):
+        parsed = _parsed(REQUEST_ICS, "org@example.com")
+        assert itip.evaluate_inbound_reply(parsed, None, False) == (None, None, None)
+
+    def test_recurrence_instance_rejected_at_gate(self):
+        ics = REPLY_ICS.replace(
+            "SEQUENCE:0", "SEQUENCE:0\nRECURRENCE-ID:20260601T100000Z"
+        )
+        parsed = _parsed(ics, "alice@corp.example")
+        assert itip.evaluate_inbound_reply(parsed, None, False) == (None, None, None)
+
+
+class TestRecurrenceDetection:
+    def test_detects_recurrence_id(self):
+        ics = REPLY_ICS.replace(
+            "SEQUENCE:0", "SEQUENCE:0\nRECURRENCE-ID:20260601T100000Z"
+        )
+        assert itip.reply_is_recurrence_instance(ics) is True
+
+    def test_plain_reply_is_not_recurrence(self):
+        assert itip.reply_is_recurrence_instance(REPLY_ICS) is False
+
+    def test_unparseable_is_not_recurrence(self):
+        assert itip.reply_is_recurrence_instance("nope") is False

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -434,6 +434,16 @@ class Base(Configuration):
     CALDAV_DEFAULT_WEB_URL = values.Value(
         None, environ_name="CALDAV_DEFAULT_WEB_URL", environ_prefix=None
     )
+    CALENDAR_ITIP_REPLY_ENABLED = values.BooleanValue(
+        False, environ_name="CALENDAR_ITIP_REPLY_ENABLED", environ_prefix=None
+    )
+    # Also apply unverifiable ("none") REPLYs, flagged unverified; default off
+    # applies only DMARC-verified ones. Only safe where From can't be spoofed.
+    CALENDAR_ITIP_REPLY_APPLY_UNVERIFIED = values.BooleanValue(
+        False,
+        environ_name="CALENDAR_ITIP_REPLY_APPLY_UNVERIFIED",
+        environ_prefix=None,
+    )
 
     # Spam filtering settings
 


### PR DESCRIPTION
Closes the calendar RSVP loop: applies an inbound iTIP `METHOD:REPLY` to the
organizer's stored event — the mirror of the attendee-side `respond_to_event`.
Off by default behind `CALENDAR_ITIP_REPLY_ENABLED`.

**How:** detect a `text/calendar; method=REPLY` part in the inbound pipeline →
gate → async `calendar_apply_reply_task` → `CalDAVService.apply_reply` finds the
event by UID and writes the replying attendee's PARTSTAT back to its real
resource href with `If-Match`.

**Trust:** consumes the pipeline's existing `postmark["auth"]` verdict — no new
auth mechanism. The DMARC-verified From is the only ATTENDEE that can be moved,
and must itself be RSVPing, so a crafted multi-ATTENDEE reply can't move a third
party. `fail` never applied; `none` only with `CALENDAR_ITIP_REPLY_APPLY_UNVERIFIED`;
an absent verdict counts as verified only when a supported inbound-auth mode ran.

**CalDAV correctness:** write to the event's real href (filenames needn't equal
the UID) with `If-Match` + 412 refetch-retry; `SCHEDULE-AGENT=CLIENT` to suppress
server re-fanout; SEQUENCE + clamped per-attendee DTSTAMP staleness guard;
recurrence-instance and DTSTART-less replies rejected; oversized parts capped.

Tests: unit trust matrix + the two-ATTENDEE attack; `apply_reply` against live
Radicale (non-UID filename, If-Match, 412 retry); full-stack e2e through the MTA
deliver endpoint.

Follow-up: #752 (`respond_to_event` shares the same href hazard on the
interactive RSVP path). Open question: apply in-backend as here, or hand the
reply to SabreDAV's scheduling inbox?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inbound iTIP `METHOD:REPLY` handling to update matching CalDAV attendee PARTSTATs.
  * Added trust-gated application (including recurrence-instance rejection) and fan-out task enqueueing when applicable.
  * Introduced iTIP REPLY feature flags and exposed iTIP reply verification status in message metadata.
* **Bug Fixes**
  * Treats unsupported/unknown inbound auth modes as disabled.
  * Preserves `X-STMSG-REPLY-DTSTAMP` during calendar rebuild/sanitization.
* **Tests**
  * Added unit and end-to-end coverage for parsing, gating, CalDAV apply behavior, concurrency handling, and message flagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->