### PR TITLE
🐛(dnscheck) relax DKIM whitespace check for DNS configs

### DIFF
--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 SPF_CHECK_CACHE_KEY_PREFIX = "dns:spf_check:"
 SPF_CHECK_CACHE_TIMEOUT = 600  # 10 minutes
 
+# DKIM tags whose values are base64: internal whitespace is not significant.
+DKIM_BASE64_TAGS = frozenset({"p", "b", "bh"})
+DKIM_VERSION = "DKIM1"
+
 
 def normalize_txt_value(value: str) -> str:
     """
@@ -27,25 +31,27 @@ def normalize_txt_value(value: str) -> str:
 
 
 def parse_dkim_tags(value: str) -> Optional[Dict[str, str]]:
-    """Parse a DKIM record into a dict of tag=value pairs.
+    """Parse a DKIM key record into a dict of tag=value pairs.
 
-    Per RFC 6376, tags are separated by semicolons, with tag=value format.
-    The v= tag MUST be first and equal to DKIM1.
-    Returns None if the record is not a valid DKIM record.
+    Per RFC 6376 3.2, tags are separated by semicolons and folding whitespace
+    is allowed on both sides of the "=". Per 3.6.1, v= is optional and defaults
+    to DKIM1, but MUST be first and equal to DKIM1 when present.
+    Returns None if the record is not a valid DKIM key record.
     """
     parts = [p.strip() for p in value.split(";") if p.strip()]
-    if not parts:
-        return None
-    # v= must be first
-    first = parts[0]
-    if not first.startswith("v=") or first.split("=", 1)[1].strip() != "DKIM1":
-        return None
     tags = {}
     for part in parts:
         if "=" not in part:
             continue
         key, val = part.split("=", 1)
         tags[key.strip()] = val.strip()
+    if not tags:
+        return None
+    if "v" in tags:
+        if tags["v"] != DKIM_VERSION or parts[0].split("=", 1)[0].strip() != "v":
+            return None
+    else:
+        tags["v"] = DKIM_VERSION
     return tags
 
 
@@ -71,6 +77,17 @@ def parse_spf_terms(value: str) -> Optional[Tuple[str, set]]:
     return (all_mechanism, other_terms)
 
 
+def _dkim_tag_equal(tag: str, expected: str, found: str) -> bool:
+    """Compare a single DKIM tag value.
+
+    Per RFC 6376, whitespace inside a base64 value must be ignored. It is
+    significant for other tags, so this cannot be applied globally.
+    """
+    if tag in DKIM_BASE64_TAGS:
+        return "".join(expected.split()) == "".join(found.split())
+    return expected == found
+
+
 def _check_dkim_semantic(
     expected_value: str, found_values: List[str]
 ) -> Optional[Dict[str, any]]:
@@ -82,7 +99,10 @@ def _check_dkim_semantic(
         found_tags = parse_dkim_tags(found_value)
         if not found_tags:
             continue
-        if not all(found_tags.get(k) == v for k, v in expected_tags.items()):
+        if not all(
+            k in found_tags and _dkim_tag_equal(k, v, found_tags[k])
+            for k, v in expected_tags.items()
+        ):
             continue
         # Check for t=y (testing mode) → insecure
         if found_tags.get("t") and "y" in found_tags["t"].split(":"):

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -21,43 +21,58 @@ SPF_CHECK_CACHE_TIMEOUT = 600  # 10 minutes
 # DKIM tags whose values are base64: internal whitespace is not significant.
 DKIM_BASE64_TAGS = frozenset({"p", "b", "bh"})
 DKIM_VERSION = "DKIM1"
+DKIM_DEFAULT_KEY_TYPE = "rsa"
+# RFC 6376 3.2 spells tag-name as ALPHA *ALNUMPUNC. Only the leading ALPHA is
+# enforced, matching dkimpy: vendor tags such as "x-foo" are used in the wild
+# and verify fine, so rejecting them would report working records as broken.
+DKIM_TAG_NAME_RE = re.compile(r"[a-zA-Z]")
 
 
 def normalize_txt_value(value: str) -> str:
     """
     Normalize a TXT record value.
+
+    Only a lone trailing semicolon is dropped, so that it does not defeat
+    exact comparison. A repeated one is kept: it makes a DKIM tag-list
+    invalid (RFC 6376 3.2) and must not normalize into a valid record.
     """
-    return re.sub(r"\;$", "", re.sub(r"\s*\;\s*", ";", value.strip('"')))
+    return re.sub(r"(?<!;);$", "", re.sub(r"\s*\;\s*", ";", value.strip('"')))
 
 
 def parse_dkim_tags(value: str) -> Optional[Dict[str, str]]:
     """Parse a DKIM key record into a dict of tag=value pairs.
 
     Per RFC 6376 3.2, tags are separated by semicolons and folding whitespace
-    is allowed on both sides of the "=". Every segment must be a named
+    is allowed on both sides of the "=". Every tag-spec must be a named
     tag=value pair, and a duplicate tag name invalidates the whole tag-list.
     Per 3.6.1, v= is optional and defaults to DKIM1, but MUST be first and
     equal to DKIM1 when present.
     Returns None if the record is not a valid DKIM key record.
     """
-    # A trailing semicolon is valid, hence dropping empty segments up front.
-    parts = [p.strip() for p in value.split(";") if p.strip()]
+    specs = value.split(";")
+    # A single trailing semicolon is allowed; any other empty tag-spec
+    # (leading, interior, or a second trailing one) makes the record invalid.
+    if len(specs) > 1 and not specs[-1].strip():
+        specs.pop()
     tags = {}
-    for part in parts:
+    for spec in specs:
+        part = spec.strip()
         if "=" not in part:
             return None
         key, val = part.split("=", 1)
         key = key.strip()
-        if not key or key in tags:
+        if not DKIM_TAG_NAME_RE.match(key) or key in tags:
             return None
         tags[key] = val.strip()
-    if not tags:
-        return None
     if "v" in tags:
-        if tags["v"] != DKIM_VERSION or parts[0].split("=", 1)[0].strip() != "v":
+        if tags["v"] != DKIM_VERSION or specs[0].split("=", 1)[0].strip() != "v":
             return None
     else:
         tags["v"] = DKIM_VERSION
+    # RFC 6376 3.6.1: k= is optional and defaults to rsa. Records omitting it
+    # are common, so applying the default keeps them from reading as a
+    # mismatch against the k= we publish.
+    tags.setdefault("k", DKIM_DEFAULT_KEY_TYPE)
     return tags
 
 

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -33,9 +33,10 @@ def normalize_txt_value(value: str) -> str:
 def parse_dkim_tags(value: str) -> Optional[Dict[str, str]]:
     """Parse a DKIM key record into a dict of tag=value pairs.
 
-    Per RFC 6376 3.2, tags are separated by semicolons and folding whitespace
-    is allowed on both sides of the "=". Per 3.6.1, v= is optional and defaults
-    to DKIM1, but MUST be first and equal to DKIM1 when present.
+    Per RFC 6376 3.2, tags are separated by semicolons, folding whitespace is
+    allowed on both sides of the "=", and a duplicate tag name invalidates the
+    whole tag-list. Per 3.6.1, v= is optional and defaults to DKIM1, but MUST
+    be first and equal to DKIM1 when present.
     Returns None if the record is not a valid DKIM key record.
     """
     parts = [p.strip() for p in value.split(";") if p.strip()]
@@ -44,7 +45,10 @@ def parse_dkim_tags(value: str) -> Optional[Dict[str, str]]:
         if "=" not in part:
             continue
         key, val = part.split("=", 1)
-        tags[key.strip()] = val.strip()
+        key = key.strip()
+        if key in tags:
+            return None
+        tags[key] = val.strip()
     if not tags:
         return None
     if "v" in tags:

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -33,20 +33,22 @@ def normalize_txt_value(value: str) -> str:
 def parse_dkim_tags(value: str) -> Optional[Dict[str, str]]:
     """Parse a DKIM key record into a dict of tag=value pairs.
 
-    Per RFC 6376 3.2, tags are separated by semicolons, folding whitespace is
-    allowed on both sides of the "=", and a duplicate tag name invalidates the
-    whole tag-list. Per 3.6.1, v= is optional and defaults to DKIM1, but MUST
-    be first and equal to DKIM1 when present.
+    Per RFC 6376 3.2, tags are separated by semicolons and folding whitespace
+    is allowed on both sides of the "=". Every segment must be a named
+    tag=value pair, and a duplicate tag name invalidates the whole tag-list.
+    Per 3.6.1, v= is optional and defaults to DKIM1, but MUST be first and
+    equal to DKIM1 when present.
     Returns None if the record is not a valid DKIM key record.
     """
+    # A trailing semicolon is valid, hence dropping empty segments up front.
     parts = [p.strip() for p in value.split(";") if p.strip()]
     tags = {}
     for part in parts:
         if "=" not in part:
-            continue
+            return None
         key, val = part.split("=", 1)
         key = key.strip()
-        if key in tags:
+        if not key or key in tags:
             return None
         tags[key] = val.strip()
     if not tags:

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -847,6 +847,14 @@ class TestParseDkimTags:
         """A TXT record with no tag=value pair is not a DKIM record."""
         assert parse_dkim_tags("not a dkim record") is None
 
+    def test_duplicate_p_tag_returns_none(self):
+        """RFC 6376 3.2: a duplicate tag name invalidates the whole tag-list."""
+        assert parse_dkim_tags("v=DKIM1; k=rsa; p=AAAA; p=MIGfMA0") is None
+
+    def test_duplicate_v_tag_returns_none(self):
+        """A repeated v= tag invalidates the record even if both values match."""
+        assert parse_dkim_tags("v=DKIM1; k=rsa; p=MIGfMA0; v=DKIM1") is None
+
     def test_v_not_first_returns_none(self):
         """Test that v= not being first tag returns None."""
         assert parse_dkim_tags("k=rsa; v=DKIM1; p=MIGfMA0") is None

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -847,6 +847,20 @@ class TestParseDkimTags:
         """A TXT record with no tag=value pair is not a DKIM record."""
         assert parse_dkim_tags("not a dkim record") is None
 
+    def test_segment_without_equals_returns_none(self):
+        """RFC 6376 3.2: every segment must be a tag=value pair."""
+        assert parse_dkim_tags("v; v=DKIM1; k=rsa; p=MIGfMA0") is None
+        assert parse_dkim_tags("k=rsa; p=MIGfMA0; trailing") is None
+
+    def test_empty_tag_name_returns_none(self):
+        """A segment with no tag name before the '=' is malformed."""
+        assert parse_dkim_tags("v=DKIM1; k=rsa; =MIGfMA0") is None
+
+    def test_trailing_semicolon_is_valid(self):
+        """A trailing semicolon is explicitly allowed by RFC 6376 3.2."""
+        result = parse_dkim_tags("v=DKIM1; k=rsa; p=MIGfMA0;")
+        assert result == {"v": "DKIM1", "k": "rsa", "p": "MIGfMA0"}
+
     def test_duplicate_p_tag_returns_none(self):
         """RFC 6376 3.2: a duplicate tag name invalidates the whole tag-list."""
         assert parse_dkim_tags("v=DKIM1; k=rsa; p=AAAA; p=MIGfMA0") is None
@@ -1041,6 +1055,40 @@ class TestDKIMSemanticComparison:
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
+
+    def test_dkim_malformed_segment_is_incorrect(self, maildomain_factory):
+        """A bare segment must not let a record through the semantic check.
+
+        The leading "v" segment would otherwise satisfy the "v= must be first"
+        rule while the record itself is malformed and fails verification.
+        """
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("v; v=DKIM1; k=rsa; p=MIGfMA0")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "incorrect"
+
+    def test_dkim_trailing_junk_segment_is_incorrect(self, maildomain_factory):
+        """A trailing segment without '=' invalidates the whole tag-list."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("k=rsa; p=MIGfMA0; trailing")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "incorrect"
 
     def test_dkim_missing_expected_tag_is_incorrect(self, maildomain_factory):
         """A tag present in the expected record but absent in DNS is a mismatch."""

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -843,6 +843,11 @@ class TestParseDkimTags:
         result = parse_dkim_tags("k=rsa; p=MIGfMA0")
         assert result == {"v": "DKIM1", "k": "rsa", "p": "MIGfMA0"}
 
+    def test_missing_k_defaults_to_rsa(self):
+        """RFC 6376 3.6.1: k= is optional in a key record and defaults to rsa."""
+        result = parse_dkim_tags("v=DKIM1; p=MIGfMA0")
+        assert result == {"v": "DKIM1", "k": "rsa", "p": "MIGfMA0"}
+
     def test_record_without_any_tag_returns_none(self):
         """A TXT record with no tag=value pair is not a DKIM record."""
         assert parse_dkim_tags("not a dkim record") is None
@@ -860,6 +865,33 @@ class TestParseDkimTags:
         """A trailing semicolon is explicitly allowed by RFC 6376 3.2."""
         result = parse_dkim_tags("v=DKIM1; k=rsa; p=MIGfMA0;")
         assert result == {"v": "DKIM1", "k": "rsa", "p": "MIGfMA0"}
+
+    def test_leading_semicolon_returns_none(self):
+        """Only a trailing semicolon is optional; a leading one is malformed."""
+        assert parse_dkim_tags("; v=DKIM1; k=rsa; p=MIGfMA0") is None
+
+    def test_interior_empty_tag_spec_returns_none(self):
+        """An empty tag-spec between two others is malformed."""
+        assert parse_dkim_tags("v=DKIM1; k=rsa;; p=MIGfMA0") is None
+
+    def test_second_trailing_semicolon_returns_none(self):
+        """RFC 6376 3.2 allows one optional trailing semicolon, not two."""
+        assert parse_dkim_tags("v=DKIM1; k=rsa; p=MIGfMA0;;") is None
+
+    def test_tag_name_not_starting_with_alpha_returns_none(self):
+        """RFC 6376 3.2: a tag name must start with an ALPHA."""
+        assert parse_dkim_tags("v=DKIM1; 2x=junk; k=rsa; p=MIGfMA0") is None
+        assert parse_dkim_tags("v=DKIM1; _x=junk; k=rsa; p=MIGfMA0") is None
+
+    def test_vendor_tag_name_is_accepted(self):
+        """Tags like "x-foo" are used in the wild and verify, so keep them."""
+        result = parse_dkim_tags("v=DKIM1; x-vendor=junk; k=rsa; p=MIGfMA0")
+        assert result == {
+            "v": "DKIM1",
+            "x-vendor": "junk",
+            "k": "rsa",
+            "p": "MIGfMA0",
+        }
 
     def test_duplicate_p_tag_returns_none(self):
         """RFC 6376 3.2: a duplicate tag name invalidates the whole tag-list."""
@@ -1055,6 +1087,51 @@ class TestDKIMSemanticComparison:
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
+
+    def test_dkim_without_k_tag_is_correct(self, maildomain_factory):
+        """A record omitting the optional k= tag signs as rsa and is valid."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("v=DKIM1; p=MIGfMA0")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_dkim_missing_k_does_not_match_ed25519(self, maildomain_factory):
+        """The rsa default must not satisfy an expected ed25519 key."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=ed25519; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("v=DKIM1; p=MIGfMA0")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "incorrect"
+
+    def test_dkim_double_trailing_semicolon_is_incorrect(self, maildomain_factory):
+        """Normalization must not turn a repeated trailing ';' into a valid one."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("v=DKIM1; k=rsa; p=MIGfMA0;;")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "incorrect"
 
     def test_dkim_malformed_segment_is_incorrect(self, maildomain_factory):
         """A bare segment must not let a record through the semantic check.

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -833,6 +833,20 @@ class TestParseDkimTags:
         result = parse_dkim_tags("v=DKIM1; k=rsa; p=MIGfMA0; t=y:s")
         assert result == {"v": "DKIM1", "k": "rsa", "p": "MIGfMA0", "t": "y:s"}
 
+    def test_whitespace_around_equals(self):
+        """RFC 6376 3.2 allows folding whitespace on both sides of the '='."""
+        result = parse_dkim_tags("v = DKIM1; k = rsa; p = MIGfMA0")
+        assert result == {"v": "DKIM1", "k": "rsa", "p": "MIGfMA0"}
+
+    def test_missing_v_defaults_to_dkim1(self):
+        """RFC 6376 3.6.1: v= is optional in a key record and defaults to DKIM1."""
+        result = parse_dkim_tags("k=rsa; p=MIGfMA0")
+        assert result == {"v": "DKIM1", "k": "rsa", "p": "MIGfMA0"}
+
+    def test_record_without_any_tag_returns_none(self):
+        """A TXT record with no tag=value pair is not a DKIM record."""
+        assert parse_dkim_tags("not a dkim record") is None
+
     def test_v_not_first_returns_none(self):
         """Test that v= not being first tag returns None."""
         assert parse_dkim_tags("k=rsa; v=DKIM1; p=MIGfMA0") is None
@@ -954,6 +968,83 @@ class TestDKIMSemanticComparison:
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
             mock_resolve.return_value = _txt_answer("v=DKIM1; k=rsa; p=WRONG_KEY")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "incorrect"
+
+    def test_dkim_key_with_internal_whitespace_is_correct(self, maildomain_factory):
+        """Whitespace inside the base64 key is not significant (RFC 6376)."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer(
+                "v=DKIM1; k=rsa; p=MIGfMA0 GCSqGSIb3"
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_dkim_whitespace_in_other_tags_is_significant(self, maildomain_factory):
+        """Internal whitespace outside base64 tags still marks a mismatch."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("v=DKIM1; k=r sa; p=MIGfMA0")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "incorrect"
+
+    def test_dkim_whitespace_before_equals_is_correct(self, maildomain_factory):
+        """Folding whitespace before the '=' is legal, including on v= (RFC 6376)."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("v = DKIM1; k=rsa; p = MIGfMA0")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_dkim_without_v_tag_is_correct(self, maildomain_factory):
+        """A key record omitting the optional v= tag is still valid (RFC 6376)."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("k=rsa; p=MIGfMA0")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_dkim_missing_expected_tag_is_incorrect(self, maildomain_factory):
+        """A tag present in the expected record but absent in DNS is a mismatch."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "selector._domainkey",
+            "value": "v=DKIM1; k=rsa; p=MIGfMA0",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("v=DKIM1; k=rsa")
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "incorrect"


### PR DESCRIPTION
Whitespace is ignored in DKIM keys but that wasn't implemented in our validator, which showed "Invalid" in the admin UI for some keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DKIM record parsing with default `DKIM1` version and `rsa` key type when omitted.
  * Added validation for tag names, malformed segments, duplicate tags, invalid version placement, and semicolon formatting.
  * DKIM comparisons now ignore whitespace within base64-encoded values while preserving exact comparisons for other values.
  * Improved handling of optional tags, vendor-specific tags, trailing content, and malformed records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->