### PR TITLE
🐛(spf) improve SPF checker with more edge cases

### DIFF
--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -425,7 +425,7 @@ def _resolve_spf_includes(
         (resolved_domains, visited_domains, transient_failures, error) where
         visited_domains are the ones we got to look up, transient_failures the
         ones whose lookup failed in a way that may well succeed next time, and
-        error is None on success, or a string describing the issue
+        error is None on success, or a string describing the first problem met
         ("limit_reached", "void_limit_reached", "duplicate:domain.com").
     """
     queue = collections.deque()
@@ -438,10 +438,13 @@ def _resolve_spf_includes(
     transient = set()
     lookup_count = 0
     void_count = 0
+    # Kept aside rather than returned on the spot, so that a dead end on one
+    # branch neither hides an earlier problem nor cuts the walk short.
+    error = None
 
     while queue:
         if lookup_count >= max_lookups:
-            return resolved, visited, transient, "limit_reached"
+            return resolved, visited, transient, error or "limit_reached"
 
         include_domain = queue.popleft()
         if include_domain in visited:
@@ -465,7 +468,7 @@ def _resolve_spf_includes(
             logger.debug("No TXT record for %s", include_domain)
             void_count += 1
             if void_count > max_void_lookups:
-                return resolved, visited, transient, "void_limit_reached"
+                return resolved, visited, transient, error or "void_limit_reached"
             continue
         except (dns.resolver.Timeout, dns.resolver.NoNameservers):
             logger.debug("DNS resolution failed for %s, may retry", include_domain)
@@ -479,7 +482,15 @@ def _resolve_spf_includes(
             continue
 
         if len(spf_records) > 1:
-            return resolved, visited, transient, f"duplicate:{include_domain}"
+            # A name publishing two records permerrors (RFC 7208 4.5), so this
+            # include delegates nothing — the same dead end a malformed record
+            # below is, and walked past the same way. Only a third party can
+            # be one: the customer's own duplicates never reach here, they are
+            # caught before the walk starts. Stopping would let where a third
+            # party sits in the record decide whether we find our own include.
+            logger.debug("Duplicate SPF records at %s", include_domain)
+            error = error or f"duplicate:{include_domain}"
+            continue
 
         if not spf_records:
             continue
@@ -498,7 +509,7 @@ def _resolve_spf_includes(
             if child_domain not in visited:
                 queue.append(child_domain)
 
-    return resolved, visited, transient, None
+    return resolved, visited, transient, error
 
 
 def _txt_record_value(rr) -> str:

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -39,6 +39,15 @@ SPF_VERSION_RE = re.compile(rf"{SPF_VERSION}( |$)", re.IGNORECASE)
 SPF_QUALIFIERS = "+-?~"
 # RFC 7208 4.6.1: a term name ends at the first ":", "=" or "/".
 SPF_TERM_NAME_RE = re.compile(r"[^:=/]*")
+# RFC 7208 5: the complete set of mechanisms. SPF has no extension point for
+# new ones, so a term that is neither one of these nor a "name=value"
+# modifier is a syntax error.
+SPF_MECHANISMS = frozenset({"all", "include", "a", "mx", "ptr", "ip4", "ip6", "exists"})
+# RFC 7208 12: "include", "exists", "ip4" and "ip6" spell a mandatory ":"
+# argument, "all" takes none, and "a", "mx" and "ptr" take an optional one.
+SPF_MECHANISMS_NEEDING_ARGUMENT = frozenset({"include", "exists", "ip4", "ip6"})
+# RFC 7208 6: each of these may appear at most once, on pain of permerror.
+SPF_SINGLETON_MODIFIERS = ("redirect", "exp")
 # Ordered from most permissive to strictest (RFC 7208 4.6.2).
 SPF_ALL_STRICTNESS = {"+all": 0, "?all": 1, "~all": 2, "-all": 3}
 SPF_ALL_MECHANISMS = frozenset(SPF_ALL_STRICTNESS)
@@ -147,9 +156,43 @@ def parse_spf_terms(value: str) -> Optional[Tuple[str, set]]:
         if canonical in SPF_ALL_MECHANISMS:
             if all_mechanism is None:
                 all_mechanism = canonical
-        else:
+        # Mechanisms after the first "all" are never tested (RFC 7208 5.1).
+        # Modifiers are not mechanisms and still apply (4.6.3): a canonical
+        # mechanism always carries its qualifier, a modifier never does.
+        elif all_mechanism is None or canonical[0] not in SPF_QUALIFIERS:
             other_terms.add(canonical)
     return (all_mechanism, other_terms)
+
+
+def spf_syntax_is_valid(value: str) -> bool:
+    """Whether an SPF record's terms are well formed.
+
+    A syntax error anywhere makes receivers return permerror for the whole
+    record (RFC 7208 4.6), so the delegation it describes never takes effect.
+    Term names and the presence of their arguments are checked; the contents
+    of an argument (that an IP parses, that a CIDR is in range) are not. Those
+    are permerrors too, but validating them means reimplementing the grammar,
+    and being wrong there would report working records as broken.
+    """
+    if not is_spf_record(value):
+        return False
+    modifiers = collections.Counter()
+    for term in value[len(SPF_VERSION) :].split():
+        _qualifier, name, argument = _parse_spf_term(term)
+        if argument.startswith("="):
+            # Unrecognized modifiers must be ignored whatever they are (6),
+            # so only their names are worth counting.
+            modifiers[name] += 1
+            continue
+        if name not in SPF_MECHANISMS:
+            return False
+        if name in SPF_MECHANISMS_NEEDING_ARGUMENT and not argument.startswith(":"):
+            return False
+        if name == "all" and argument:
+            return False
+        if argument == ":":
+            return False
+    return all(modifiers[name] <= 1 for name in SPF_SINGLETON_MODIFIERS)
 
 
 def _dkim_tag_equal(tag: str, expected: str, found: str) -> bool:
@@ -199,6 +242,13 @@ def _check_spf(expected_value: str, found_values: List[str]) -> Dict[str, any]:
     found_spf_values = [v for v in found_values if is_spf_record(v)]
     if not found_spf_values:
         return {"status": "missing", "found": found_values}
+
+    # A record receivers permerror on delegates nothing, whatever it lists.
+    # This is deliberately kept apart from is_spf_record: RFC 7208 4.5 selects
+    # records on the version section alone, before 4.6 validates them, so a
+    # malformed record still counts towards the duplicate check.
+    if not all(spf_syntax_is_valid(v) for v in found_spf_values):
+        return {"status": "incorrect", "found": found_values}
 
     # If there are expected includes, check they resolve via BFS.
     # This is the primary signal: includes being set up is what matters.
@@ -271,9 +321,10 @@ def _extract_include_domains(spf_value: str) -> List[str]:
 
     Both the "include:" mechanism and the "redirect=" modifier hand the
     decision over to another domain's record (RFC 7208 5.2 and 6.1), so a
-    domain reached either way counts. An "all" mechanism anywhere in the
-    record makes the redirect inoperative though (RFC 7208 5.1 and 6.1), and
-    a record it never reaches delegates nothing.
+    domain reached either way counts. An "all" mechanism ends that though:
+    it always matches, so an include listed after it is never tested (5.1),
+    and a redirect is inoperative when an "all" appears anywhere at all in
+    the record (5.1 and 6.1), wherever the two sit relative to each other.
     """
     includes = []
     redirects = []
@@ -282,7 +333,7 @@ def _extract_include_domains(spf_value: str) -> List[str]:
         qualifier, name, argument = _parse_spf_term(term)
         if name == "all" and not argument:
             has_all = True
-        elif name == "include" and argument.startswith(":"):
+        elif name == "include" and argument.startswith(":") and not has_all:
             includes.append(argument[1:])
         elif name == "redirect" and not qualifier and argument.startswith("="):
             redirects.append(argument[1:])
@@ -294,19 +345,22 @@ def _extract_include_domains(spf_value: str) -> List[str]:
 
 
 def _resolve_spf_includes(
-    found_values: List[str], max_lookups: int = 10
+    found_values: List[str], max_lookups: int = 10, max_void_lookups: int = 2
 ) -> Tuple[set, set, set, Optional[str]]:
     """BFS through SPF include chains, return all domains with valid SPF records.
 
     Seeds from the domains found_values delegate to, follows the chain via BFS.
-    Per RFC 7208, stops after max_lookups DNS lookups.
+    Per RFC 7208 4.6.4, stops after max_lookups DNS lookups, and after
+    max_void_lookups of those came back with nothing. Both caps are what keeps
+    a record from turning us into a DNS amplifier aimed at whatever names it
+    lists, which need not even exist (RFC 7208 11.1).
 
     Returns:
         (resolved_domains, visited_domains, transient_failures, error) where
         visited_domains are the ones we got to look up, transient_failures the
         ones whose lookup failed in a way that may well succeed next time, and
         error is None on success, or a string describing the issue
-        ("limit_reached", "duplicate:domain.com").
+        ("limit_reached", "void_limit_reached", "duplicate:domain.com").
     """
     queue = collections.deque()
     for found_value in found_values:
@@ -317,6 +371,7 @@ def _resolve_spf_includes(
     resolved = set()
     transient = set()
     lookup_count = 0
+    void_count = 0
 
     while queue:
         if lookup_count >= max_lookups:
@@ -337,8 +392,14 @@ def _resolve_spf_includes(
             ]
         except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
             # An include pointing at a name that publishes nothing is a
-            # settled answer, not a failure to look it up.
+            # settled answer, not a failure to look it up — but it is a "void
+            # lookup", and a run of them is the amplification RFC 7208 4.6.4
+            # caps. A name that answers without an SPF record is not one: the
+            # query did come back with something.
             logger.debug("No TXT record for %s", include_domain)
+            void_count += 1
+            if void_count > max_void_lookups:
+                return resolved, visited, transient, "void_limit_reached"
             continue
         except (dns.resolver.Timeout, dns.resolver.NoNameservers):
             logger.debug("DNS resolution failed for %s, may retry", include_domain)

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 from django.core.cache import cache
 
 import dns.resolver
+from sentry_sdk import capture_exception
 
 from core.models import MailDomain
 
@@ -30,22 +31,24 @@ DKIM_TAG_NAME_RE = re.compile(r"[a-zA-Z]")
 SPF_VERSION = "v=spf1"
 # RFC 7208 4.5: a record starts with a version section of exactly "v=spf1",
 # terminated by a space or the end of the record, so "v=spf10" is not one.
-# Per Section 12, ABNF literals are case-insensitive: "V=sPf1" is.
-SPF_VERSION_RE = re.compile(rf"{SPF_VERSION}(\s|$)", re.IGNORECASE)
+# Per Section 12, ABNF literals are case-insensitive: "V=sPf1" is. Only a
+# space terminates it: RFC 7208 4.6.1 separates terms with SP alone, and a
+# record broken by another control character is one receivers reject too.
+SPF_VERSION_RE = re.compile(rf"{SPF_VERSION}( |$)", re.IGNORECASE)
 # RFC 7208 4.6.1: directive = [ qualifier ] mechanism.
 SPF_QUALIFIERS = "+-?~"
 # RFC 7208 4.6.1: a term name ends at the first ":", "=" or "/".
 SPF_TERM_NAME_RE = re.compile(r"[^:=/]*")
-SPF_ALL_MECHANISMS = frozenset({"+all", "-all", "~all", "?all"})
 # Ordered from most permissive to strictest (RFC 7208 4.6.2).
 SPF_ALL_STRICTNESS = {"+all": 0, "?all": 1, "~all": 2, "-all": 3}
+SPF_ALL_MECHANISMS = frozenset(SPF_ALL_STRICTNESS)
 
 # RFC 7208 3.3 and RFC 6376 3.6.2: the strings of a single TXT record are
 # concatenated with no separator, which is how records over 255 octets are
 # published. Some local resolvers (e.g. systemd-resolved) instead merge
 # separate TXT records into one RR; those show up as a later string opening
 # its own record, and have to stay apart.
-TXT_RECORD_START_RE = re.compile(r"v=(spf1(\s|$)|DMARC1\b)", re.IGNORECASE)
+TXT_RECORD_START_RE = re.compile(r"v=(spf1( |$)|DMARC1\b)", re.IGNORECASE)
 
 
 def normalize_txt_value(value: str) -> str:
@@ -134,8 +137,10 @@ def parse_spf_terms(value: str) -> Optional[Tuple[str, set]]:
 
     Returns (all_mechanism, other_terms) where all_mechanism is the canonical
     "-all", "~all", "+all" or "?all" (a bare "all" means "+all"), or None when
-    the record has no "all" at all. Terms are canonicalized, so ordering,
-    letter case and implicit qualifiers do not matter.
+    the record has no "all" at all. Only the first one counts: "all" always
+    matches, so anything after it is never tested (RFC 7208 5.1). Terms are
+    canonicalized, so ordering, letter case and implicit qualifiers do not
+    matter.
     Returns None if not a valid SPF record.
     """
     if not is_spf_record(value):
@@ -145,7 +150,8 @@ def parse_spf_terms(value: str) -> Optional[Tuple[str, set]]:
     for term in value[len(SPF_VERSION) :].split():
         canonical = _canonical_spf_term(term)
         if canonical in SPF_ALL_MECHANISMS:
-            all_mechanism = canonical
+            if all_mechanism is None:
+                all_mechanism = canonical
         else:
             other_terms.add(canonical)
     return (all_mechanism, other_terms)
@@ -202,13 +208,15 @@ def _check_spf(expected_value: str, found_values: List[str]) -> Dict[str, any]:
     # If there are expected includes, check they resolve via BFS.
     # This is the primary signal: includes being set up is what matters.
     if expected_includes:
-        resolved, transient, error = _resolve_spf_includes(found_spf_values)
+        resolved, visited, transient, error = _resolve_spf_includes(found_spf_values)
         if not expected_includes <= resolved:
             # A problem met while walking the chain only matters when it is
             # what kept our own include out of reach: a third party
             # duplicating its record, or a chain too long past our include,
             # says nothing about the record we asked the customer to publish.
-            if transient:
+            # A branch that failed transiently is unexplored, so unless every
+            # include we expect was looked up and settled, it may sit there.
+            if transient and not expected_includes <= visited - transient:
                 return {
                     "status": "error",
                     "error": "DNS query failed while following the SPF chain",
@@ -265,37 +273,42 @@ def _extract_include_domains(spf_value: str) -> List[str]:
 
     Both the "include:" mechanism and the "redirect=" modifier hand the
     decision over to another domain's record (RFC 7208 5.2 and 6.1), so a
-    domain reached either way counts.
+    domain reached either way counts. An "all" mechanism anywhere in the
+    record makes the redirect inoperative though (RFC 7208 5.1 and 6.1), and
+    a record it never reaches delegates nothing.
     """
-    domains = []
+    includes = []
+    redirects = []
+    has_all = False
     for term in spf_value.split():
         qualifier, name, argument = _parse_spf_term(term)
-        if name == "include" and argument.startswith(":"):
-            domain = argument[1:]
+        if name == "all" and not argument:
+            has_all = True
+        elif name == "include" and argument.startswith(":"):
+            includes.append(argument[1:])
         elif name == "redirect" and not qualifier and argument.startswith("="):
-            domain = argument[1:]
-        else:
-            continue
-        # A macro only expands at evaluation time, so it names no domain we
-        # could look up here.
-        if domain and "%" not in domain:
-            domains.append(domain)
-    return domains
+            redirects.append(argument[1:])
+    # A redirect is only reached once every mechanism failed to match, so it
+    # comes last. A macro only expands at evaluation time, so it names no
+    # domain we could look up here.
+    domains = includes if has_all else includes + redirects
+    return [domain for domain in domains if domain and "%" not in domain]
 
 
 def _resolve_spf_includes(
     found_values: List[str], max_lookups: int = 10
-) -> Tuple[set, set, Optional[str]]:
+) -> Tuple[set, set, set, Optional[str]]:
     """BFS through SPF include chains, return all domains with valid SPF records.
 
     Seeds from the domains found_values delegate to, follows the chain via BFS.
     Per RFC 7208, stops after max_lookups DNS lookups.
 
     Returns:
-        (resolved_domains, transient_failures, error) where transient_failures
-        holds the domains whose lookup failed in a way that may well succeed
-        next time, and error is None on success, or a string describing the
-        issue ("limit_reached", "duplicate:domain.com").
+        (resolved_domains, visited_domains, transient_failures, error) where
+        visited_domains are the ones we got to look up, transient_failures the
+        ones whose lookup failed in a way that may well succeed next time, and
+        error is None on success, or a string describing the issue
+        ("limit_reached", "duplicate:domain.com").
     """
     queue = collections.deque()
     for found_value in found_values:
@@ -309,7 +322,7 @@ def _resolve_spf_includes(
 
     while queue:
         if lookup_count >= max_lookups:
-            return resolved, transient, "limit_reached"
+            return resolved, visited, transient, "limit_reached"
 
         include_domain = queue.popleft()
         if include_domain in visited:
@@ -325,16 +338,24 @@ def _resolve_spf_includes(
                 for value in _txt_record_values(rr)
                 if is_spf_record(value)
             ]
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+            # An include pointing at a name that publishes nothing is a
+            # settled answer, not a failure to look it up.
+            logger.debug("No TXT record for %s", include_domain)
+            continue
         except (dns.resolver.Timeout, dns.resolver.NoNameservers):
-            logger.debug("DNS resolution timed out for %s", include_domain)
+            logger.debug("DNS resolution failed for %s, may retry", include_domain)
             transient.add(include_domain)
             continue
-        except Exception:  # pylint: disable=broad-exception-caught
-            logger.debug("DNS resolution failed for %s", include_domain)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "Unexpected error resolving %s: %s", include_domain, exc, exc_info=True
+            )
+            capture_exception(exc)
             continue
 
         if len(spf_records) > 1:
-            return resolved, transient, f"duplicate:{include_domain}"
+            return resolved, visited, transient, f"duplicate:{include_domain}"
 
         if not spf_records:
             continue
@@ -344,7 +365,7 @@ def _resolve_spf_includes(
             if child_domain not in visited:
                 queue.append(child_domain)
 
-    return resolved, transient, None
+    return resolved, visited, transient, None
 
 
 def _txt_record_values(rr) -> List[str]:
@@ -352,9 +373,11 @@ def _txt_record_values(rr) -> List[str]:
 
     Its strings belong to one record and are concatenated, unless a later one
     opens a record of its own — the sign of a resolver having merged separate
-    records into one RR.
+    records into one RR. SPF records are US-ASCII (RFC 7208 3.1), but an
+    unrelated TXT record at the same name may hold anything, and that is no
+    reason to fail the whole check.
     """
-    strings = [s.decode() for s in rr.strings]
+    strings = [s.decode(errors="replace") for s in rr.strings]
     if any(TXT_RECORD_START_RE.match(s) for s in strings[1:]):
         return [normalize_txt_value(s) for s in strings]
     return [normalize_txt_value("".join(strings))]
@@ -372,7 +395,9 @@ def _resolve_dns_values(record_type, target, query_name):
         for rr in answers.rrset:
             if target.endswith("._domainkey"):
                 # DKIM: concatenate strings (long key split across strings)
-                values.append(normalize_txt_value(b"".join(rr.strings).decode()))
+                values.append(
+                    normalize_txt_value(b"".join(rr.strings).decode(errors="replace"))
+                )
             else:
                 values.extend(_txt_record_values(rr))
         return values
@@ -383,17 +408,12 @@ def _resolve_dns_values(record_type, target, query_name):
 
 def _check_txt_security(expected_value, found_values):
     """Check for duplicate/insecure SPF and DMARC records. Returns result or None."""
-    # SPF duplicate and insecure checks
+    # SPF duplicate check. Whether the policy is strong enough is left to
+    # _check_spf: a weak "all" only reads as "insecure" once the delegation
+    # is known to be in place, and "insecure" is a status we still send on.
     if is_spf_record(expected_value):
-        spf_records = [v for v in found_values if is_spf_record(v)]
-        if len(spf_records) > 1:
+        if len([v for v in found_values if is_spf_record(v)]) > 1:
             return {"status": "duplicate", "found": found_values}
-        expected_all, _ = parse_spf_terms(expected_value)
-        if expected_all == "-all":
-            for spf in spf_records:
-                found_all, _ = parse_spf_terms(spf)
-                if found_all in ("+all", "?all"):
-                    return {"status": "insecure", "found": found_values}
 
     # DMARC duplicate and insecure checks
     if expected_value.startswith("v=DMARC1"):
@@ -502,7 +522,9 @@ def _check_spf_status_uncached(maildomain: MailDomain) -> Tuple[bool, bool]:
     spf_records = [
         r
         for r in expected_records
-        if r["type"].upper() == "TXT" and is_spf_record(r["value"])
+        # check_single_record normalizes before matching, so a configured
+        # value carrying its zone-file quotes has to be recognized here too.
+        if r["type"].upper() == "TXT" and is_spf_record(normalize_txt_value(r["value"]))
     ]
     if not spf_records:
         return True, True

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -27,6 +27,26 @@ DKIM_DEFAULT_KEY_TYPE = "rsa"
 # and verify fine, so rejecting them would report working records as broken.
 DKIM_TAG_NAME_RE = re.compile(r"[a-zA-Z]")
 
+SPF_VERSION = "v=spf1"
+# RFC 7208 4.5: a record starts with a version section of exactly "v=spf1",
+# terminated by a space or the end of the record, so "v=spf10" is not one.
+# Per Section 12, ABNF literals are case-insensitive: "V=sPf1" is.
+SPF_VERSION_RE = re.compile(rf"{SPF_VERSION}(\s|$)", re.IGNORECASE)
+# RFC 7208 4.6.1: directive = [ qualifier ] mechanism.
+SPF_QUALIFIERS = "+-?~"
+# RFC 7208 4.6.1: a term name ends at the first ":", "=" or "/".
+SPF_TERM_NAME_RE = re.compile(r"[^:=/]*")
+SPF_ALL_MECHANISMS = frozenset({"+all", "-all", "~all", "?all"})
+# Ordered from most permissive to strictest (RFC 7208 4.6.2).
+SPF_ALL_STRICTNESS = {"+all": 0, "?all": 1, "~all": 2, "-all": 3}
+
+# RFC 7208 3.3 and RFC 6376 3.6.2: the strings of a single TXT record are
+# concatenated with no separator, which is how records over 255 octets are
+# published. Some local resolvers (e.g. systemd-resolved) instead merge
+# separate TXT records into one RR; those show up as a later string opening
+# its own record, and have to stay apart.
+TXT_RECORD_START_RE = re.compile(r"v=(spf1(\s|$)|DMARC1\b)", re.IGNORECASE)
+
 
 def normalize_txt_value(value: str) -> str:
     """
@@ -76,25 +96,58 @@ def parse_dkim_tags(value: str) -> Optional[Dict[str, str]]:
     return tags
 
 
-def parse_spf_terms(value: str) -> Optional[Tuple[str, set]]:
-    """Parse an SPF record into its qualifier-all and set of other terms.
+def is_spf_record(value: str) -> bool:
+    """Whether a TXT value is an SPF record, per the RFC 7208 4.5 rules."""
+    return SPF_VERSION_RE.match(value) is not None
 
-    Per RFC 7208, v=spf1 must be first. Returns (all_mechanism, other_terms)
-    where all_mechanism is e.g. "-all", "~all", "+all", "?all" or None,
-    and other_terms is the set of remaining mechanisms/modifiers.
+
+def _parse_spf_term(term: str) -> Tuple[str, str, str]:
+    """Split an SPF term into (qualifier, name, argument).
+
+    A directive is an optional "+"/"-"/"?"/"~" qualifier followed by a
+    mechanism, while a modifier is a bare "name=value" and takes no qualifier
+    (RFC 7208 4.6.1). Names are case-insensitive, and so are the domains they
+    carry; an argument holding a macro keeps its case, since "%{s}" and "%{S}"
+    do not expand the same way. The argument keeps its separator.
+    """
+    qualifier = ""
+    if term and term[0] in SPF_QUALIFIERS:
+        qualifier, term = term[0], term[1:]
+    name = SPF_TERM_NAME_RE.match(term).group()
+    argument = term[len(name) :]
+    if "%" not in argument:
+        argument = argument.lower()
+    return qualifier, name.lower(), argument
+
+
+def _canonical_spf_term(term: str) -> str:
+    """Canonical form of an SPF term, so that case and an implicit "+" (which
+    is what an omitted qualifier means) do not make equivalent terms differ."""
+    qualifier, name, argument = _parse_spf_term(term)
+    if argument.startswith("="):  # a modifier, which takes no qualifier
+        return f"{name}{argument}"
+    return f"{qualifier or '+'}{name}{argument}"
+
+
+def parse_spf_terms(value: str) -> Optional[Tuple[str, set]]:
+    """Parse an SPF record into its qualified "all" and set of other terms.
+
+    Returns (all_mechanism, other_terms) where all_mechanism is the canonical
+    "-all", "~all", "+all" or "?all" (a bare "all" means "+all"), or None when
+    the record has no "all" at all. Terms are canonicalized, so ordering,
+    letter case and implicit qualifiers do not matter.
     Returns None if not a valid SPF record.
     """
-    if not value.startswith("v=spf1"):
+    if not is_spf_record(value):
         return None
-    rest = value[len("v=spf1") :].strip()
-    terms = rest.split()
     all_mechanism = None
     other_terms = set()
-    for term in terms:
-        if term in ("-all", "~all", "+all", "?all", "all"):
-            all_mechanism = term
+    for term in value[len(SPF_VERSION) :].split():
+        canonical = _canonical_spf_term(term)
+        if canonical in SPF_ALL_MECHANISMS:
+            all_mechanism = canonical
         else:
-            other_terms.add(term)
+            other_terms.add(canonical)
     return (all_mechanism, other_terms)
 
 
@@ -142,19 +195,27 @@ def _check_spf(expected_value: str, found_values: List[str]) -> Dict[str, any]:
     expected_includes = set(_extract_include_domains(expected_value))
 
     # Check there's at least one valid SPF record in found values
-    found_spf_values = [v for v in found_values if parse_spf_terms(v)]
+    found_spf_values = [v for v in found_values if is_spf_record(v)]
     if not found_spf_values:
         return {"status": "missing", "found": found_values}
 
     # If there are expected includes, check they resolve via BFS.
     # This is the primary signal: includes being set up is what matters.
     if expected_includes:
-        resolved, error = _resolve_spf_includes(found_values)
-        if error and error.startswith("duplicate:"):
-            return {"status": "duplicate", "found": found_values}
-        if error == "limit_reached":
-            return {"status": "incorrect", "found": found_values}
+        resolved, transient, error = _resolve_spf_includes(found_spf_values)
         if not expected_includes <= resolved:
+            # A problem met while walking the chain only matters when it is
+            # what kept our own include out of reach: a third party
+            # duplicating its record, or a chain too long past our include,
+            # says nothing about the record we asked the customer to publish.
+            if transient:
+                return {
+                    "status": "error",
+                    "error": "DNS query failed while following the SPF chain",
+                    "found": found_values,
+                }
+            if error and error.startswith("duplicate:"):
+                return {"status": "duplicate", "found": found_values}
             return {"status": "incorrect", "found": found_values}
         # Includes resolve — check if "all" mechanism is acceptable
         if _found_all_matches(expected_all, found_spf_values):
@@ -164,15 +225,27 @@ def _check_spf(expected_value: str, found_values: List[str]) -> Dict[str, any]:
     # No includes: direct terms comparison (order-independent, ~all accepted for -all)
     for found_value in found_spf_values:
         found_all, found_terms = parse_spf_terms(found_value)
-        all_ok = expected_all == found_all or (
-            expected_all == "-all" and found_all == "~all"
-        )
         if expected_terms <= found_terms:
-            if all_ok:
+            if _all_is_acceptable(expected_all, found_all):
                 return {"status": "correct", "found": found_values}
             return {"status": "insecure", "found": found_values}
 
     return {"status": "incorrect", "found": found_values}
+
+
+def _all_is_acceptable(expected_all: Optional[str], found_all: Optional[str]) -> bool:
+    """Whether a found "all" mechanism is at least as strict as expected.
+
+    "~all" also passes for an expected "-all": softfail is where most domains
+    start, and it does not keep us from sending.
+    """
+    if expected_all == found_all:
+        return True
+    if expected_all is None or found_all is None:
+        return False
+    if expected_all == "-all" and found_all == "~all":
+        return True
+    return SPF_ALL_STRICTNESS[found_all] > SPF_ALL_STRICTNESS[expected_all]
 
 
 def _found_all_matches(expected_all: str, found_values: List[str]) -> bool:
@@ -182,46 +255,61 @@ def _found_all_matches(expected_all: str, found_values: List[str]) -> bool:
         if not found:
             continue
         found_all, _ = found
-        if expected_all == found_all or (
-            expected_all == "-all" and found_all == "~all"
-        ):
+        if _all_is_acceptable(expected_all, found_all):
             return True
     return False
 
 
 def _extract_include_domains(spf_value: str) -> List[str]:
-    """Extract include: domains from an SPF value, preserving order."""
-    return [
-        term[len("include:") :]
-        for term in spf_value.split()
-        if term.startswith("include:")
-    ]
+    """Extract the domains an SPF record delegates to, preserving order.
+
+    Both the "include:" mechanism and the "redirect=" modifier hand the
+    decision over to another domain's record (RFC 7208 5.2 and 6.1), so a
+    domain reached either way counts.
+    """
+    domains = []
+    for term in spf_value.split():
+        qualifier, name, argument = _parse_spf_term(term)
+        if name == "include" and argument.startswith(":"):
+            domain = argument[1:]
+        elif name == "redirect" and not qualifier and argument.startswith("="):
+            domain = argument[1:]
+        else:
+            continue
+        # A macro only expands at evaluation time, so it names no domain we
+        # could look up here.
+        if domain and "%" not in domain:
+            domains.append(domain)
+    return domains
 
 
 def _resolve_spf_includes(
     found_values: List[str], max_lookups: int = 10
-) -> Tuple[set, Optional[str]]:
+) -> Tuple[set, set, Optional[str]]:
     """BFS through SPF include chains, return all domains with valid SPF records.
 
-    Seeds from include: domains in found_values, follows the chain via BFS.
+    Seeds from the domains found_values delegate to, follows the chain via BFS.
     Per RFC 7208, stops after max_lookups DNS lookups.
 
     Returns:
-        (resolved_domains, error) where error is None on success, or a string
-        describing the issue ("limit_reached", "duplicate:domain.com").
+        (resolved_domains, transient_failures, error) where transient_failures
+        holds the domains whose lookup failed in a way that may well succeed
+        next time, and error is None on success, or a string describing the
+        issue ("limit_reached", "duplicate:domain.com").
     """
     queue = collections.deque()
     for found_value in found_values:
-        if found_value.startswith("v=spf1"):
+        if is_spf_record(found_value):
             queue.extend(_extract_include_domains(found_value))
 
     visited = set()
     resolved = set()
+    transient = set()
     lookup_count = 0
 
     while queue:
         if lookup_count >= max_lookups:
-            return resolved, "limit_reached"
+            return resolved, transient, "limit_reached"
 
         include_domain = queue.popleft()
         if include_domain in visited:
@@ -231,18 +319,22 @@ def _resolve_spf_includes(
 
         try:
             answers = dns.resolver.resolve(include_domain, "TXT")
-            spf_records = []
-            for rr in answers.rrset:
-                for s in rr.strings:
-                    txt_value = normalize_txt_value(s.decode())
-                    if txt_value.startswith("v=spf1"):
-                        spf_records.append(txt_value)
+            spf_records = [
+                value
+                for rr in answers.rrset
+                for value in _txt_record_values(rr)
+                if is_spf_record(value)
+            ]
+        except (dns.resolver.Timeout, dns.resolver.NoNameservers):
+            logger.debug("DNS resolution timed out for %s", include_domain)
+            transient.add(include_domain)
+            continue
         except Exception:  # pylint: disable=broad-exception-caught
             logger.debug("DNS resolution failed for %s", include_domain)
             continue
 
         if len(spf_records) > 1:
-            return resolved, f"duplicate:{include_domain}"
+            return resolved, transient, f"duplicate:{include_domain}"
 
         if not spf_records:
             continue
@@ -252,7 +344,20 @@ def _resolve_spf_includes(
             if child_domain not in visited:
                 queue.append(child_domain)
 
-    return resolved, None
+    return resolved, transient, None
+
+
+def _txt_record_values(rr) -> List[str]:
+    """Normalized TXT values carried by a single resource record.
+
+    Its strings belong to one record and are concatenated, unless a later one
+    opens a record of its own — the sign of a resolver having merged separate
+    records into one RR.
+    """
+    strings = [s.decode() for s in rr.strings]
+    if any(TXT_RECORD_START_RE.match(s) for s in strings[1:]):
+        return [normalize_txt_value(s) for s in strings]
+    return [normalize_txt_value("".join(strings))]
 
 
 def _resolve_dns_values(record_type, target, query_name):
@@ -263,20 +368,13 @@ def _resolve_dns_values(record_type, target, query_name):
 
     if record_type.upper() == "TXT":
         answers = dns.resolver.resolve(query_name, "TXT")
-        # Some local resolvers (e.g. systemd-resolved) merge separate TXT
-        # records into a single RR with multiple strings. DKIM keys can also
-        # legitimately span multiple strings within one record. We handle
-        # both by emitting each individual string as a value, plus the
-        # concatenated form for DKIM.
         values = []
         for rr in answers.rrset:
             if target.endswith("._domainkey"):
                 # DKIM: concatenate strings (long key split across strings)
                 values.append(normalize_txt_value(b"".join(rr.strings).decode()))
             else:
-                # Other TXT: treat each string as a separate value
-                for s in rr.strings:
-                    values.append(normalize_txt_value(s.decode()))
+                values.extend(_txt_record_values(rr))
         return values
 
     answers = dns.resolver.resolve(query_name, record_type)
@@ -286,13 +384,15 @@ def _resolve_dns_values(record_type, target, query_name):
 def _check_txt_security(expected_value, found_values):
     """Check for duplicate/insecure SPF and DMARC records. Returns result or None."""
     # SPF duplicate and insecure checks
-    if expected_value.startswith("v=spf1"):
-        spf_records = [v for v in found_values if v.startswith("v=spf1")]
+    if is_spf_record(expected_value):
+        spf_records = [v for v in found_values if is_spf_record(v)]
         if len(spf_records) > 1:
             return {"status": "duplicate", "found": found_values}
-        if expected_value.endswith("-all"):
+        expected_all, _ = parse_spf_terms(expected_value)
+        if expected_all == "-all":
             for spf in spf_records:
-                if spf.endswith("+all") or spf.endswith("?all"):
+                found_all, _ = parse_spf_terms(spf)
+                if found_all in ("+all", "?all"):
                     return {"status": "insecure", "found": found_values}
 
     # DMARC duplicate and insecure checks
@@ -341,7 +441,7 @@ def check_single_record(
 
         # SPF: always use semantic check (handles exact match, reordering,
         # ~all acceptance, and recursive include verification)
-        if record_type.upper() == "TXT" and expected_value.startswith("v=spf1"):
+        if record_type.upper() == "TXT" and is_spf_record(expected_value):
             return _check_spf(expected_value, found_values)
 
         # Exact match (non-SPF)
@@ -402,7 +502,7 @@ def _check_spf_status_uncached(maildomain: MailDomain) -> Tuple[bool, bool]:
     spf_records = [
         r
         for r in expected_records
-        if r["type"].upper() == "TXT" and r["value"].startswith("v=spf1")
+        if r["type"].upper() == "TXT" and is_spf_record(r["value"])
     ]
     if not spf_records:
         return True, True

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -35,7 +35,9 @@ SPF_VERSION = "v=spf1"
 # Per Section 12, ABNF literals are case-insensitive: "V=sPf1" is. Only a
 # space terminates it: RFC 7208 4.6.1 separates terms with SP alone, and a
 # record broken by another control character is one receivers reject too.
-SPF_VERSION_RE = re.compile(rf"{SPF_VERSION}( |$)", re.IGNORECASE)
+# Records are US-ASCII (3.1) and receivers compare bytes, so the folding has
+# to stay ASCII as well: Unicode maps U+017F onto "s" and U+212A onto "k".
+SPF_VERSION_RE = re.compile(rf"{SPF_VERSION}( |$)", re.IGNORECASE | re.ASCII)
 # RFC 7208 4.6.1: directive = [ qualifier ] mechanism.
 SPF_QUALIFIERS = "+-?~"
 # RFC 7208 4.6.1: a term name ends at the first ":", "=" or "/".
@@ -47,10 +49,13 @@ SPF_MECHANISMS = frozenset({"all", "include", "a", "mx", "ptr", "ip4", "ip6", "e
 # RFC 7208 12: "include", "exists", "ip4" and "ip6" spell a mandatory ":"
 # argument, "all" takes none, and "a", "mx" and "ptr" take an optional one.
 SPF_MECHANISMS_NEEDING_ARGUMENT = frozenset({"include", "exists", "ip4", "ip6"})
-# RFC 7208 6: each of these may appear at most once, on pain of permerror.
-SPF_SINGLETON_MODIFIERS = ("redirect", "exp")
-# RFC 7208 12: name = ALPHA *( ALPHA / DIGIT / "-" / "_" / "." )
-SPF_MODIFIER_NAME_RE = re.compile(r"[a-z][a-z0-9_.-]*", re.IGNORECASE)
+# The only two modifiers RFC 7208 defines: each may appear at most once (6),
+# and each takes a domain-spec, which is never empty (6.1 and 6.2). Any other
+# modifier must be ignored, however often it appears and even if it is empty.
+SPF_DEFINED_MODIFIERS = ("redirect", "exp")
+# RFC 7208 12: name = ALPHA *( ALPHA / DIGIT / "-" / "_" / "." ), where ALPHA
+# is ASCII, so the folding is held to ASCII as it is for the version above.
+SPF_MODIFIER_NAME_RE = re.compile(r"[a-z][a-z0-9_.-]*", re.IGNORECASE | re.ASCII)
 # RFC 7208 12: ip4-cidr-length is 0-32 and ip6-cidr-length 0-128.
 SPF_MAX_CIDR_LENGTH = {"ip4": 32, "ip6": 128}
 # Ordered from most permissive to strictest (RFC 7208 4.6.2).
@@ -169,6 +174,18 @@ def parse_spf_terms(value: str) -> Optional[Tuple[str, set]]:
     return (all_mechanism, other_terms)
 
 
+def _cidr_length_is_valid(length: str, maximum: int) -> bool:
+    """Whether a CIDR length is spelled as RFC 7208 12 requires.
+
+    Either "0" or a digit string that does not start with one, within the
+    maximum for its address family. Anything else left by the split — a
+    second "/", an empty string — is not a length at all.
+    """
+    if not length.isdigit() or (length.startswith("0") and length != "0"):
+        return False
+    return int(length) <= maximum
+
+
 def _ip_network_is_valid(name: str, argument: str) -> bool:
     """Whether an "ip4:" or "ip6:" argument is an address and CIDR length.
 
@@ -177,20 +194,28 @@ def _ip_network_is_valid(name: str, argument: str) -> bool:
     of its own. RFC 7208 12 allows a single length, never the dual "//" form.
     """
     literal, separator, cidr_length = argument[1:].partition("/")
-    if separator:
-        # Spelled as "0" or a digit string not starting with one, so a second
-        # "/" or a leading zero leaves something that is not a length.
-        if not cidr_length.isdigit() or (
-            cidr_length.startswith("0") and cidr_length != "0"
-        ):
-            return False
-        if int(cidr_length) > SPF_MAX_CIDR_LENGTH[name]:
-            return False
+    if separator and not _cidr_length_is_valid(cidr_length, SPF_MAX_CIDR_LENGTH[name]):
+        return False
     try:
         address = ipaddress.ip_address(literal)
     except ValueError:
         return False
     return (address.version == 4) == (name == "ip4")
+
+
+def _dual_cidr_is_valid(argument: str) -> bool:
+    """Whether an "a" or "mx" argument that is only a dual-cidr-length is in
+    range: [ ip4-cidr-length ] [ "/" ip6-cidr-length ] (RFC 7208 12).
+
+    Unambiguous exactly because no domain-spec precedes it here; once one
+    does, it may carry a macro holding a "/" of its own.
+    """
+    ip4_part, has_ip6, ip6_length = argument.partition("//")
+    if has_ip6 and not _cidr_length_is_valid(ip6_length, SPF_MAX_CIDR_LENGTH["ip6"]):
+        return False
+    return not ip4_part or _cidr_length_is_valid(
+        ip4_part[1:], SPF_MAX_CIDR_LENGTH["ip4"]
+    )
 
 
 def spf_syntax_is_valid(value: str) -> bool:
@@ -213,8 +238,10 @@ def spf_syntax_is_valid(value: str) -> bool:
             # A modifier is a bare "name=value" (4.6.1): a qualifier belongs
             # to a directive, so a qualified one is neither. Unrecognized
             # modifiers must still be ignored whatever they say (6), so only
-            # their names are worth checking and counting.
+            # their name, and the domain-spec of the two defined ones, matter.
             if qualifier or not SPF_MODIFIER_NAME_RE.fullmatch(name):
+                return False
+            if name in SPF_DEFINED_MODIFIERS and argument == "=":
                 return False
             modifiers[name] += 1
             continue
@@ -228,7 +255,10 @@ def spf_syntax_is_valid(value: str) -> bool:
             return False
         if name in SPF_MAX_CIDR_LENGTH and not _ip_network_is_valid(name, argument):
             return False
-    return all(modifiers[name] <= 1 for name in SPF_SINGLETON_MODIFIERS)
+        if name in ("a", "mx") and argument.startswith("/"):
+            if not _dual_cidr_is_valid(argument):
+                return False
+    return all(modifiers[name] <= 1 for name in SPF_DEFINED_MODIFIERS)
 
 
 def _dkim_tag_equal(tag: str, expected: str, found: str) -> bool:

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -3,6 +3,7 @@ DNS checking functionality for mail domains.
 """
 
 import collections
+import ipaddress
 import logging
 import re
 from typing import Dict, List, Optional, Tuple
@@ -48,6 +49,10 @@ SPF_MECHANISMS = frozenset({"all", "include", "a", "mx", "ptr", "ip4", "ip6", "e
 SPF_MECHANISMS_NEEDING_ARGUMENT = frozenset({"include", "exists", "ip4", "ip6"})
 # RFC 7208 6: each of these may appear at most once, on pain of permerror.
 SPF_SINGLETON_MODIFIERS = ("redirect", "exp")
+# RFC 7208 12: name = ALPHA *( ALPHA / DIGIT / "-" / "_" / "." )
+SPF_MODIFIER_NAME_RE = re.compile(r"[a-z][a-z0-9_.-]*", re.IGNORECASE)
+# RFC 7208 12: ip4-cidr-length is 0-32 and ip6-cidr-length 0-128.
+SPF_MAX_CIDR_LENGTH = {"ip4": 32, "ip6": 128}
 # Ordered from most permissive to strictest (RFC 7208 4.6.2).
 SPF_ALL_STRICTNESS = {"+all": 0, "?all": 1, "~all": 2, "-all": 3}
 SPF_ALL_MECHANISMS = frozenset(SPF_ALL_STRICTNESS)
@@ -164,24 +169,53 @@ def parse_spf_terms(value: str) -> Optional[Tuple[str, set]]:
     return (all_mechanism, other_terms)
 
 
+def _ip_network_is_valid(name: str, argument: str) -> bool:
+    """Whether an "ip4:" or "ip6:" argument is an address and CIDR length.
+
+    Splitting on "/" is only unambiguous here: an ip-network is a literal, so
+    unlike the domain-spec of "a" or "mx" it cannot carry a macro with a "/"
+    of its own. RFC 7208 12 allows a single length, never the dual "//" form.
+    """
+    literal, separator, cidr_length = argument[1:].partition("/")
+    if separator:
+        # Spelled as "0" or a digit string not starting with one, so a second
+        # "/" or a leading zero leaves something that is not a length.
+        if not cidr_length.isdigit() or (
+            cidr_length.startswith("0") and cidr_length != "0"
+        ):
+            return False
+        if int(cidr_length) > SPF_MAX_CIDR_LENGTH[name]:
+            return False
+    try:
+        address = ipaddress.ip_address(literal)
+    except ValueError:
+        return False
+    return (address.version == 4) == (name == "ip4")
+
+
 def spf_syntax_is_valid(value: str) -> bool:
     """Whether an SPF record's terms are well formed.
 
     A syntax error anywhere makes receivers return permerror for the whole
     record (RFC 7208 4.6), so the delegation it describes never takes effect.
-    Term names and the presence of their arguments are checked; the contents
-    of an argument (that an IP parses, that a CIDR is in range) are not. Those
-    are permerrors too, but validating them means reimplementing the grammar,
-    and being wrong there would report working records as broken.
+    Term names, the presence of their arguments and the ip4/ip6 literals are
+    checked. A domain-spec is not: it may hold macros that expand at
+    evaluation time, and rejecting one wrongly would report a working record
+    as broken. That leaves the CIDR lengths of "a" and "mx" unchecked too,
+    since their domain-spec can contain the "/" they would be split on.
     """
     if not is_spf_record(value):
         return False
     modifiers = collections.Counter()
     for term in value[len(SPF_VERSION) :].split():
-        _qualifier, name, argument = _parse_spf_term(term)
+        qualifier, name, argument = _parse_spf_term(term)
         if argument.startswith("="):
-            # Unrecognized modifiers must be ignored whatever they are (6),
-            # so only their names are worth counting.
+            # A modifier is a bare "name=value" (4.6.1): a qualifier belongs
+            # to a directive, so a qualified one is neither. Unrecognized
+            # modifiers must still be ignored whatever they say (6), so only
+            # their names are worth checking and counting.
+            if qualifier or not SPF_MODIFIER_NAME_RE.fullmatch(name):
+                return False
             modifiers[name] += 1
             continue
         if name not in SPF_MECHANISMS:
@@ -191,6 +225,8 @@ def spf_syntax_is_valid(value: str) -> bool:
         if name == "all" and argument:
             return False
         if argument == ":":
+            return False
+        if name in SPF_MAX_CIDR_LENGTH and not _ip_network_is_valid(name, argument):
             return False
     return all(modifiers[name] <= 1 for name in SPF_SINGLETON_MODIFIERS)
 
@@ -416,6 +452,15 @@ def _resolve_spf_includes(
             return resolved, visited, transient, f"duplicate:{include_domain}"
 
         if not spf_records:
+            continue
+
+        # Every version-matching record counted towards the duplicate check
+        # above, per the RFC 7208 4.5 selection rules; only now that one has
+        # been selected does 4.6 syntax apply. A record receivers permerror
+        # on makes the include return permerror too (5.2), so it delegates
+        # nothing and leads nowhere.
+        if not spf_syntax_is_valid(spf_records[0]):
+            logger.debug("Malformed SPF record at %s", include_domain)
             continue
 
         resolved.add(include_domain)

--- a/src/backend/core/services/dns/check.py
+++ b/src/backend/core/services/dns/check.py
@@ -42,13 +42,8 @@ SPF_TERM_NAME_RE = re.compile(r"[^:=/]*")
 # Ordered from most permissive to strictest (RFC 7208 4.6.2).
 SPF_ALL_STRICTNESS = {"+all": 0, "?all": 1, "~all": 2, "-all": 3}
 SPF_ALL_MECHANISMS = frozenset(SPF_ALL_STRICTNESS)
-
-# RFC 7208 3.3 and RFC 6376 3.6.2: the strings of a single TXT record are
-# concatenated with no separator, which is how records over 255 octets are
-# published. Some local resolvers (e.g. systemd-resolved) instead merge
-# separate TXT records into one RR; those show up as a later string opening
-# its own record, and have to stay apart.
-TXT_RECORD_START_RE = re.compile(r"v=(spf1( |$)|DMARC1\b)", re.IGNORECASE)
+# RFC 7208 4.7: a record with no "all" ends in an implicit "?all".
+SPF_IMPLICIT_ALL = "?all"
 
 
 def normalize_txt_value(value: str) -> str:
@@ -244,13 +239,16 @@ def _check_spf(expected_value: str, found_values: List[str]) -> Dict[str, any]:
 def _all_is_acceptable(expected_all: Optional[str], found_all: Optional[str]) -> bool:
     """Whether a found "all" mechanism is at least as strict as expected.
 
-    "~all" also passes for an expected "-all": softfail is where most domains
-    start, and it does not keep us from sending.
+    A record with no "all" is read as the implicit "?all" it ends in, on
+    either side: without it, an expected value carrying no "all" of its own
+    could never be matched. "~all" also passes for an expected "-all":
+    softfail is where most domains start, and it does not keep us from
+    sending.
     """
+    expected_all = expected_all or SPF_IMPLICIT_ALL
+    found_all = found_all or SPF_IMPLICIT_ALL
     if expected_all == found_all:
         return True
-    if expected_all is None or found_all is None:
-        return False
     if expected_all == "-all" and found_all == "~all":
         return True
     return SPF_ALL_STRICTNESS[found_all] > SPF_ALL_STRICTNESS[expected_all]
@@ -334,8 +332,7 @@ def _resolve_spf_includes(
             answers = dns.resolver.resolve(include_domain, "TXT")
             spf_records = [
                 value
-                for rr in answers.rrset
-                for value in _txt_record_values(rr)
+                for value in (_txt_record_value(rr) for rr in answers.rrset)
                 if is_spf_record(value)
             ]
         except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
@@ -368,22 +365,20 @@ def _resolve_spf_includes(
     return resolved, visited, transient, None
 
 
-def _txt_record_values(rr) -> List[str]:
-    """Normalized TXT values carried by a single resource record.
+def _txt_record_value(rr) -> str:
+    """Normalized value of a single TXT resource record.
 
-    Its strings belong to one record and are concatenated, unless a later one
-    opens a record of its own — the sign of a resolver having merged separate
-    records into one RR. SPF records are US-ASCII (RFC 7208 3.1), but an
-    unrelated TXT record at the same name may hold anything, and that is no
-    reason to fail the whole check.
+    RFC 7208 3.3 and RFC 6376 3.6.2: the strings of one record are
+    concatenated with no separator, which is how a value over the 255-octet
+    limit on a character-string is published. Separate TXT records arrive as
+    separate resource records, so several strings here always belong to the
+    same record. SPF records are US-ASCII (RFC 7208 3.1), but an unrelated
+    TXT record may hold anything, and that is no reason to fail the check.
     """
-    strings = [s.decode(errors="replace") for s in rr.strings]
-    if any(TXT_RECORD_START_RE.match(s) for s in strings[1:]):
-        return [normalize_txt_value(s) for s in strings]
-    return [normalize_txt_value("".join(strings))]
+    return normalize_txt_value(b"".join(rr.strings).decode(errors="replace"))
 
 
-def _resolve_dns_values(record_type, target, query_name):
+def _resolve_dns_values(record_type, query_name):
     """Resolve DNS and return found values and normalized expected value flag."""
     if record_type.upper() == "MX":
         answers = dns.resolver.resolve(query_name, "MX")
@@ -391,16 +386,7 @@ def _resolve_dns_values(record_type, target, query_name):
 
     if record_type.upper() == "TXT":
         answers = dns.resolver.resolve(query_name, "TXT")
-        values = []
-        for rr in answers.rrset:
-            if target.endswith("._domainkey"):
-                # DKIM: concatenate strings (long key split across strings)
-                values.append(
-                    normalize_txt_value(b"".join(rr.strings).decode(errors="replace"))
-                )
-            else:
-                values.extend(_txt_record_values(rr))
-        return values
+        return [_txt_record_value(rr) for rr in answers.rrset]
 
     answers = dns.resolver.resolve(query_name, record_type)
     return [answer.to_text() for answer in answers]
@@ -449,7 +435,7 @@ def check_single_record(
     query_name = f"{target}.{maildomain.name}" if target else maildomain.name
 
     try:
-        found_values = _resolve_dns_values(record_type, target, query_name)
+        found_values = _resolve_dns_values(record_type, query_name)
         if record_type.upper() == "TXT":
             expected_value = normalize_txt_value(expected_value)
 

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -1677,6 +1677,39 @@ class TestSPFValidRecordsAreNotFlagged:
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
 
+    def test_broken_third_party_include_listed_first_does_not_hide_ours(
+        self, maildomain_factory
+    ):
+        """Same record, with the broken third party listed before our include.
+
+        Where a third party sits in the record must not decide whether we find
+        the include we asked for. The walk goes past its duplicate the way it
+        goes past a malformed record, instead of stopping on it.
+        """
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer(
+                        "v=spf1 include:broken.example.net include:_spf.example.com -all"
+                    ),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                    "broken.example.net": _txt_answer(
+                        "v=spf1 ip4:5.6.7.8 -all",
+                        "v=spf1 ip4:9.10.11.12 ~all",
+                    ),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
     def test_long_chain_after_our_include_does_not_hide_it(self, maildomain_factory):
         """Hitting the 10-lookup limit further along the record must not mask an
         include that already resolved."""

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -1013,10 +1013,49 @@ class TestSpfSyntaxIsValid:
         """Mechanism names are case-insensitive (RFC 7208 12)."""
         assert spf_syntax_is_valid("v=spf1 MX Include:x.example.com -ALL")
 
-    def test_malformed_argument_is_not_checked(self):
-        """Known limitation: argument contents are not validated, so a bad IP
-        still reads as valid even though receivers permerror on it."""
-        assert spf_syntax_is_valid("v=spf1 ip4:999.1.1.1 -all")
+    def test_well_formed_ip_literals(self):
+        """ip4 and ip6 take an address with an optional CIDR length."""
+        assert spf_syntax_is_valid(
+            "v=spf1 ip4:1.2.3.4 ip4:192.0.2.0/24 ip6:2001:db8::1 ip6:2001:db8::/32 -all"
+        )
+
+    def test_malformed_ip4_literal(self):
+        """RFC 7208 12 spells ip4-network as a dotted quad of 0-255 values."""
+        assert not spf_syntax_is_valid("v=spf1 ip4:999.1.1.1 -all")
+
+    def test_truncated_ip4_literal(self):
+        """RFC 7208 5.6: parts may not be omitted in place of a CIDR."""
+        assert not spf_syntax_is_valid("v=spf1 ip4:192.0.2 -all")
+
+    def test_malformed_ip6_literal(self):
+        """ip6-network is an address per RFC 4291 2.2."""
+        assert not spf_syntax_is_valid("v=spf1 ip6:gggg::1 -all")
+
+    def test_cidr_length_out_of_range(self):
+        """RFC 7208 12 bounds the lengths at 32 for ip4 and 128 for ip6."""
+        assert not spf_syntax_is_valid("v=spf1 ip4:1.2.3.4/33 -all")
+        assert not spf_syntax_is_valid("v=spf1 ip6:2001:db8::1/129 -all")
+
+    def test_dual_cidr_not_allowed_on_ip4(self):
+        """The dual "//" form belongs to a and mx, not to ip4 and ip6."""
+        assert not spf_syntax_is_valid("v=spf1 ip4:1.2.3.4//24 -all")
+
+    def test_a_and_mx_cidr_arguments_are_not_checked(self):
+        """Known limitation: a domain-spec may itself contain "/" inside a
+        macro, so a and mx arguments are left alone rather than mis-split."""
+        assert spf_syntax_is_valid("v=spf1 a:foo.example.com/24//64 mx/99 -all")
+
+    def test_qualified_modifier(self):
+        """RFC 7208 4.6.1: a qualifier belongs to a directive. A modifier is a
+        bare "name=value", so a qualified one is neither."""
+        assert not spf_syntax_is_valid("v=spf1 +redirect=a.example.com")
+        assert not spf_syntax_is_valid("v=spf1 -zzz=one -all")
+
+    def test_modifier_name_must_follow_the_grammar(self):
+        """RFC 7208 12: name = ALPHA *( ALPHA / DIGIT / "-" / "_" / "." )."""
+        assert not spf_syntax_is_valid("v=spf1 1bad=x -all")
+        assert not spf_syntax_is_valid("v=spf1 =x -all")
+        assert spf_syntax_is_valid("v=spf1 moo.cow-far_out=man:dog/cat -all")
 
     def test_repeated_redirect_modifier(self):
         """RFC 7208 6: redirect= MUST NOT appear more than once."""
@@ -2153,6 +2192,34 @@ class TestSPFRecursiveCheck:
                     )
                 if name == "_spf.messages.org":
                     return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incorrect"
+
+    def test_spf_invalid_record_at_the_include_target(
+        self, maildomain_factory, settings
+    ):
+        """RFC 7208 5.2: a recursive check returning permerror makes the
+        include return permerror, so a malformed record at the target breaks
+        the chain rather than completing it."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
+                if name == "_spf.messages.org":
+                    return _txt_answer("v=spf1 ip4:999.1.1.1 gibberish -all")
                 raise NXDOMAIN()
 
             mock_resolve.side_effect = resolve_side_effect

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -949,6 +949,18 @@ class TestParseSpfTerms:
         """RFC 7208 4.5: "v=spf10" is not an SPF record."""
         assert parse_spf_terms("v=spf10 include:_spf.example.com -all") is None
 
+    def test_version_must_be_terminated_by_a_space(self):
+        """RFC 7208 4.6.1 separates terms with SP alone. Receivers read a
+        record broken by another control character as no record at all, so we
+        must not report it as one either."""
+        assert parse_spf_terms("v=spf1\tinclude:_spf.example.com -all") is None
+
+    def test_empty_record_is_valid(self):
+        """RFC 7208 4.5: a bare "v=spf1" is a record, with no terms."""
+        all_mech, terms = parse_spf_terms("v=spf1")
+        assert all_mech is None
+        assert terms == set()
+
     def test_qualifiers_are_made_explicit(self):
         """An omitted qualifier means "+", so both spellings are one term."""
         _all_mech, terms = parse_spf_terms("v=spf1 +MX ip4:1.2.3.4")
@@ -957,6 +969,12 @@ class TestParseSpfTerms:
     def test_bare_all_means_pass(self):
         """A bare "all" carries the implicit "+" qualifier."""
         all_mech, _terms = parse_spf_terms("v=spf1 mx all")
+        assert all_mech == "+all"
+
+    def test_first_all_wins(self):
+        """RFC 7208 5.1: "all" always matches, so anything after it is never
+        tested — including a second, stricter "all"."""
+        all_mech, _terms = parse_spf_terms("v=spf1 +all -all")
         assert all_mech == "+all"
 
     def test_modifiers_keep_no_qualifier(self):
@@ -1456,7 +1474,7 @@ class TestSPFValidRecordsAreNotFlagged:
 
             result = check_single_record(maildomain, expected_record)
             # The delegation is in place; only the "all" is missing locally.
-            assert result["status"] in ("correct", "insecure")
+            assert result["status"] == "insecure"
 
     def test_v_spf10_is_not_a_second_record(self, maildomain_factory):
         """RFC 7208 4.5: the version section is terminated by a space or the end
@@ -1537,6 +1555,35 @@ class TestSPFValidRecordsAreNotFlagged:
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
 
+    def test_unrelated_non_ascii_txt_record(self, maildomain_factory):
+        """SPF records are US-ASCII (RFC 7208 3.1), but another TXT record at
+        the same name may hold anything, and decoding it must not fail the
+        whole check."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        binary_rr = MagicMock()
+        binary_rr.strings = (b"\xff\xfe some vendor blob",)
+        spf_rr = MagicMock()
+        spf_rr.strings = (b"v=spf1 include:_spf.example.com -all",)
+        answer = MagicMock()
+        answer.rrset = [binary_rr, spf_rr]
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": answer,
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
     def test_stricter_all_than_expected_is_correct(self, maildomain_factory):
         """A domain hardening ~all into -all is stricter, not insecure."""
         maildomain = maildomain_factory(name="example.com")
@@ -1573,9 +1620,10 @@ class TestSPFValidRecordsAreNotFlagged:
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
 
-    def test_transient_dns_failure_in_chain_is_not_cached(self, maildomain_factory):
-        """A timeout while walking the chain says nothing about the record, so
-        it must not be cached as a definitive failure for 10 minutes."""
+    def test_transient_dns_failure_in_chain_is_reported_as_an_error(
+        self, maildomain_factory
+    ):
+        """A timeout while walking the chain says nothing about the record."""
         maildomain = maildomain_factory(name="example.com")
         expected_record = {
             "type": "TXT",
@@ -1594,6 +1642,62 @@ class TestSPFValidRecordsAreNotFlagged:
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "error"
+
+    @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_transient_dns_failure_in_chain_is_not_cached(self, maildomain_factory):
+        """That error must not be cached as a definitive failure for 10 minutes."""
+        cache.clear()
+        maildomain = maildomain_factory(name="example.com")
+
+        with (
+            patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve,
+            patch("core.services.dns.check.cache.set") as mock_cache_set,
+        ):
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
+                raise Timeout()
+
+            mock_resolve.side_effect = resolve_side_effect
+
+            assert check_spf_status(maildomain) is False
+            mock_cache_set.assert_not_called()
+
+    @override_settings(
+        MESSAGES_TECHNICAL_DOMAIN="messages.org",
+        MESSAGES_DNS_RECORDS='[{"target":"","type":"txt",'
+        '"value":"v=spf1 include:_spf.messages.org -all"}]',
+    )
+    def test_unrelated_transient_failure_stays_definitive(self, maildomain_factory):
+        """A timeout on someone else's include, when ours was looked up and
+        settled, is not what hid it: the answer is definitive and cacheable."""
+        cache.clear()
+        maildomain = maildomain_factory(name="example.com")
+
+        with (
+            patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve,
+            patch("core.services.dns.check.cache.set") as mock_cache_set,
+        ):
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer(
+                        "v=spf1 include:_spf.messages.org"
+                        " include:other.example.net -all"
+                    )
+                if name == "_spf.messages.org":
+                    raise NXDOMAIN()
+                raise Timeout()
+
+            mock_resolve.side_effect = resolve_side_effect
+
+            assert check_spf_status(maildomain) is False
+            mock_cache_set.assert_called_once()
 
 
 @pytest.fixture(name="maildomain_factory")
@@ -1850,6 +1954,64 @@ class TestSPFRecursiveCheck:
             result = check_single_record(maildomain, expected_record)
 
             assert result["status"] == "duplicate"
+
+    def test_spf_weak_all_does_not_excuse_a_missing_include(
+        self, maildomain_factory, settings
+    ):
+        """A weak "all" says the policy is lax; it says nothing about whether
+        the domain delegates to us. Reporting "insecure" here would let
+        check_spf_status send for a domain that never included us."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer("v=spf1 ?all include:other.example.net")
+                if name == "other.example.net":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incorrect"
+
+    def test_spf_redirect_is_ignored_when_all_is_present(
+        self, maildomain_factory, settings
+    ):
+        """RFC 7208 5.1 and 6.1: a "redirect=" modifier MUST be ignored when the
+        record has an "all" mechanism anywhere, so it delegates nothing and our
+        include is not actually in place."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer("v=spf1 redirect=policy.example.net -all")
+                if name == "policy.example.net":
+                    return _txt_answer("v=spf1 include:_spf.messages.org -all")
+                if name == "_spf.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incorrect"
 
 
 @pytest.mark.django_db

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -949,6 +949,13 @@ class TestParseSpfTerms:
         """RFC 7208 4.5: "v=spf10" is not an SPF record."""
         assert parse_spf_terms("v=spf10 include:_spf.example.com -all") is None
 
+    def test_version_must_be_ascii(self):
+        """RFC 7208 3.1 encodes records in US-ASCII and receivers compare
+        bytes, but Unicode case folding maps U+017F onto "s" and U+212A onto
+        "k". A record spelled with either is no record at all."""
+        assert parse_spf_terms("v=ſpf1 include:_spf.example.com -all") is None
+        assert parse_spf_terms("v=spf1 -all".replace("k", "K")) is not None
+
     def test_version_must_be_terminated_by_a_space(self):
         """RFC 7208 4.6.1 separates terms with SP alone. Receivers read a
         record broken by another control character as no record at all, so we
@@ -1040,10 +1047,35 @@ class TestSpfSyntaxIsValid:
         """The dual "//" form belongs to a and mx, not to ip4 and ip6."""
         assert not spf_syntax_is_valid("v=spf1 ip4:1.2.3.4//24 -all")
 
-    def test_a_and_mx_cidr_arguments_are_not_checked(self):
-        """Known limitation: a domain-spec may itself contain "/" inside a
-        macro, so a and mx arguments are left alone rather than mis-split."""
-        assert spf_syntax_is_valid("v=spf1 a:foo.example.com/24//64 mx/99 -all")
+    def test_a_and_mx_bare_dual_cidr_is_checked(self):
+        """With no domain-spec the whole argument is a dual-cidr-length, so
+        there is nothing it could be confused with (RFC 7208 12)."""
+        assert spf_syntax_is_valid("v=spf1 a/24//64 mx/32 a//128 -all")
+        assert not spf_syntax_is_valid("v=spf1 mx/99 -all")
+        assert not spf_syntax_is_valid("v=spf1 a//129 -all")
+        assert not spf_syntax_is_valid("v=spf1 a/ -all")
+
+    def test_a_and_mx_domain_spec_is_not_checked(self):
+        """Known limitation: once a domain-spec is present it may hold a macro
+        carrying a "/" of its own, so the argument is left alone."""
+        assert spf_syntax_is_valid("v=spf1 a:foo.example.com/24//64 -all")
+        assert spf_syntax_is_valid("v=spf1 mx:%{d}/99 -all")
+
+    def test_defined_modifiers_need_a_domain_spec(self):
+        """RFC 7208 6.1 and 6.2 spell redirect and exp with a domain-spec,
+        which is never empty."""
+        assert not spf_syntax_is_valid("v=spf1 redirect=")
+        assert not spf_syntax_is_valid("v=spf1 exp= -all")
+
+    def test_unknown_modifier_may_be_empty(self):
+        """RFC 7208 12: unknown-modifier takes a macro-string, and that one
+        is allowed to be empty."""
+        assert spf_syntax_is_valid("v=spf1 zzz= -all")
+
+    def test_non_ascii_lookalike_is_not_a_mechanism_name(self):
+        """Case-insensitive matching must stay ASCII: U+017F case-folds to
+        "s" and U+212A to "k", but receivers compare bytes."""
+        assert not spf_syntax_is_valid("v=spf1 ſoo=x -all")
 
     def test_qualified_modifier(self):
         """RFC 7208 4.6.1: a qualifier belongs to a directive. A modifier is a

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -340,10 +340,9 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
     def test_check_single_record_spf_duplicate(self, maildomain_factory):
         """Test that duplicate SPF records are detected.
 
-        Per RFC 7208, a domain must not have multiple SPF records.
-        Example in the wild: saint-sozy.fr has both
-          "v=spf1 include:_spf.mail.suite.anct.gouv.fr -all"
-          "v=spf1 include:_spf.legacy-provider.com ~all"
+        Per RFC 7208, a domain must not have multiple SPF records. Domains
+        that kept a previous provider's record alongside ours are the common
+        case in the wild.
         """
         maildomain = maildomain_factory(name="example.com")
         expected_record = {
@@ -921,7 +920,7 @@ class TestParseSpfTerms:
         """Test parsing a basic SPF record."""
         all_mech, terms = parse_spf_terms("v=spf1 include:_spf.example.com -all")
         assert all_mech == "-all"
-        assert terms == {"include:_spf.example.com"}
+        assert terms == {"+include:_spf.example.com"}
 
     def test_multiple_includes(self):
         """Test parsing SPF with multiple includes."""
@@ -929,7 +928,7 @@ class TestParseSpfTerms:
             "v=spf1 include:_spf.example.com include:other.com -all"
         )
         assert all_mech == "-all"
-        assert terms == {"include:_spf.example.com", "include:other.com"}
+        assert terms == {"+include:_spf.example.com", "+include:other.com"}
 
     def test_tilde_all(self):
         """Test parsing SPF with ~all mechanism."""
@@ -940,11 +939,41 @@ class TestParseSpfTerms:
         """Test that non-SPF record returns None."""
         assert parse_spf_terms("not-an-spf-record") is None
 
+    def test_version_is_case_insensitive(self):
+        """RFC 7208 12: ABNF literals are case-insensitive."""
+        all_mech, terms = parse_spf_terms("V=sPf1 MX -ALL")
+        assert all_mech == "-all"
+        assert terms == {"+mx"}
+
+    def test_version_must_be_terminated(self):
+        """RFC 7208 4.5: "v=spf10" is not an SPF record."""
+        assert parse_spf_terms("v=spf10 include:_spf.example.com -all") is None
+
+    def test_qualifiers_are_made_explicit(self):
+        """An omitted qualifier means "+", so both spellings are one term."""
+        _all_mech, terms = parse_spf_terms("v=spf1 +MX ip4:1.2.3.4")
+        assert terms == {"+mx", "+ip4:1.2.3.4"}
+
+    def test_bare_all_means_pass(self):
+        """A bare "all" carries the implicit "+" qualifier."""
+        all_mech, _terms = parse_spf_terms("v=spf1 mx all")
+        assert all_mech == "+all"
+
+    def test_modifiers_keep_no_qualifier(self):
+        """Modifiers are name=value pairs and take no qualifier."""
+        _all_mech, terms = parse_spf_terms("v=spf1 redirect=_spf.example.com")
+        assert terms == {"redirect=_spf.example.com"}
+
+    def test_macro_argument_keeps_its_case(self):
+        """ "%{s}" and "%{S}" do not expand the same way (RFC 7208 7.3)."""
+        _all_mech, terms = parse_spf_terms("v=spf1 exists:%{S}.example.com")
+        assert terms == {"+exists:%{S}.example.com"}
+
     def test_no_all_mechanism(self):
         """Test parsing SPF without an all mechanism."""
         all_mech, terms = parse_spf_terms("v=spf1 include:_spf.example.com")
         assert all_mech is None
-        assert terms == {"include:_spf.example.com"}
+        assert terms == {"+include:_spf.example.com"}
 
 
 @pytest.mark.django_db
@@ -1299,6 +1328,272 @@ class TestSPFSemanticComparison:
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "incorrect"
+
+
+@pytest.mark.django_db
+class TestSPFValidRecordsAreNotFlagged:
+    """Valid SPF records that must not be reported as broken.
+
+    A false "incorrect" here blocks outgoing mail (MESSAGES_SPF_CHECK_OUTGOING),
+    so every shape RFC 7208 allows has to be accepted.
+    """
+
+    @staticmethod
+    def _resolver(records):
+        """Side effect resolving TXT queries from a {name: answer} mapping."""
+
+        def resolve_side_effect(name, _record_type):
+            if name not in records:
+                raise NXDOMAIN()
+            return records[name]
+
+        return resolve_side_effect
+
+    def test_explicit_plus_qualifier_on_include(self, maildomain_factory):
+        """RFC 7208 4.6.1: every mechanism takes an optional qualifier, so
+        "+include:" delegates exactly like "include:".
+
+        Records of this shape are published in the wild and used to be
+        flagged as incorrect, which stopped us from sending for them.
+        """
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer(
+                        "v=spf1 +mx +a +include:_spf.example.com"
+                        " +include:spf.example.net -all",
+                        "google-site-verification=abc123",
+                    ),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                    "spf.example.net": _txt_answer("v=spf1 ip4:5.6.7.8 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_uppercase_version_and_mechanism_names(self, maildomain_factory):
+        """RFC 7208 12: ABNF literals are case-insensitive, so "V=SPF1" and
+        "INCLUDE:" are a valid record."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer(
+                        "V=SPF1 MX INCLUDE:_SPF.Example.COM -ALL"
+                    ),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_record_split_across_several_strings(self, maildomain_factory):
+        """RFC 7208 3.3: the strings of one TXT record are concatenated with no
+        separator, which is how records over 255 octets are published."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        split_rr = MagicMock()
+        split_rr.strings = (
+            b"v=spf1 include:a.example.net include:b.example.net ",
+            b"include:_spf.example.com -all",
+        )
+        answer = MagicMock()
+        answer.rrset = [split_rr]
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": answer,
+                    "a.example.net": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                    "b.example.net": _txt_answer("v=spf1 ip4:5.6.7.8 -all"),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:9.10.11.12 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_delegation_through_redirect_modifier(self, maildomain_factory):
+        """RFC 7208 6.1: "redirect=" hands the whole decision to another
+        domain's record, so it reaches our include just like an include does."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer("v=spf1 redirect=policy.example.net"),
+                    "policy.example.net": _txt_answer(
+                        "v=spf1 include:_spf.example.com -all"
+                    ),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            # The delegation is in place; only the "all" is missing locally.
+            assert result["status"] in ("correct", "insecure")
+
+    def test_v_spf10_is_not_a_second_record(self, maildomain_factory):
+        """RFC 7208 4.5: the version section is terminated by a space or the end
+        of the record, so "v=spf10" is not an SPF record and cannot make the
+        domain look like it publishes two."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer(
+                        "v=spf1 include:_spf.example.com -all",
+                        "v=spf10 include:legacy.example.net ~all",
+                    ),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_broken_third_party_include_does_not_hide_ours(self, maildomain_factory):
+        """A third party duplicating its own SPF record is not our customer's
+        problem as long as the include we asked for is in place."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer(
+                        "v=spf1 include:_spf.example.com include:broken.example.net -all"
+                    ),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                    "broken.example.net": _txt_answer(
+                        "v=spf1 ip4:5.6.7.8 -all",
+                        "v=spf1 ip4:9.10.11.12 ~all",
+                    ),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_long_chain_after_our_include_does_not_hide_it(self, maildomain_factory):
+        """Hitting the 10-lookup limit further along the record must not mask an
+        include that already resolved."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+        # Our include first, then a long tail of other providers.
+        records = {
+            "example.com": _txt_answer(
+                "v=spf1 include:_spf.example.com "
+                + " ".join(f"include:p{i}.example.net" for i in range(12))
+                + " -all"
+            ),
+            "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+        }
+        for i in range(12):
+            records[f"p{i}.example.net"] = _txt_answer(f"v=spf1 ip4:10.0.0.{i} -all")
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(records)
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_stricter_all_than_expected_is_correct(self, maildomain_factory):
+        """A domain hardening ~all into -all is stricter, not insecure."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com ~all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer("v=spf1 include:_spf.example.com -all"),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_qualifiers_in_terms_only_comparison(self, maildomain_factory):
+        """With no include to follow, terms are compared directly: an explicit
+        "+" qualifier and upper case must not make them differ."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 ip4:1.2.3.4 mx -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.return_value = _txt_answer("v=spf1 +MX +ip4:1.2.3.4 -all")
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_transient_dns_failure_in_chain_is_not_cached(self, maildomain_factory):
+        """A timeout while walking the chain says nothing about the record, so
+        it must not be cached as a definitive failure for 10 minutes."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer("v=spf1 include:_spf.example.com -all")
+                raise Timeout()
+
+            mock_resolve.side_effect = resolve_side_effect
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "error"
 
 
 @pytest.fixture(name="maildomain_factory")

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -407,12 +407,16 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
 
             assert result["status"] == "correct"
 
-    def test_check_single_record_spf_found_when_resolver_merges_txt_records(
+    def test_check_single_record_spf_found_among_other_txt_records(
         self, maildomain_factory
     ):
-        """Regression: some local resolvers (e.g. systemd-resolved) merge
-        separate TXT records into a single RR with multiple strings. SPF must
-        still be found by iterating individual strings."""
+        """SPF must be found when the name carries other TXT records too.
+
+        Separate TXT records arrive as separate resource records, each with
+        its own strings: the RDATA boundary is part of the record framing, so
+        no resolver can merge two records into one. Several strings on one
+        record therefore always belong together (RFC 7208 3.3).
+        """
         maildomain = maildomain_factory(name="example.com")
         expected_record = {
             "type": "TXT",
@@ -421,15 +425,10 @@ class TestDNSChecking:  # pylint: disable=too-many-public-methods
         }
 
         with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
-            # Single RR with two strings (merged by local resolver)
-            merged_rr = MagicMock()
-            merged_rr.strings = (
-                b"google-site-verification=abc123",
-                b"v=spf1 include:_spf.example.com -all",
+            mock_resolve.return_value = _txt_answer(
+                "google-site-verification=abc123",
+                "v=spf1 include:_spf.example.com -all",
             )
-            answer = MagicMock()
-            answer.rrset = [merged_rr]
-            mock_resolve.return_value = answer
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
@@ -1422,7 +1421,9 @@ class TestSPFValidRecordsAreNotFlagged:
 
     def test_record_split_across_several_strings(self, maildomain_factory):
         """RFC 7208 3.3: the strings of one TXT record are concatenated with no
-        separator, which is how records over 255 octets are published."""
+        separator, which is how a value over the 255-octet character-string
+        limit is published. Publishers split where they like, not only at
+        exactly 255 octets, so the split point carries no meaning."""
         maildomain = maildomain_factory(name="example.com")
         expected_record = {
             "type": "TXT",
@@ -1554,6 +1555,50 @@ class TestSPFValidRecordsAreNotFlagged:
 
             result = check_single_record(maildomain, expected_record)
             assert result["status"] == "correct"
+
+    def test_expected_value_without_an_all_mechanism(self, maildomain_factory):
+        """A configured expected value carrying no "all" ends in the implicit
+        "?all" (RFC 7208 4.7); a stricter published one satisfies it. Reading
+        it as "no acceptable all exists" would make the check unsatisfiable."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer("v=spf1 include:_spf.example.com -all"),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "correct"
+
+    def test_expected_value_without_an_all_still_rejects_plus_all(
+        self, maildomain_factory
+    ):
+        """The implicit "?all" is still stricter than a published "+all"."""
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.example.com",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+            mock_resolve.side_effect = self._resolver(
+                {
+                    "example.com": _txt_answer("v=spf1 include:_spf.example.com +all"),
+                    "_spf.example.com": _txt_answer("v=spf1 ip4:1.2.3.4 -all"),
+                }
+            )
+
+            result = check_single_record(maildomain, expected_record)
+            assert result["status"] == "insecure"
 
     def test_unrelated_non_ascii_txt_record(self, maildomain_factory):
         """SPF records are US-ASCII (RFC 7208 3.1), but another TXT record at

--- a/src/backend/core/tests/dns/test_check.py
+++ b/src/backend/core/tests/dns/test_check.py
@@ -20,6 +20,7 @@ from core.services.dns.check import (
     invalidate_spf_check_cache,
     parse_dkim_tags,
     parse_spf_terms,
+    spf_syntax_is_valid,
 )
 
 
@@ -975,6 +976,82 @@ class TestParseSpfTerms:
         tested — including a second, stricter "all"."""
         all_mech, _terms = parse_spf_terms("v=spf1 +all -all")
         assert all_mech == "+all"
+
+    def test_mechanisms_after_all_are_dropped(self):
+        """Mechanisms listed after "all" MUST be ignored (RFC 7208 5.1)."""
+        all_mech, terms = parse_spf_terms("v=spf1 mx -all ip4:1.2.3.4")
+        assert all_mech == "-all"
+        assert terms == {"+mx"}
+
+    def test_modifiers_after_all_are_kept(self):
+        """Modifiers are not mechanisms, so an "all" does not skip them."""
+        _all_mech, terms = parse_spf_terms("v=spf1 -all exp=why.example.com")
+        assert terms == {"exp=why.example.com"}
+
+
+class TestSpfSyntaxIsValid:
+    """Test the SPF record syntax check."""
+
+    def test_known_mechanisms_and_modifiers(self):
+        """Every mechanism of RFC 7208 5, plus modifiers, are accepted."""
+        assert spf_syntax_is_valid(
+            "v=spf1 a mx ptr ip4:1.2.3.4 ip6:2001:db8::1 exists:%{i}.e.com"
+            " include:x.example.com redirect=y.example.com exp=z.example.com -all"
+        )
+
+    def test_unknown_mechanism(self):
+        """An unknown bare term is a syntax error (RFC 7208 4.6)."""
+        assert not spf_syntax_is_valid("v=spf1 include:x.example.com gibberish -all")
+
+    def test_unknown_modifier_is_ignored(self):
+        """RFC 7208 6: unrecognized modifiers MUST be ignored, not rejected."""
+        assert spf_syntax_is_valid(
+            "v=spf1 moo.cow-far_out=man:dog/cat ip4:1.2.3.4 -all"
+        )
+
+    def test_case_insensitive(self):
+        """Mechanism names are case-insensitive (RFC 7208 12)."""
+        assert spf_syntax_is_valid("v=spf1 MX Include:x.example.com -ALL")
+
+    def test_malformed_argument_is_not_checked(self):
+        """Known limitation: argument contents are not validated, so a bad IP
+        still reads as valid even though receivers permerror on it."""
+        assert spf_syntax_is_valid("v=spf1 ip4:999.1.1.1 -all")
+
+    def test_repeated_redirect_modifier(self):
+        """RFC 7208 6: redirect= MUST NOT appear more than once."""
+        assert not spf_syntax_is_valid(
+            "v=spf1 redirect=a.example.com redirect=b.example.com"
+        )
+
+    def test_repeated_exp_modifier(self):
+        """RFC 7208 6: exp= MUST NOT appear more than once."""
+        assert not spf_syntax_is_valid(
+            "v=spf1 exp=a.example.com exp=b.example.com -all"
+        )
+
+    def test_repeated_unknown_modifier_is_allowed(self):
+        """Only redirect= and exp= are capped; others MUST just be ignored."""
+        assert spf_syntax_is_valid("v=spf1 zzz=one zzz=two -all")
+
+    def test_mechanism_missing_its_required_argument(self):
+        """include, exists, ip4 and ip6 all spell a mandatory ":" argument."""
+        assert not spf_syntax_is_valid("v=spf1 include -all")
+        assert not spf_syntax_is_valid("v=spf1 include: -all")
+        assert not spf_syntax_is_valid("v=spf1 ip4 -all")
+
+    def test_all_takes_no_argument(self):
+        """RFC 7208 12 spells all as the bare word."""
+        assert not spf_syntax_is_valid("v=spf1 -all:example.com")
+
+    def test_optional_argument_may_be_omitted(self):
+        """a, mx and ptr default to the current domain."""
+        assert spf_syntax_is_valid("v=spf1 a mx ptr -all")
+        assert not spf_syntax_is_valid("v=spf1 a: -all")
+
+    def test_non_spf_value(self):
+        """A value that is not a record at all cannot be a valid one."""
+        assert not spf_syntax_is_valid("google-site-verification=abc123")
 
     def test_modifiers_keep_no_qualifier(self):
         """Modifiers are name=value pairs and take no qualifier."""
@@ -2027,6 +2104,155 @@ class TestSPFRecursiveCheck:
             result = check_single_record(maildomain, expected_record)
 
             assert result["status"] == "incorrect"
+
+    def test_spf_include_after_all_is_never_reached(self, maildomain_factory, settings):
+        """RFC 7208 5.1: "all" always matches, so mechanisms listed after it
+        MUST be ignored. An include placed after it delegates nothing, and the
+        record hard-fails every sender."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer("v=spf1 -all include:_spf.messages.org")
+                if name == "_spf.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incorrect"
+
+    def test_spf_unknown_mechanism_is_a_syntax_error(
+        self, maildomain_factory, settings
+    ):
+        """RFC 7208 4.6: a syntax error anywhere in the record makes receivers
+        return permerror, so the delegation never takes effect."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer(
+                        "v=spf1 include:_spf.messages.org gibberish -all"
+                    )
+                if name == "_spf.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incorrect"
+
+    def test_spf_void_lookups_are_capped(self, maildomain_factory, settings):
+        """RFC 7208 4.6.4 and 11.1: a record listing names that do not exist
+        turns a verifier into a DNS amplifier aimed at them, so the walk stops
+        after two void lookups instead of spending the full budget of ten."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer(
+                        "v=spf1 "
+                        + " ".join(f"include:v{i}.victim.example" for i in range(9))
+                        + " include:_spf.messages.org -all"
+                    )
+                if name == "_spf.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "incorrect"
+            # One lookup for the domain itself, then three void ones: the
+            # third trips the cap. Without it this would have been ten.
+            assert mock_resolve.call_count == 4
+
+    def test_spf_void_lookups_do_not_mask_an_include_reached_first(
+        self, maildomain_factory, settings
+    ):
+        """The cap must not hide a delegation that already resolved."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer(
+                        "v=spf1 include:_spf.messages.org "
+                        + " ".join(f"include:v{i}.example.net" for i in range(9))
+                        + " -all"
+                    )
+                if name == "_spf.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                raise NXDOMAIN()
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "correct"
+
+    def test_spf_name_answering_without_a_record_is_not_a_void_lookup(
+        self, maildomain_factory, settings
+    ):
+        """A void lookup is one that came back empty. A name that answers with
+        TXT records but no SPF among them did answer."""
+        settings.MESSAGES_TECHNICAL_DOMAIN = "messages.org"
+        maildomain = maildomain_factory(name="example.com")
+        expected_record = {
+            "type": "TXT",
+            "target": "",
+            "value": "v=spf1 include:_spf.messages.org -all",
+        }
+
+        with patch("core.services.dns.check.dns.resolver.resolve") as mock_resolve:
+
+            def resolve_side_effect(name, _record_type):
+                if name == "example.com":
+                    return _txt_answer(
+                        "v=spf1 "
+                        + " ".join(f"include:n{i}.example.net" for i in range(5))
+                        + " include:_spf.messages.org -all"
+                    )
+                if name == "_spf.messages.org":
+                    return _txt_answer("v=spf1 ip4:1.2.3.4 -all")
+                return _txt_answer("google-site-verification=abc123")
+
+            mock_resolve.side_effect = resolve_side_effect
+            result = check_single_record(maildomain, expected_record)
+
+            assert result["status"] == "correct"
 
     def test_spf_redirect_is_ignored_when_all_is_present(
         self, maildomain_factory, settings


### PR DESCRIPTION
SPF check is now in the critical send path and we have seen unusual but valid records in the wild. Implement the full RFC (as we should have) to make those pass anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SPF validation with case-insensitive syntax handling and accurate qualifier, modifier, include, and redirect support.
  - Correctly distinguishes missing, duplicate, invalid, insecure, transient, and incorrect SPF results.
  - Enforces SPF lookup and void-lookup limits during recursive validation.
  - Handles SPF records split across TXT strings while preserving separate records.
  - Prevents malformed or overly complex SPF chains from producing misleading results.
  - Applies consistent SPF detection across security checks and cached status results.
  - Improved handling of DKIM key fragments in TXT records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->