### PR TITLE
Upgrades frontend deps, adds an allowlist setup for the admin path, harden github actions setup

### DIFF
--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
 
   synchronize-with-crowdin:
@@ -15,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install frontend dependencies
         run: make install-frozen-front
       - name: Generate frontend source translations
@@ -30,7 +35,6 @@ jobs:
           download_translations: false
           create_pull_request: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
 

--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -14,13 +14,13 @@ jobs:
       DJANGO_CONFIGURATION: Build
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install frontend dependencies
         run: make install-frozen-front
       - name: Generate frontend source translations
         run: make i18n-generate
       - name: crowdin action
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@0d5670f539973aea2f01abce61a8989934df0025 # v3.0.2
         with:
           config: crowdin/config.yml
           upload_sources: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,20 +54,20 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ inputs.registry }}/${{ github.repository }}-${{ inputs.image_name }}
           tags: |
@@ -90,7 +90,7 @@ jobs:
             echo "amd64_first=$FIRST_AMD64_TAG"
           } >> "$GITHUB_OUTPUT"
       - name: Build and push (amd64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}
@@ -102,7 +102,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build_args }}
       - name: Build and push (arm64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}
@@ -140,13 +140,13 @@ jobs:
       # tagged as sha256-<digest>. It proves the image was built by this
       # workflow from this repo. Verified with: gh attestation verify <image>
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ inputs.registry }}/${{ github.repository }}-${{ inputs.image_name }}
           subject-digest: ${{ steps.create-manifest.outputs.digest }}
           push-to-registry: true
       - name: Delete all untagged container images
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
           package-name: messages-${{ inputs.image_name }}
           package-type: 'container'

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -135,6 +135,14 @@ jobs:
       - name: Build frontend
         run: make build-front
 
+  test-front-distroless:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Build and smoke-test the frontend production image
+        run: make test-front-distroless
+
   check-api-state:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create env files
         run: make create-env-files
       - name: Run linting checks
@@ -34,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create env files
         run: make create-env-files
       - name: Run pyright (strict) on the jmap-email library
@@ -47,6 +51,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create env files
         run: make create-env-files
       - name: Setup data directories
@@ -65,6 +71,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create env files
         run: make create-env-files
       - name: Install frontend dependencies
@@ -80,6 +88,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create env files
         run: make create-env-files
       - name: Run E2E tests only for Chromium browser to speed up the tests
@@ -114,6 +124,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create env files
         run: make create-env-files
       - name: Install frontend dependencies
@@ -128,6 +140,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create env files
         run: make create-env-files
       - name: Install frontend dependencies
@@ -140,6 +154,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build and smoke-test the frontend production image
         run: make test-front-distroless
 
@@ -148,6 +164,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create env files
         run: make create-env-files
       - name: Install frontend dependencies

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create env files
         run: make create-env-files
       - name: Run linting checks
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create env files
         run: make create-env-files
       - name: Run pyright (strict) on the jmap-email library
@@ -46,7 +46,7 @@ jobs:
       DOCKER_USER: 1001
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create env files
         run: make create-env-files
       - name: Setup data directories
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create env files
         run: make create-env-files
       - name: Install frontend dependencies
@@ -79,7 +79,7 @@ jobs:
       PW_TEST_HTML_REPORT_OPEN: 'never'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create env files
         run: make create-env-files
       - name: Run E2E tests only for Chromium browser to speed up the tests
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Create env files
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Create env files
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create env files
         run: make create-env-files
       - name: Install frontend dependencies
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create env files
         run: make create-env-files
       - name: Install frontend dependencies
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and smoke-test the frontend production image
         run: make test-front-distroless
 
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create env files
         run: make create-env-files
       - name: Install frontend dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 ### Added
 
 - Setup guides for the authentication provider and the identity provider
+- IP allowlist for the Django admin URL in the frontend Caddy proxy
+- Smoke test for the frontend production image (make test-front-distroless)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Changed
 
 - Bump keycloak to 26.7.2
+- Bump Caddy to 2.11.4 and lprobe to v0.2.0 in the frontend image
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,14 @@ test-back-distroless: build-back-distroless ## build and smoke-test the distrole
 		print(f'OK: Python {sys.version.split()[0]}, {ssl.OPENSSL_VERSION}')"
 .PHONY: test-back-distroless
 
+build-front-distroless: ## build the frontend distroless production image (Caddy + static bundle)
+	@docker build --target runtime-prod -t messages-frontend-distroless src/frontend/
+.PHONY: build-front-distroless
+
+test-front-distroless: build-front-distroless ## build and smoke-test the frontend distroless production image
+	@bin/smoke-test-front messages-frontend-distroless
+.PHONY: test-front-distroless
+
 build-pymta-distroless: build-python-base ## build the pymta distroless production image
 	@docker build --target runtime-distroless-prod -t messages-pymta-distroless -f src/mta-in/Dockerfile.pymta src/mta-in/
 .PHONY: build-pymta-distroless

--- a/bin/smoke-test-front
+++ b/bin/smoke-test-front
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Smoke-test the frontend production image (runtime-prod: distroless +
+# Caddy + lprobe). The script picks the network mode from the daemon:
+# - bridge mode (normal Docker, Docker Desktop): publish port 8080 and
+#   reach the stub backend through host.docker.internal.
+# - host mode (a daemon without bridge networking): share the host
+#   network; the image default backend localhost:8000 then matches.
+# Host ports 8080 (Caddy, hardcoded in the image HEALTHCHECK) and 8000
+# (stub backend) must be free.
+# Requires: docker, curl, python3.
+set -o errexit -o nounset -o pipefail
+
+IMAGE="${1:-messages-frontend-distroless}"
+BASE=http://127.0.0.1:8080
+CID=""
+STUB_PID=""
+
+command -v python3 >/dev/null || { echo "FAIL: python3 is required." >&2; exit 1; }
+
+if docker network inspect bridge >/dev/null 2>&1; then
+  NET_MODE=bridge
+  STUB_BIND=0.0.0.0
+  RUN_FLAGS=(-p 8080:8080 --add-host=host.docker.internal:host-gateway
+    -e MESSAGES_FRONTEND_BACKEND_SERVER=host.docker.internal:8000)
+else
+  NET_MODE=host
+  STUB_BIND=127.0.0.1
+  RUN_FLAGS=(--network host)
+fi
+
+cleanup() {
+  [ -n "$CID" ] && docker rm -f "$CID" >/dev/null 2>&1 || true
+  [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'cleanup; trap - EXIT; exit 130' INT TERM
+
+fail() {
+  echo "FAIL: $*" >&2
+  [ -n "$CID" ] && docker logs "$CID" >&2 || true
+  exit 1
+}
+
+port_open() { (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
+
+for port in 8080 8000; do
+  if port_open "$port"; then
+    echo "FAIL: port ${port} is already in use on the host." >&2
+    echo "Stop the process that uses it, then run the test again." >&2
+    exit 1
+  fi
+done
+
+# The stub echoes X-Forwarded-For, which Caddy sets to {client_ip}: the
+# script reads it back to learn the client IP that Caddy sees. The wide
+# 0.0.0.0 bind in bridge mode is deliberate: the container reaches the
+# stub through the bridge gateway or the Docker Desktop VM, not through
+# the host loopback.
+python3 - "$STUB_BIND" <<'EOF' &
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        xff = self.headers.get("X-Forwarded-For", "")
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(f"stub-backend\nXFF={xff}\n".encode())
+    def log_message(self, *args):
+        pass
+HTTPServer((sys.argv[1], 8000), H).serve_forever()
+EOF
+STUB_PID=$!
+
+for _ in $(seq 1 50); do
+  port_open 8000 && break
+  sleep 0.1
+done
+port_open 8000 || fail "the stub backend did not start on port 8000"
+
+start_container() {
+  CID=$(docker run -d "${RUN_FLAGS[@]}" "$@" "$IMAGE") \
+    || fail "docker run did not start the container"
+  for _ in $(seq 1 100); do
+    if curl -fs -o /dev/null --connect-timeout 3 --max-time 10 \
+      "$BASE/__lbheartbeat__" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  fail "container did not become ready on $BASE"
+}
+
+stop_container() {
+  docker rm -f "$CID" >/dev/null
+  CID=""
+}
+
+code() { curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 --max-time 10 "$@"; }
+
+assert_code() {
+  local expected="$1" label="$2"; shift 2
+  # curl prints 000 on a connection error; keep going so fail() can dump
+  # the container logs.
+  local got; got=$(code "$@" || true)
+  [ "$got" = "$expected" ] || fail "$label: expected HTTP $expected, got $got"
+  echo "ok: $label ($expected)"
+}
+
+# Boot + heartbeat: proves Caddy starts on distroless.
+start_container
+assert_code 200 "heartbeat" "$BASE/__lbheartbeat__"
+
+# Run the exact HEALTHCHECK command in the network namespace of the
+# running container, without a wait for the first health tick.
+docker run --rm --network "container:$CID" --entrypoint /usr/bin/lprobe "$IMAGE" \
+  -mode=http -port=8080 -endpoint=/__lbheartbeat__ \
+  || fail "lprobe healthcheck command"
+echo "ok: lprobe healthcheck"
+
+# Proxy path first: a 502 here means the container cannot reach the
+# stub (host firewall on the bridge, host.docker.internal:8000), not an
+# allowlist problem.
+assert_code 200 "api proxy" "$BASE/api/hello"
+
+# Backward compatibility: no allowlist -> admin reaches the stub.
+assert_code 200 "default admin passthrough" "$BASE/admin/"
+
+# The client IP Caddy sees depends on the network mode (loopback,
+# bridge gateway, Docker Desktop proxy): read it from the stub echo.
+CLIENT_IP=$(curl -s --max-time 10 "$BASE/api/echo" | sed -n 's/^XFF=//p' || true)
+[ -n "$CLIENT_IP" ] || fail "could not detect the client IP through the stub"
+case "$CLIENT_IP" in
+  *:*) CLIENT_CIDR="$CLIENT_IP/128" ;;
+  *) CLIENT_CIDR="$CLIENT_IP/32" ;;
+esac
+echo "ok: client IP detected ($CLIENT_CIDR, $NET_MODE mode)"
+stop_container
+
+# Allowlist without the client IP -> admin 403, the rest stays open.
+start_container -e 'DJANGO_ADMIN_IP_ALLOWLIST=192.0.2.0/24'
+assert_code 403 "admin denied" "$BASE/admin/"
+assert_code 403 "admin denied (no slash)" "$BASE/admin"
+assert_code 200 "SPA root still open" "$BASE/"
+assert_code 200 "api still open" "$BASE/api/hello"
+assert_code 403 "spoofed XFF ignored" -H 'X-Forwarded-For: 192.0.2.10' "$BASE/admin/"
+stop_container
+
+# Allowlist contains the client IP -> admin passes through.
+start_container -e "DJANGO_ADMIN_IP_ALLOWLIST=$CLIENT_CIDR"
+assert_code 200 "admin allowed for client IP" "$BASE/admin/"
+stop_container
+
+# Trusted proxy: XFF from a trusted peer sets client_ip.
+start_container \
+  -e "MESSAGES_FRONTEND_TRUSTED_PROXIES=$CLIENT_CIDR" \
+  -e 'DJANGO_ADMIN_IP_ALLOWLIST=192.0.2.0/24'
+assert_code 200 "trusted proxy: XFF accepted" -H 'X-Forwarded-For: 192.0.2.10' "$BASE/admin/"
+# trusted_proxies_strict: the rightmost untrusted address wins, so a
+# client-appended allowlisted prefix stays ineffective.
+assert_code 403 "trusted proxy: appended XFF chain denied" \
+  -H 'X-Forwarded-For: 192.0.2.10, 198.51.100.10' "$BASE/admin/"
+assert_code 403 "trusted proxy: no XFF -> peer IP denied" "$BASE/admin/"
+stop_container
+
+# private_ranges is the documented Scalingo value; the client IP is a
+# loopback or private bridge address in both modes, so it is trusted.
+start_container \
+  -e 'MESSAGES_FRONTEND_TRUSTED_PROXIES=private_ranges' \
+  -e 'DJANGO_ADMIN_IP_ALLOWLIST=192.0.2.0/24'
+assert_code 200 "private_ranges: XFF accepted" -H 'X-Forwarded-For: 192.0.2.10' "$BASE/admin/"
+stop_container
+
+echo "OK: frontend production image smoke test passed"

--- a/deploy/paas/scalingo_postfrontend
+++ b/deploy/paas/scalingo_postfrontend
@@ -13,7 +13,7 @@ mv src/backend/* ./
 mkdir -p messages_backend && touch messages_backend/__init__.py
 
 # Download Caddy binary
-CADDY_VERSION="2.9.1"
+CADDY_VERSION="2.11.4"
 curl -fsSL "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_amd64.tar.gz" | tar -xz -C bin/ caddy
 chmod +x bin/caddy
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -382,6 +382,29 @@ The following build-time variables are **deprecated**: they only act as fallback
 | `NEXT_PUBLIC_SENTRY_ENVIRONMENT` | `ENVIRONMENT` (backend environment) |
 | `NEXT_PUBLIC_MOBILE_OTA_MANIFEST_URL` | `MOBILE_OTA_MANIFEST_URL` |
 
+### Frontend Production Proxy (Caddy)
+
+The production frontend image runs Caddy (`src/frontend/caddy/Caddyfile`).
+Caddy reads these variables at start.
+
+| Variable | Default | Description | Required |
+|----------|---------|-------------|----------|
+| `PORT` | `8080` | Port Caddy listens on. Do not change it in the Docker image: the container HEALTHCHECK hardcodes 8080. | Optional |
+| `MESSAGES_FRONTEND_ROOT` | `/app` | Directory of the built SPA files that Caddy serves. | Optional |
+| `MESSAGES_FRONTEND_BACKEND_SERVER` | `localhost:8000` | `host:port` of the Django backend. Caddy proxies `/api/*`, `/static/*` and the admin URL to it. | Optional |
+| `DJANGO_ADMIN_IP_ALLOWLIST` | `0.0.0.0/0 ::/0` | Space-separated CIDR list of client IPs allowed on the Django admin URL. The default allows all (no filtering). Caddy answers 403 to denied requests. The client IP is the TCP peer unless `MESSAGES_FRONTEND_TRUSTED_PROXIES` is set. | Optional |
+| `MESSAGES_FRONTEND_TRUSTED_PROXIES` | _(empty)_ | Space-separated CIDR list of upstream proxies whose `X-Forwarded-For` sets the client IP. Empty = trust no proxy. Set only the exact addresses of your load balancer. Caddy walks the header from right to left and takes the first address that is not a trusted proxy. | Optional |
+
+To turn the admin filter off, leave `DJANGO_ADMIN_IP_ALLOWLIST`
+unset. Do not set it to an empty value: an empty list matches no client IP,
+so Caddy answers 403 to every admin request.
+
+On Scalingo, the routers set `X-Forwarded-For` and the container port is only
+reachable through them, but their IP ranges are not published. Set
+`MESSAGES_FRONTEND_TRUSTED_PROXIES=private_ranges` there: the Caddy keyword
+covers the private ranges the routers use. Do not use `private_ranges` when
+untrusted machines share the private network with Caddy.
+
 ## Development Tools
 
 ### Crowdin (Translations)

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -61,12 +61,12 @@ FROM ${FRONTEND_IMAGE} AS frontend-source
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d AS tools-download
 ARG TARGETARCH
 
-ARG CADDY_VERSION=2.9.1
+ARG CADDY_VERSION=2.11.4
 # When upgrading, run
-# for arch in amd64 arm64; do printf "CADDY_SHA256_%s=%s\n" "$(echo $arch | tr a-z A-Z)" "$(wget -qO- "https://github.com/caddyserver/caddy/releases/download/v2.9.1/caddy_2.9.1_linux_${arch}.tar.gz" | sha256sum | cut -d' ' -f1)"; done
+# for arch in amd64 arm64; do printf "CADDY_SHA256_%s=%s\n" "$(echo $arch | tr a-z A-Z)" "$(wget -qO- "https://github.com/caddyserver/caddy/releases/download/v2.11.4/caddy_2.11.4_linux_${arch}.tar.gz" | sha256sum | cut -d' ' -f1)"; done
 # and update checksums accordingly
-ARG CADDY_SHA256_AMD64=0542edbb5ce0d6987de6a37caa2bbc52a42445ec094fb9ba3e605534af5dd898
-ARG CADDY_SHA256_ARM64=e6f117f373c690f159dc0178d03e9003b4962118a49d889fadaef14cfc7666f8
+ARG CADDY_SHA256_AMD64=527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9
+ARG CADDY_SHA256_ARM64=52d42ae12b3462097e9868da6dfed3c9648ae12edd3b3638102312af84cb6904
 RUN wget -qO /tmp/caddy.tar.gz "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_${TARGETARCH}.tar.gz" \
     && case "${TARGETARCH}" in \
          amd64) echo "${CADDY_SHA256_AMD64}  /tmp/caddy.tar.gz" | sha256sum -c - ;; \
@@ -77,12 +77,12 @@ RUN wget -qO /tmp/caddy.tar.gz "https://github.com/caddyserver/caddy/releases/do
     && mv caddy /usr/bin/caddy \
     && rm /tmp/caddy.tar.gz
 
-ARG LPROBE_VERSION=v0.0.7
+ARG LPROBE_VERSION=v0.2.0
 # When upgrading, run
-# for arch in amd64 arm64; do printf "LPROBE_SHA256_%s=%s\n" "$(echo $arch | tr a-z A-Z)" "$(wget -qO- "https://github.com/fivexl/lprobe/releases/download/v0.0.7/lprobe-linux-${arch}" | sha256sum | cut -d' ' -f1)"; done
+# for arch in amd64 arm64; do printf "LPROBE_SHA256_%s=%s\n" "$(echo $arch | tr a-z A-Z)" "$(wget -qO- "https://github.com/fivexl/lprobe/releases/download/v0.2.0/lprobe-linux-${arch}" | sha256sum | cut -d' ' -f1)"; done
 # and update checksums accordingly
-ARG LPROBE_SHA256_AMD64=8cd314ee2bc271d241c47fa1f498c27e7a61f5163f80c0a785059599ffc13b95
-ARG LPROBE_SHA256_ARM64=cbcf5d452c6cca711bc555ca847d4e4ce052a126f37f60a43954a44a91fd230e
+ARG LPROBE_SHA256_AMD64=8b55ddb15c2d8c5e1773c73c1413b26c7041e5836dabdbcef5f806ba6b9d17a2
+ARG LPROBE_SHA256_ARM64=3f31eee19167f23dc64c645021b75306956da245e5b9763c90abd12797d0a72a
 RUN wget -qO /usr/bin/lprobe "https://github.com/fivexl/lprobe/releases/download/${LPROBE_VERSION}/lprobe-linux-${TARGETARCH}" \
     && case "${TARGETARCH}" in \
          amd64) echo "${LPROBE_SHA256_AMD64}  /usr/bin/lprobe" | sha256sum -c - ;; \

--- a/src/frontend/caddy/Caddyfile
+++ b/src/frontend/caddy/Caddyfile
@@ -1,6 +1,13 @@
 {
 	auto_https off
 	admin off
+	servers {
+		trusted_proxies static {$MESSAGES_FRONTEND_TRUSTED_PROXIES}
+		# Walk X-Forwarded-For right to left and take the first address
+		# that is not a trusted proxy. Without this, the leftmost entry
+		# wins and a client-appended prefix defeats the admin allowlist.
+		trusted_proxies_strict
+	}
 }
 
 :{$PORT} {
@@ -26,25 +33,34 @@
 
 		reverse_proxy /__heartbeat__/* {$MESSAGES_FRONTEND_BACKEND_SERVER:localhost:8000} {
 			header_up X-Forwarded-Proto https
-			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-For {client_ip}
 		}
 
 		# Django backend proxy
 		reverse_proxy /api/* {$MESSAGES_FRONTEND_BACKEND_SERVER:localhost:8000} {
 			header_up X-Forwarded-Proto https
-			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-For {client_ip}
 		}
+
+		# Django admin IP allowlist. The default allows all (no filtering).
+		# client_ip uses X-Forwarded-For only from the proxies listed in
+		# MESSAGES_FRONTEND_TRUSTED_PROXIES.
+		@admin_denied {
+			path /{$DJANGO_ADMIN_URL:admin} /{$DJANGO_ADMIN_URL:admin}/*
+			not client_ip {$DJANGO_ADMIN_IP_ALLOWLIST:0.0.0.0/0 ::/0}
+		}
+		respond @admin_denied 403
 
 		redir /{$DJANGO_ADMIN_URL:admin} /{$DJANGO_ADMIN_URL:admin}/ 301
 
 		reverse_proxy /{$DJANGO_ADMIN_URL:admin}/* {$MESSAGES_FRONTEND_BACKEND_SERVER:localhost:8000} {
 			header_up X-Forwarded-Proto https
-			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-For {client_ip}
 		}
 
 		reverse_proxy /static/* {$MESSAGES_FRONTEND_BACKEND_SERVER:localhost:8000} {
 			header_up X-Forwarded-Proto https
-			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-For {client_ip}
 		}
 
 		# --- Cache policy for the static SPA output ---


### PR DESCRIPTION
* Upgraded Caddy and lprobe in frontend Dockerfile
* Added variables to add an IP allowlist on the django admin path
* Upgraded every github action to latest + pin to commit SHA instead of version
* Added a Smoke Test for the frontend distroless build, in order to ensure XFF spoofing regressions
* Set persist-credentials: false on all 11 checkout steps in messages.yml and crowdin_upload.yml, so the job token leaves .git/config after clone.
* Remove the unused GITHUB_TOKEN from the crowdin upload step (used only for PR/push actions, not configured in our setup) and restrict that workflow to permissions: contents: read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable IP allowlisting for the Django admin URL, returning 403 responses for unauthorized client addresses.
  - Added trusted-proxy configuration for accurate client IP forwarding.
  - Added production frontend image build and smoke-test coverage.

- **Documentation**
  - Documented frontend production proxy environment variables, trusted proxies, and admin access filtering.

- **Chores**
  - Updated the frontend production proxy to Caddy 2.11.4 and lprobe 0.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->