### PR TITLE
✨(inbound) ARC relay-trust: inbound_auth "arc" + arc_gate

### DIFF
--- a/docs/spam-config.md
+++ b/docs/spam-config.md
@@ -1,0 +1,104 @@
+# `SPAM_CONFIG`
+
+Inbound spam filtering **and** sender-authentication config. Set globally via the
+`SPAM_CONFIG` env var (JSON), overridable per mail domain through
+`MailDomain.custom_settings["SPAM_CONFIG"]` (merged by
+`MailDomain.get_spam_config()`).
+
+> Naming note: these keys cover both spam scoring and sender auth/trust. The
+> auth keys live here because `inbound_auth` already did — not because they are
+> "spam". A future split into a dedicated auth/trust config is possible but out
+> of scope here.
+
+## Keys
+
+| Key | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `rspamd_url` | string | — | rspamd `/checkv2` endpoint. Absent = no rspamd scan. |
+| `rspamd_auth` | string | — | Optional `Authorization` header value for rspamd. |
+| `rules` | list | `[]` | Hardcoded header-match spam rules (see below). |
+| `trusted_relays` | int | `0` | How many upstream `Received` blocks to trust for the header-match `rules`. Block 0 = the block our own MTA prepends. Not used by `inbound_auth: "arc"`. |
+| `inbound_auth` | string\|null | `null` | Sender-auth backend for the verdict/banner (see below). |
+| `trusted_arc_sealers` | list | `[]` | ARC sealer `d=` allowlist. `[]` = accept any valid seal. Used by `inbound_auth: "arc"` and `arc_gate`. |
+| `arc_gate` | string | `"off"` | Action when a message is **not** sealed by a trusted sealer (see below). |
+
+## `rules`
+
+Each rule matches one header, within the `trusted_relays` block window:
+
+```jsonc
+{ "header_match":       "X-Foo: exact-value", "action": "spam" }  // literal, case-insensitive
+{ "header_match_regex": "X-Spam-Level:\\*{5,}", "action": "spam" } // regex, IGNORECASE
+```
+
+`action`: `"spam"` / `"reject"` → `is_spam=True`; `"ham"` / `"no action"` →
+`is_spam=False`. Default `"spam"`. First matching rule wins. `Return-Path` is
+never eligible (spoofable envelope value).
+
+## `inbound_auth` — the verdict / banner
+
+Produces `postmark["auth"]`: absent = verified, `"none"` = unverified,
+`"fail"` = likely forged (DMARC disavowal).
+
+| Value | Source |
+| --- | --- |
+| `"native"` | Local DKIM verify + strict `From`/`d=` alignment. |
+| `"rspamd"` | dkim/dmarc from the rspamd result. |
+| `"arc"` | dkim/dmarc from a trusted sealer's **sealed** `ARC-Authentication-Results` only. Plaintext headers are never read. Untrusted/unsealed → unverified. |
+| `"authentication-results"` | Parse `dkim=`/`dmarc=` from the top-level `Authentication-Results`, trusted by `trusted_relays` position. |
+| `null` / absent | Disabled. |
+
+## `arc_gate` — relay-trust enforcement
+
+Verifies the ARC chain (dkimpy) and applies an action when the message is **not**
+sealed by a trusted sealer (`cv=pass` **and** outermost sealer ∈
+`trusted_arc_sealers`, or any `cv=pass` when the allowlist is empty).
+
+| Value | Effect |
+| --- | --- |
+| `"off"` | No gating (default). |
+| `"spam"` | Not trusted-sealed → `is_spam=True` (Junk). |
+| `"drop"` | Not trusted-sealed → silently discarded. |
+
+Runs first among the spam steps, so an untrusted verdict is authoritative. A DNS
+/ verification failure never spams or drops (can't verify ≠ forged). `quarantine`
+and `reject` are planned for a follow-up.
+
+> **Public-MX warning:** with an empty `trusted_arc_sealers`, "any valid seal"
+> is bypassable — an attacker self-seals their own domain (`cv=pass`,
+> `d=attacker.example`). On a publicly reachable MX, **populate the allowlist**
+> so the ARC seal is a real trust anchor. `trusted_arc_sealers` may list several
+> sealers (e.g. an external relay plus an internal gateway).
+
+## Examples
+
+Public MX, accept only trusted-ARC-sealed mail (mark the rest as spam):
+
+```jsonc
+{
+  "inbound_auth": "arc",
+  "trusted_arc_sealers": ["relay.example"],
+  "arc_gate": "spam",
+  "rspamd_url": "http://rspamd:11334/checkv2",
+  "trusted_relays": 99,
+  "rules": [ { "header_match_regex": "X-Spam-Level:\\*{5,}", "action": "spam" } ]
+}
+```
+
+Minimal ARC gate, no rspamd:
+
+```jsonc
+{ "inbound_auth": "arc", "trusted_arc_sealers": ["relay.example"], "arc_gate": "spam" }
+```
+
+Multiple sealers (external relay + internal gateway):
+
+```jsonc
+{ "inbound_auth": "arc", "trusted_arc_sealers": ["relay.example", "gateway.internal.example"], "arc_gate": "spam" }
+```
+
+Legacy header-based auth (no ARC):
+
+```jsonc
+{ "inbound_auth": "authentication-results", "trusted_relays": 1 }
+```

--- a/src/backend/core/mda/arc.py
+++ b/src/backend/core/mda/arc.py
@@ -1,0 +1,57 @@
+"""ARC chain verification for inbound relay-trust (RFC 8617)."""
+
+import logging
+from typing import Any, Dict, Optional, Set
+
+from dkim import CV_Pass, arc_verify
+
+logger = logging.getLogger(__name__)
+
+
+def _sealer_trusted(sealer: Optional[str], trusted: Set[str]) -> bool:
+    """True if sealer equals or is a subdomain of a trusted sealer."""
+    if not sealer:
+        return False
+    if sealer in trusted:
+        return True
+    return any(sealer.endswith("." + t) for t in trusted)
+
+
+def arc_result(raw_data: bytes, trusted_sealers: Set[str]) -> Dict[str, Any]:
+    """Verify the ARC chain; empty trusted_sealers accepts any valid seal."""
+    result: Dict[str, Any] = {
+        "trusted": False,
+        "sealer": None,
+        "aar": None,
+        "dnsfail": False,
+    }
+
+    try:
+        cv, results, _reason = arc_verify(raw_data)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning("ARC verify errored (treating as untrusted): %s", exc)
+        return result
+
+    if not results:
+        return result
+
+    outer = results[0]
+    sealer_raw = outer.get("ams-domain")
+    if isinstance(sealer_raw, (bytes, bytearray)):
+        sealer = sealer_raw.decode("ascii", "replace")
+    else:
+        sealer = sealer_raw or None
+    if sealer:
+        sealer = sealer.strip().rstrip(".").lower() or None
+    result["sealer"] = sealer
+
+    allowed = not trusted_sealers or _sealer_trusted(sealer, trusted_sealers)
+    if cv == CV_Pass and allowed:
+        result["trusted"] = True
+        aar_raw = outer.get("aar-value")
+        if isinstance(aar_raw, (bytes, bytearray)):
+            result["aar"] = aar_raw.decode("utf-8", "replace")
+        elif isinstance(aar_raw, str):
+            result["aar"] = aar_raw
+
+    return result

--- a/src/backend/core/mda/inbound_auth.py
+++ b/src/backend/core/mda/inbound_auth.py
@@ -23,10 +23,11 @@ The backend is picked by ``SPAM_CONFIG["inbound_auth"]``:
     (we can't call it forgery without the From domain's published policy).
   - ``"rspamd"``: read DKIM / DMARC symbols from the rspamd /checkv2 result
     (reused from the spam check, or fetched on demand by the caller).
-  - ``"authentication-results"``: parse ``dkim=`` / ``dmarc=`` entries from the
-    ``Authentication-Results`` header set by a trusted upstream relay. The
-    header slice respects ``SPAM_CONFIG["trusted_relays"]`` so forged headers
-    from untrusted hops are ignored.
+  - ``"arc"``: dkim/dmarc from the ``ARC-Authentication-Results`` sealed by a
+    trusted sealer (``trusted_arc_sealers``; empty = any valid seal). Plaintext
+    headers are never read. Unsealed/untrusted -> unverified.
+  - ``"authentication-results"``: parse ``dkim=`` / ``dmarc=`` from the
+    top-level ``Authentication-Results`` sliced by ``trusted_relays``.
   - missing / ``None``: disabled, always returns ``None``.
 
 Backend failures (DNS lookup blowing up, rspamd unreachable, no AR header from
@@ -41,6 +42,7 @@ from typing import Any
 
 from jmap_email import JmapEmail, first_address_email
 
+from core.mda.arc import arc_result
 from core.mda.signing import verify_message_dkim
 from core.mda.utils import headers_blocks
 
@@ -229,16 +231,23 @@ def get_inbound_auth_mode(spam_config: dict[str, Any]) -> str:
     return (spam_config.get("inbound_auth") or "").strip().lower()
 
 
+def trusted_arc_sealers(spam_config: dict[str, Any]) -> set[str]:
+    """Normalized ``trusted_arc_sealers`` allowlist from the spam config."""
+    return {
+        s.strip().rstrip(".").lower()
+        for s in (spam_config.get("trusted_arc_sealers") or [])
+        if isinstance(s, str) and s.strip()
+    }
+
+
 def check_inbound_authentication(
     raw_data: bytes,
     parsed_email: JmapEmail,
     spam_config: dict[str, Any],
     rspamd_result: dict[str, Any] | None = None,
+    arc: dict[str, Any] | None = None,
 ) -> str | None:
-    """Return the sender-auth verdict for this message (``postmark["auth"]``).
-
-    See module docstring for the rule set and supported backends.
-    """
+    """Return the sender-auth verdict for this message (``postmark["auth"]``)."""
     mode = get_inbound_auth_mode(spam_config)
     if not mode:
         return None
@@ -249,6 +258,12 @@ def check_inbound_authentication(
     elif mode == "rspamd":
         dkim = _rspamd_outcome("dkim", rspamd_result)
         dmarc = _rspamd_outcome("dmarc", rspamd_result)
+    elif mode == "arc":
+        if arc is None:
+            arc = arc_result(raw_data, trusted_arc_sealers(spam_config))
+        ar_values = [arc["aar"]] if arc["trusted"] and arc["aar"] else []
+        dkim = _ar_outcome("dkim", ar_values)
+        dmarc = _ar_outcome("dmarc", ar_values)
     elif mode == "authentication-results":
         trusted_relays = int(spam_config.get("trusted_relays", 0))
         ar_values = _authentication_results_values(parsed_email, trusted_relays)

--- a/src/backend/core/mda/inbound_auth.py
+++ b/src/backend/core/mda/inbound_auth.py
@@ -233,9 +233,15 @@ def get_inbound_auth_mode(spam_config: dict[str, Any]) -> str:
 
 def trusted_arc_sealers(spam_config: dict[str, Any]) -> set[str]:
     """Normalized ``trusted_arc_sealers`` allowlist from the spam config."""
+    sealers = spam_config.get("trusted_arc_sealers")
+    if isinstance(sealers, str):
+        sealers = [sealers]
+    elif not isinstance(sealers, (list, tuple, set)):
+        sealers = []
+
     return {
         s.strip().rstrip(".").lower()
-        for s in (spam_config.get("trusted_arc_sealers") or [])
+        for s in sealers
         if isinstance(s, str) and s.strip()
     }
 

--- a/src/backend/core/mda/inbound_pipeline.py
+++ b/src/backend/core/mda/inbound_pipeline.py
@@ -37,9 +37,11 @@ from jmap_email import JmapEmail
 
 from core import enums, models
 from core.mda import spam
+from core.mda.arc import arc_result
 from core.mda.inbound_auth import (
     check_inbound_authentication,
     get_inbound_auth_mode,
+    trusted_arc_sealers,
 )
 from core.services.thread_events import assign_users
 
@@ -132,6 +134,9 @@ class InboundContext:  # pylint: disable=too-many-instance-attributes
     # the symbols (DKIM/DMARC verdicts) without a second HTTP call.
     rspamd_result: Optional[Dict[str, Any]] = None
 
+    # Populated by ``arc_gate_step`` so ``inbound_auth_step`` can reuse it.
+    arc: Optional[Dict[str, Any]] = None
+
     # Memoised results of blocking webhook steps, keyed by
     # ``(channel_id, phase)``. Pre-loaded from Redis at the start of a
     # *retry* attempt so an already-succeeded blocking webhook is replayed
@@ -172,6 +177,30 @@ DEFERRAL_MAX_AGE = timedelta(seconds=settings.MESSAGES_INBOUND_DEFERRAL_MAX_AGE)
 # Steps. Each is callable as ``step(ctx) -> Decision`` and carries a
 # ``.name`` for log/return-value reporting.
 # ---------------------------------------------------------------------------
+
+
+def _make_arc_gate_step(spam_config: Dict[str, Any]) -> Step:
+    action = str(spam_config.get("arc_gate") or "off").strip().lower()
+
+    def arc_gate(ctx: InboundContext) -> Decision:
+        if action == "off":
+            return Decision.CONTINUE
+        ctx.arc = arc_result(ctx.raw_data, trusted_arc_sealers(spam_config))
+        if ctx.arc["trusted"] or ctx.arc["dnsfail"]:
+            return Decision.CONTINUE
+        logger.info(
+            "ARC gate: untrusted message (sealer=%s) -> %s",
+            ctx.arc["sealer"],
+            action,
+        )
+        if action == "drop":
+            return Decision.DROP
+        if action == "spam" and ctx.is_spam is None:
+            ctx.is_spam = True
+        return Decision.CONTINUE
+
+    arc_gate.name = "arc_gate"
+    return arc_gate
 
 
 def _make_hardcoded_rules_step(spam_config: Dict[str, Any]) -> Step:
@@ -291,7 +320,7 @@ def _make_inbound_auth_step(spam_config: Dict[str, Any]) -> Step:
                 ctx.raw_data, spam_config, envelope=ctx.inbound_message.envelope
             )
         verdict = check_inbound_authentication(
-            ctx.raw_data, ctx.parsed_email, spam_config, ctx.rspamd_result
+            ctx.raw_data, ctx.parsed_email, spam_config, ctx.rspamd_result, ctx.arc
         )
         if not verdict:
             # Widget submissions arrive over an unauthenticated web form, so
@@ -358,6 +387,7 @@ def build_inbound_pipeline(ctx: InboundContext) -> List[Step]:
 
     return [
         *webhook_steps_for_mailbox(ctx.mailbox, phase="before_spam", channels=channels),
+        _make_arc_gate_step(ctx.spam_config),
         _make_hardcoded_rules_step(ctx.spam_config),
         _make_rspamd_step(ctx.spam_config),
         _make_inbound_auth_step(ctx.spam_config),

--- a/src/backend/core/tests/mda/test_arc.py
+++ b/src/backend/core/tests/mda/test_arc.py
@@ -1,0 +1,145 @@
+"""Tests for ARC chain verification (core.mda.arc)."""
+
+# pylint: disable=missing-function-docstring,missing-class-docstring
+# pylint: disable=protected-access,unused-argument
+
+import base64
+from unittest.mock import patch
+
+import dkim
+
+from core.mda import arc
+
+
+class TestSealerTrusted:
+    def test_exact_match(self):
+        assert arc._sealer_trusted("relay.example", {"relay.example"})
+
+    def test_subdomain_match(self):
+        assert arc._sealer_trusted("mx.relay.example", {"relay.example"})
+
+    def test_lookalike_not_matched(self):
+        assert not arc._sealer_trusted("evil-relay.example", {"relay.example"})
+
+    def test_none(self):
+        assert not arc._sealer_trusted(None, {"relay.example"})
+
+
+class TestArcResult:
+    def test_empty_allowlist_accepts_any_valid(self):
+        results = [
+            {"ams-domain": b"whoever.example", "aar-value": b"i=1; mx; dkim=pass"}
+        ]
+        with patch(
+            "core.mda.arc.arc_verify", return_value=(arc.CV_Pass, results, "ok")
+        ):
+            out = arc.arc_result(b"raw", set())
+        assert out["trusted"] is True
+        assert out["sealer"] == "whoever.example"
+
+    def test_verify_exception_untrusted(self):
+        with patch("core.mda.arc.arc_verify", side_effect=Exception("boom")):
+            out = arc.arc_result(b"raw", {"relay.example"})
+        assert out["dnsfail"] is False
+        assert out["trusted"] is False
+
+    def test_trusted_seal_exposes_aar(self):
+        results = [{"ams-domain": b"relay.example", "aar-value": b"i=2; mx; dkim=pass"}]
+        with patch(
+            "core.mda.arc.arc_verify", return_value=(arc.CV_Pass, results, "ok")
+        ):
+            out = arc.arc_result(b"raw", {"relay.example"})
+        assert out["trusted"] is True
+        assert out["sealer"] == "relay.example"
+        assert out["aar"] == "i=2; mx; dkim=pass"
+
+    def test_untrusted_sealer_no_aar(self):
+        results = [{"ams-domain": b"evil.net", "aar-value": b"i=2; mx; dkim=pass"}]
+        with patch(
+            "core.mda.arc.arc_verify", return_value=(arc.CV_Pass, results, "ok")
+        ):
+            out = arc.arc_result(b"raw", {"relay.example"})
+        assert out["trusted"] is False
+        assert out["sealer"] == "evil.net"
+        assert out["aar"] is None
+
+    def test_cv_fail_untrusted(self):
+        results = [{"ams-domain": b"relay.example", "aar-value": b"i=2; mx; dkim=pass"}]
+        with patch("core.mda.arc.arc_verify", return_value=(b"fail", results, "bad")):
+            out = arc.arc_result(b"raw", {"relay.example"})
+        assert out["trusted"] is False
+        assert out["aar"] is None
+
+    def test_no_arc_set(self):
+        with patch("core.mda.arc.arc_verify", return_value=(b"none", [], "no arc")):
+            out = arc.arc_result(b"raw", {"relay.example"})
+        assert out == {"trusted": False, "sealer": None, "aar": None, "dnsfail": False}
+
+
+# A message ARC-sealed once with a throwaway 2048-bit RSA key (domain
+# relay.example, selector arcsel). Verified offline via a stub dnsfunc that
+# returns the matching public key below — exercises the real dkimpy crypto
+# without network or PII.
+_PUBKEY_TXT = (
+    "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz950COD08H"
+    "iYPJpql+PUqMY7oH7Z3jR/7KPX0b6hZFaw8wQCE3xB4cWB3Bwarw27oA7f4IfMOH6ifKqf3h"
+    "wSo0/zcH6s2Tz2UP8hrC9lq5OoiMdzmzfQ1wx6M5Z0stCCe/FFkh4GihANLtiOslxK+R1Gee"
+    "Q+fP2eQWbXcYdElVoWKwTQxpfALfshyxLmLjJq4Ji86wRpii9mSUne1GDbHAMvEU5tgZI+Hr"
+    "vluxwR3v6hEe+mhy0la8sXLHK9wEu0D3h3G26te/nat24ZMukI6+jjvhVIRp6LM2rWU2rZgq"
+    "6iEmuWl0jURCWD+JrxTuLMU7VgnMYuUOgKI6yuuma1IwIDAQAB"
+)
+
+_SEALED_B64 = (
+    "QVJDLVNlYWw6IGk9MTsgY3Y9bm9uZTsgYT1yc2Etc2hhMjU2OyBkPXJlbGF5LmV4YW1wbGU7"
+    "IHM9YXJjc2VsOyB0PTEyMzQ1Ow0KIGI9WGFvVlAvam1OcVNvNWJwK3ZYM25INS9jRmJZK1Y4"
+    "TVdvN2cvQkoyZUd6ZXo0TENIS0U1N1UzU0g1U0RBT0xuc0MzQ3BvDQogbm9VTktyTm9UQ1hk"
+    "THBJR1dqNWM0d1NpMExTVjB2NUF1dWphQkN2eEdOZ3F6aGJRT3JiUnV3bUMzSlVHeU5OSExF"
+    "RmF6d3gNCiBFd09rSHlRUGx4QXcrVDRTczhiMU50dDRNK2JoZlk2UW5kb1ZIK1JHUXByQXBp"
+    "eFhpdzV4TXlmR05XNGxCUXJ0blF4RHllNg0KIDl1aXFRYWlFaktMZlRBU2ZjdjB5ZUJqd2pv"
+    "cllnL0x4OHIxZUFqdlFjaythUGpZR1BmTjdLck5LU1pFVkxiOVczK3NENG5mDQogZWdhQjBF"
+    "QWdXTnlzaXdXUW5xR1hXN0p6N3RvNGd1d1Y2blRTcWVTb0hMdC9hUlJLc3VSUFBkaVo1Z1RR"
+    "PT0NCkFSQy1NZXNzYWdlLVNpZ25hdHVyZTogaT0xOyBhPXJzYS1zaGEyNTY7IGM9cmVsYXhl"
+    "ZC9yZWxheGVkOw0KIGQ9cmVsYXkuZXhhbXBsZTsgcz1hcmNzZWw7IHQ9MTIzNDU7IGg9ZnJv"
+    "bSA6IHRvIDogc3ViamVjdCA6IG1lc3NhZ2UtaWQNCiA6IGZyb207IGJoPUNrNVNvUk5XVXBT"
+    "UjRYMENPdjdSNXViMnBVVHRsNnh6NGRURnorK2ppNE09Ow0KIGI9R0RqSHR0QjBUWVJSM21s"
+    "UHQzbEJ0azA2ejlQcHNXZWhjcXUzWCtFRVRveXZ3S0ZOQzFtVHg2eDFBRkZOemJtRkhIRHNh"
+    "DQogZG1BdzlyVURTaTBEMEhyQ3Q2L2RBSzZ4QWIxTGRrb0Q5SzZ5MmhFYTExcm01SWF2U1Rk"
+    "NDkzcXd4TytBNkpLNUJIVHJqZlINCiA3VlNWN2FWM1FtV1FFOVdwVU56WHZ4RkJxSVU2L2lQ"
+    "TzgrUEprbmJGdi9ibW91U2RzRzVFdjZWMGV1RnU4Wk4zL2dFSDRSdQ0KIDNJTnVucVg4M0VD"
+    "RzczOWhSV0JoYVZsdkRrdlZRN293Q2gxZW5Iejl2eWwrZWdhUkdyWnhKY1BRSWE0d1UrZTNG"
+    "V3VGanh5DQogNmJXcDhvbzdDQnF2NDNqSGVWSGtBSjNtNGFzSDJhNVpzMEdHRHE3aGN4b0pz"
+    "YjlvMkFNbFBaRW1tM0dBPT0NCkFSQy1BdXRoZW50aWNhdGlvbi1SZXN1bHRzOiBpPTE7IHJl"
+    "bGF5LmV4YW1wbGU7DQogZGtpbT1wYXNzIGhlYWRlci5kPXNlbmRlci5leGFtcGxlOw0KIGRt"
+    "YXJjPXBhc3MNCkF1dGhlbnRpY2F0aW9uLVJlc3VsdHM6IHJlbGF5LmV4YW1wbGU7IGRraW09"
+    "cGFzcyBoZWFkZXIuZD1zZW5kZXIuZXhhbXBsZTsgZG1hcmM9cGFzcw0KRnJvbTogYUBzZW5k"
+    "ZXIuZXhhbXBsZQ0KVG86IGJAcmNwdC5leGFtcGxlDQpTdWJqZWN0OiBoaQ0KTWVzc2FnZS1J"
+    "RDogPHhAc2VuZGVyLmV4YW1wbGU+DQoNCmJvZHkNCg=="
+)
+
+
+def _stub_dns(name, timeout=5):
+    return _PUBKEY_TXT
+
+
+def _verify_with_stub_dns(raw):
+    return dkim.arc_verify(raw, dnsfunc=_stub_dns)
+
+
+class TestArcResultRealCrypto:
+    """Exercise the real dkimpy chain verification (stub DNS, no network)."""
+
+    SEALED = base64.b64decode(_SEALED_B64)
+
+    def test_trusted_sealer_real_verify(self):
+        with patch("core.mda.arc.arc_verify", _verify_with_stub_dns):
+            out = arc.arc_result(self.SEALED, {"relay.example"})
+        assert out["trusted"] is True
+        assert out["sealer"] == "relay.example"
+        assert "dkim=pass" in str(out["aar"])
+
+    def test_untrusted_sealer_real_verify(self):
+        with patch("core.mda.arc.arc_verify", _verify_with_stub_dns):
+            out = arc.arc_result(self.SEALED, {"other.example"})
+        assert out["trusted"] is False
+        assert out["sealer"] == "relay.example"
+        assert out["aar"] is None

--- a/src/backend/core/tests/mda/test_inbound_auth.py
+++ b/src/backend/core/tests/mda/test_inbound_auth.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=missing-function-docstring,too-many-public-methods
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from django.test import override_settings
@@ -15,6 +16,7 @@ from core.mda.inbound_auth import (
     VERDICT_UNVERIFIED,
     check_inbound_authentication,
 )
+from core.mda.inbound_pipeline import Decision, _make_arc_gate_step
 from core.mda.inbound_tasks import process_inbound_message_task
 
 RAW_EMAIL = (
@@ -410,6 +412,66 @@ class TestCheckInboundAuthenticationResults:
         assert check_inbound_authentication(b"", parsed, config) is None
 
 
+class TestCheckInboundAuthArcMode:
+    """`arc` mode: verdict from the trusted sealer's sealed AAR only; the
+    plaintext header is never read."""
+
+    CONFIG = {"inbound_auth": "arc", "trusted_arc_sealers": ["relay.example"]}
+
+    # A forged top-level header must be ignored entirely in arc mode.
+    PARSED_FORGED_HEADER = {
+        "headers": [{"name": "Authentication-Results", "value": "mx; dkim=pass"}]
+    }
+
+    def test_trusted_seal_verified(self):
+        arc = {
+            "trusted": True,
+            "sealer": "relay.example",
+            "aar": "i=2; mx; dkim=pass; dmarc=pass",
+            "dnsfail": False,
+        }
+        assert check_inbound_authentication(b"raw", {}, self.CONFIG, arc=arc) is None
+
+    def test_trusted_seal_dmarc_fail_forged(self):
+        arc = {
+            "trusted": True,
+            "sealer": "relay.example",
+            "aar": "i=2; mx; dkim=pass; dmarc=fail",
+            "dnsfail": False,
+        }
+        assert (
+            check_inbound_authentication(b"raw", {}, self.CONFIG, arc=arc)
+            == VERDICT_FORGED
+        )
+
+    def test_untrusted_ignores_forged_header(self):
+        arc = {"trusted": False, "sealer": None, "aar": None, "dnsfail": False}
+        assert (
+            check_inbound_authentication(
+                b"raw", self.PARSED_FORGED_HEADER, self.CONFIG, arc=arc
+            )
+            == VERDICT_UNVERIFIED
+        )
+
+    def test_dnsfail_unverified(self):
+        arc = {"trusted": False, "sealer": None, "aar": None, "dnsfail": True}
+        assert (
+            check_inbound_authentication(b"raw", {}, self.CONFIG, arc=arc)
+            == VERDICT_UNVERIFIED
+        )
+
+    @patch("core.mda.inbound_auth.arc_result")
+    def test_computes_arc_when_not_passed(self, mock_arc):
+        mock_arc.return_value = {
+            "trusted": True,
+            "sealer": "relay.example",
+            "aar": "i=1; mx; dkim=pass",
+            "dnsfail": False,
+        }
+        assert check_inbound_authentication(b"raw", {}, self.CONFIG) is None
+        mock_arc.assert_called_once()
+
+
 class TestCheckInboundAuthenticationResultsScrubbing:
     """`dkim=`/`dmarc=` literals inside CFWS comments or quoted strings must
     NOT be honoured — they're attacker-controlled free text."""
@@ -783,3 +845,65 @@ class TestProcessInboundMessageAuthIntegration:
             if h["name"].lower() == "x-stmsg-sender-auth"
         ]
         assert values == ["fail"]
+
+
+class TestArcGateStep:
+    """The arc_gate pipeline step marks/drops messages lacking a trusted seal."""
+
+    @staticmethod
+    def _ctx():
+        return SimpleNamespace(raw_data=b"raw", is_spam=None, arc=None)
+
+    @patch("core.mda.inbound_pipeline.arc_result")
+    def test_off_is_noop(self, mock_arc):
+        ctx = self._ctx()
+        assert _make_arc_gate_step({})(ctx) == Decision.CONTINUE
+        assert ctx.is_spam is None
+        mock_arc.assert_not_called()
+
+    @patch("core.mda.inbound_pipeline.arc_result")
+    def test_trusted_passes(self, mock_arc):
+        mock_arc.return_value = {
+            "trusted": True,
+            "dnsfail": False,
+            "sealer": "r",
+            "aar": "x",
+        }
+        ctx = self._ctx()
+        step = _make_arc_gate_step({"arc_gate": "spam"})
+        assert step(ctx) == Decision.CONTINUE
+        assert ctx.is_spam is None
+
+    @patch("core.mda.inbound_pipeline.arc_result")
+    def test_spam_marks_untrusted(self, mock_arc):
+        mock_arc.return_value = {
+            "trusted": False,
+            "dnsfail": False,
+            "sealer": None,
+            "aar": None,
+        }
+        ctx = self._ctx()
+        assert _make_arc_gate_step({"arc_gate": "spam"})(ctx) == Decision.CONTINUE
+        assert ctx.is_spam is True
+
+    @patch("core.mda.inbound_pipeline.arc_result")
+    def test_drop_untrusted(self, mock_arc):
+        mock_arc.return_value = {
+            "trusted": False,
+            "dnsfail": False,
+            "sealer": None,
+            "aar": None,
+        }
+        assert _make_arc_gate_step({"arc_gate": "drop"})(self._ctx()) == Decision.DROP
+
+    @patch("core.mda.inbound_pipeline.arc_result")
+    def test_dnsfail_no_action(self, mock_arc):
+        mock_arc.return_value = {
+            "trusted": False,
+            "dnsfail": True,
+            "sealer": None,
+            "aar": None,
+        }
+        ctx = self._ctx()
+        assert _make_arc_gate_step({"arc_gate": "drop"})(ctx) == Decision.CONTINUE
+        assert ctx.is_spam is None

--- a/src/backend/messages/settings.py
+++ b/src/backend/messages/settings.py
@@ -448,9 +448,15 @@ class Base(Configuration):
     #                              relay hops you actually operate)
     #   rules                    : list of hardcoded header-match spam rules
     #   inbound_auth             : sender authentication backend — one of
-    #                              "native", "rspamd", "authentication-results",
-    #                              or None/absent to disable. See
-    #                              core.mda.inbound_auth for semantics.
+    #                              "native", "rspamd", "arc",
+    #                              "authentication-results", or None to disable.
+    #                              See core.mda.inbound_auth for semantics.
+    #   trusted_arc_sealers      : list of trusted ARC sealer d= domains
+    #                              (empty = any valid seal). Used by inbound_auth
+    #                              "arc" and by arc_gate.
+    #   arc_gate                 : action when a message is not sealed by a
+    #                              trusted sealer — "off" (default), "spam", or
+    #                              "drop".
     SPAM_CONFIG = values.DictValue({}, environ_name="SPAM_CONFIG", environ_prefix=None)
 
     # MTA settings


### PR DESCRIPTION
## What
Add ARC-based sender trust for inbound mail, in `SPAM_CONFIG`:
- **`inbound_auth: "arc"`** — verdict backend that reads dkim/dmarc **only** from an `ARC-Authentication-Results` sealed by a trusted sealer. Plaintext headers are never read.
- **`arc_gate`** — enforce that mail is sealed by a trusted relay: `off | spam | drop`.

## Why
With `inbound_auth: authentication-results`, dkim/dmarc come from the top-level `Authentication-Results`, trusted by Received-block position. A host delivering straight to the MDA can forge that header (and `From:`) and show as verified. When inbound is relayed by a provider that ARC-seals (a filtering relay in front of a public MX), the seal is an unforgeable anchor — verify it instead of trusting a plaintext header.

## Config
```jsonc
{
  "inbound_auth": "arc",
  "trusted_arc_sealers": ["relay.example"],  // empty = any valid seal
  "arc_gate": "spam"                          // off | spam | drop
}
```
- `arc` mode → verdict from the trusted sealer's sealed AAR; unsealed → unverified.
- `arc_gate` → action when not trusted-sealed: `spam` (`is_spam=True`) / `drop` (discard).

## Design choices
- **Sealer allowlist, not just "valid ARC".** A valid chain only proves *some* domain sealed it; an attacker self-seals. The outermost sealer (highest `i=`) must be allowlisted. Empty list = any valid seal (weak; only safe when the MDA is IP-restricted to the relay).
- **No plaintext-header fallback in `arc` mode** — falling back reopens the hole.
- **DNS/verify failure never spams or drops** — can't-verify ≠ forged.
- **Gate runs first among spam steps** so untrusted is authoritative.
- **Kept in `SPAM_CONFIG`** beside `inbound_auth`, reusing per-domain overrides. (These keys are auth/trust, not spam — a split is possible but out of scope.)

## Tests
`core/mda/arc.py` verifier, `arc` verdict mode, gate step — incl. a hermetic real-crypto case (synthetic seal + stub DNS). No new dependency (dkimpy already vendored). Config reference: `docs/spam-config.md`.

## Follow-up (PR2)
- `arc_gate: quarantine` — hold untrusted mail (recoverable, admin-visible) via a new `InboundMessage` state — a first-class "untrusted" bucket instead of reusing spam/drop.
- Tighten `dnsfail`: separate transient DNS from malformed/hostile input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ARC-based sender authentication for inbound messages.
  * Added `trusted_arc_sealers` configuration and `arc_gate` actions to allow, mark as spam, or drop based on verified ARC sealing.
  * Ensures forged or untrusted top-level authentication headers are ignored when ARC trust isn’t established.
* **Documentation**
  * Expanded `SPAM_CONFIG` documentation with detailed environment-variable semantics, examples, and security guidance.
* **Tests**
  * Added coverage for ARC sealer trust matching, ARC verdict derivation, and `arc_gate` pipeline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->