### PR TITLE
🐛(config) fix stale env vars and misleading NEXT_PUBLIC deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,10 @@ venv.bak/
 deploy/env/*
 !deploy/env/*.defaults
 !deploy/env/*.e2e
-env.d/terraform
+# Pre-`deploy/env` layout: a checkout updated from an older revision keeps its
+# env.d/development/*.local files behind, and they hold local secrets. Keep the
+# whole tree ignored so they can never be staged by accident.
+env.d/
 
 # npm
 node_modules

--- a/docs/env.md
+++ b/docs/env.md
@@ -580,8 +580,7 @@ channels and resumed from a Redis watermark by `run_import_task`. See
 
 | Variable | Default | Description | Required |
 |----------|---------|-------------|----------|
-| `IMAP_TIMEOUT` | `60` | Socket timeout (seconds) for IMAP connections during import. | Optional |
-| `IMAP_MAX_RETRIES` | `3` | Retry budget for transient IMAP failures during import. | Optional |
+| `MESSAGES_IMPORT_IMAP_TIMEOUT` | `60` | Socket timeout (seconds) for IMAP import connections — applied to the connect and to each subsequent command (login, SEARCH, FETCH). Tripping it surfaces as a transient error the run resumes from. Replaces `IMAP_TIMEOUT`. | Optional |
 | `MESSAGES_IMPORT_STALL_TIMEOUT` | `900` | Seconds of heartbeat silence after which the scheduler treats a running import as crashed and re-dispatches it (which resumes from its watermark). Also the run-lock TTL. Must comfortably exceed the worst-case time between progress flushes. Continuous IMAP channels use `MESSAGES_IMPORT_IMAP_POLL_INTERVAL` as their clock instead. | Optional |
 | `MESSAGES_IMPORT_IMAP_POLL_INTERVAL` | `900` | Poll cadence (seconds) for continuous IMAP imports: the scheduler re-dispatches each active continuous channel this often to pull new mail. Global (not settable per import); must be a positive integer. | Optional |
 | `MESSAGES_IMPORT_MAX_FILE_SIZE` | `53687091200` | Largest archive (bytes) an import will accept (50 GiB); checked before a worker is spent on it. `0` disables the cap. | Optional |
@@ -608,12 +607,16 @@ channels and resumed from a Redis watermark by `run_import_task`. See
 
 ### Deprecated
 
-_Set only to receive a startup deprecation warning; otherwise ignored._
+_Read by nothing any more. Unset them: a stale value silently does nothing._
 
 | Variable | Default | Description | Required | ⚠️ Deprecated |
 |----------|---------|-------------|----------|----------|
 | `PROVISIONING_API_KEY` | None | Ignored since global `api_key` Channels landed. Migrate to a global `api_key` Channel. | Optional | Removed in a future release |
 | `METRICS_API_KEY` | None | Ignored since global `api_key` Channels landed. Migrate to a global `api_key` Channel. | Optional | Removed in a future release |
+| `MESSAGES_TESTDOMAIN` | None | The TESTDOMAIN feature (catch-all domain, email mapping, auto-creation) has been removed. Use a `MailDomain` with `oidc_autojoin=True` instead. Logs a `[REMOVED]` warning at startup while still set. | Optional | Removed |
+| `MESSAGES_TESTDOMAIN_MAPPING_BASEDOMAIN` | None | Same as above. | Optional | Removed |
+| `IMAP_TIMEOUT` | None | Renamed — use `MESSAGES_IMPORT_IMAP_TIMEOUT`. No startup warning: a value left here is ignored silently. | Optional | Removed |
+| `IMAP_MAX_RETRIES` | None | Removed with the resumable importer: a failed run now resumes from its watermark instead of burning a retry budget. No startup warning. | Optional | Removed |
 
 ## Legend
 

--- a/src/frontend/src/features/config/resolve.test.ts
+++ b/src/frontend/src/features/config/resolve.test.ts
@@ -165,6 +165,30 @@ describe("resolveConfig", () => {
     expect(helpCenterWarnings).toHaveLength(1);
   });
 
+  it("names the JSON key in the warning for object-valued settings", async () => {
+    // Several widget env vars collapse into one JSON setting, so the warning
+    // must point at the key — naming the setting alone reads as a 1:1 rename.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("NEXT_PUBLIC_LAGAUFRE_WIDGET_PATH", "/gaufre");
+    vi.stubEnv("NEXT_PUBLIC_HELP_CENTER_URL", "https://help.example.com");
+    const { resolveConfig } = await importResolve();
+
+    resolveConfig(undefined);
+
+    const [gaufreWarning] = warn.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.includes("NEXT_PUBLIC_LAGAUFRE_WIDGET_PATH"));
+    expect(gaufreWarning).toContain('"path" key');
+    expect(gaufreWarning).toContain("FRONTEND_LAGAUFRE_WIDGET_CONFIG");
+    expect(gaufreWarning).toContain("JSON object");
+
+    // A scalar replacement keeps the plain wording.
+    const [helpWarning] = warn.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.includes("NEXT_PUBLIC_HELP_CENTER_URL"));
+    expect(helpWarning).toContain("the backend setting FRONTEND_HELP_CENTER_URL");
+  });
+
   it("uses hardcoded defaults when neither API nor env vars are set", async () => {
     const { resolveConfig, DEFAULT_LANGUAGES } = await importResolve();
 

--- a/src/frontend/src/features/config/resolve.ts
+++ b/src/frontend/src/features/config/resolve.ts
@@ -90,18 +90,27 @@ const warnedKeys = new Set<string>();
  * Read a deprecated `NEXT_PUBLIC_*` build-time variable as a fallback for a
  * backend-provided setting, warning once per variable. Empty strings are
  * treated as unset, matching how these variables used to behave.
+ *
+ * `jsonKey` is required whenever the replacement is a JSON object rather than a
+ * scalar (the widget configurations): several env vars then collapse into a
+ * single setting, and naming the setting alone would read as a 1:1 rename and
+ * send the operator setting it to a bare string.
  */
 const deprecatedEnv = (
   envKey: string,
   replacement: string,
   raw: string | undefined,
+  jsonKey?: string,
 ): string | undefined => {
   if (!raw) return undefined;
   if (!warnedKeys.has(envKey)) {
     warnedKeys.add(envKey);
+    const target = jsonKey
+      ? `the "${jsonKey}" key of the ${replacement} backend setting (a JSON object)`
+      : `the backend setting ${replacement}`;
     console.warn(
       `[DEPRECATED] ${envKey} is deprecated and will be removed, ` +
-        `configure the backend setting ${replacement} instead.`,
+        `configure ${target} instead.`,
     );
   }
   return raw;
@@ -166,21 +175,25 @@ const resolveFeedbackWidget = (api?: ConfigRetrieve200): FeedbackWidgetConfig =>
       "NEXT_PUBLIC_FEEDBACK_WIDGET_API_URL",
       "FRONTEND_FEEDBACK_WIDGET_CONFIG",
       import.meta.env.NEXT_PUBLIC_FEEDBACK_WIDGET_API_URL,
+      "api_url",
     ),
     path: deprecatedEnv(
       "NEXT_PUBLIC_FEEDBACK_WIDGET_PATH",
       "FRONTEND_FEEDBACK_WIDGET_CONFIG",
       import.meta.env.NEXT_PUBLIC_FEEDBACK_WIDGET_PATH,
+      "path",
     ),
     channel: deprecatedEnv(
       "NEXT_PUBLIC_FEEDBACK_WIDGET_CHANNEL",
       "FRONTEND_FEEDBACK_WIDGET_CONFIG",
       import.meta.env.NEXT_PUBLIC_FEEDBACK_WIDGET_CHANNEL,
+      "channel",
     ),
     home_channel: deprecatedEnv(
       "NEXT_PUBLIC_FEEDBACK_WIDGET_HOME_CHANNEL",
       "FRONTEND_FEEDBACK_WIDGET_CONFIG",
       import.meta.env.NEXT_PUBLIC_FEEDBACK_WIDGET_HOME_CHANNEL,
+      "home_channel",
     ),
   };
 };
@@ -194,11 +207,13 @@ const resolveLagaufreWidget = (api?: ConfigRetrieve200): LagaufreWidgetConfig =>
       "NEXT_PUBLIC_LAGAUFRE_WIDGET_API_URL",
       "FRONTEND_LAGAUFRE_WIDGET_CONFIG",
       import.meta.env.NEXT_PUBLIC_LAGAUFRE_WIDGET_API_URL,
+      "api_url",
     ),
     path: deprecatedEnv(
       "NEXT_PUBLIC_LAGAUFRE_WIDGET_PATH",
       "FRONTEND_LAGAUFRE_WIDGET_CONFIG",
       import.meta.env.NEXT_PUBLIC_LAGAUFRE_WIDGET_PATH,
+      "path",
     ),
   };
 };


### PR DESCRIPTION
Trois correctifs indépendants relevés en préparant la MEP de `development`.

## 🙈 `.gitignore` — réignorer `env.d/`

Le passage à `deploy/env/` a retiré tous les motifs `env.d` du `.gitignore` sauf `env.d/terraform`. Conséquence : tout checkout mis à jour depuis une révision antérieure conserve ses `env.d/development/*.local` orphelins, **désormais non ignorés**. Ces fichiers contiennent des secrets locaux — un `git add .` malheureux les stagerait.

## 📝 `docs/env.md` — variables d'import obsolètes

Le refactor de l'importeur a renommé `IMAP_TIMEOUT` → `MESSAGES_IMPORT_IMAP_TIMEOUT` et supprimé `IMAP_MAX_RETRIES`, mais la doc annonçait toujours les anciens noms. **Aucun des deux n'émet de warning au démarrage** : un opérateur qui suit la doc pose une variable que plus rien ne lit, sans jamais le savoir.

Les deux sont ajoutées à la section *Deprecated*, avec les variables `MESSAGES_TESTDOMAIN*` retirées dans le même cycle.

## 🐛 `resolve.ts` — warning de dépréciation trompeur

Les réglages widget/gaufre sont des **objets JSON** : 4 `NEXT_PUBLIC_FEEDBACK_WIDGET_*` et 2 `NEXT_PUBLIC_LAGAUFRE_WIDGET_*` se replient chacun sur *une clé* de `FRONTEND_FEEDBACK_WIDGET_CONFIG` / `FRONTEND_LAGAUFRE_WIDGET_CONFIG`. Le message ne nommant que le réglage, il se lisait comme un renommage 1:1 et poussait à poser une chaîne nue, que le backend rejette ensuite comme JSON invalide.

Avant :
> `[DEPRECATED] NEXT_PUBLIC_LAGAUFRE_WIDGET_PATH is deprecated and will be removed, configure the backend setting FRONTEND_LAGAUFRE_WIDGET_CONFIG instead.`

Après :
> `[DEPRECATED] NEXT_PUBLIC_LAGAUFRE_WIDGET_PATH is deprecated and will be removed, configure the "path" key of the FRONTEND_LAGAUFRE_WIDGET_CONFIG backend setting (a JSON object) instead.`

Les remplacements scalaires gardent la formulation d'origine.

## Tests

- `resolve.test.ts` : 9 tests ✅ (dont un nouveau couvrant les deux formulations)
- `eslint` sur les fichiers modifiés : ✅
- `tsc --noEmit` : 13 erreurs, toutes préexistantes et dues à `routeTree.gen.ts` absent hors build Vite ; aucune dans `features/config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)