### PR TITLE
Fix/spacing thread item

### DIFF
--- a/src/backend/core/api/openapi.json
+++ b/src/backend/core/api/openapi.json
@@ -7004,6 +7004,14 @@
                     },
                     {
                         "in": "query",
+                        "name": "is_spam",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter threads that are spam (1=true, 0=false)."
+                    },
+                    {
+                        "in": "query",
                         "name": "label_slug",
                         "schema": {
                             "type": "string"
@@ -7043,7 +7051,7 @@
                                 "has_unread_mention"
                             ]
                         },
-                        "description": "Comma-separated list of fields to aggregate.\n                Special values: 'all' (count all threads), 'all_unread' (count all unread threads).\n                Boolean fields: has_trashed, has_draft, has_starred, has_attachments, has_archived,\n                has_sender, has_active, has_delivery_pending, has_delivery_failed, is_spam, has_messages, has_unread_mention, has_mention, has_assigned_to_me, has_unassigned.\n                Unread variants ('_unread' suffix): count threads where the condition is true AND the thread is unread.\n                Examples: 'all,all_unread', 'has_starred,has_starred_unread', 'is_spam,is_spam_unread'",
+                        "description": "Comma-separated list of fields to aggregate.\n                Special values: 'all' (count all threads), 'all_unread' (count all unread threads).\n                Boolean fields: has_trashed, has_draft, has_starred, has_attachments, has_archived,\n                has_sender, has_active, has_delivery_pending, has_delivery_failed, has_messages, has_unread_mention, has_mention, has_assigned_to_me, has_unassigned.\n                Unread variants ('_unread' suffix): count threads where the condition is true AND the thread is unread.\n                Examples: 'all,all_unread', 'has_starred,has_starred_unread'",
                         "required": true,
                         "explode": false,
                         "style": "form"

--- a/src/backend/core/api/viewsets/thread.py
+++ b/src/backend/core/api/viewsets/thread.py
@@ -321,6 +321,12 @@ class ThreadViewSet(
                 description="Filter threads that are archived (1=true, 0=false).",
             ),
             OpenApiParameter(
+                name="is_spam",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Filter threads that are spam (1=true, 0=false).",
+            ),
+            OpenApiParameter(
                 name="has_draft",
                 type=OpenApiTypes.INT,
                 location=OpenApiParameter.QUERY,
@@ -384,9 +390,9 @@ class ThreadViewSet(
                 description="""Comma-separated list of fields to aggregate.
                 Special values: 'all' (count all threads), 'all_unread' (count all unread threads).
                 Boolean fields: has_trashed, has_draft, has_starred, has_attachments, has_archived,
-                has_sender, has_active, has_delivery_pending, has_delivery_failed, is_spam, has_messages, has_unread_mention, has_mention, has_assigned_to_me, has_unassigned.
+                has_sender, has_active, has_delivery_pending, has_delivery_failed, has_messages, has_unread_mention, has_mention, has_assigned_to_me, has_unassigned.
                 Unread variants ('_unread' suffix): count threads where the condition is true AND the thread is unread.
-                Examples: 'all,all_unread', 'has_starred,has_starred_unread', 'is_spam,is_spam_unread'""",
+                Examples: 'all,all_unread', 'has_starred,has_starred_unread'""",
                 enum=list(enums.THREAD_STATS_FIELDS_MAP.keys()),
                 style="form",
                 explode=False,
@@ -425,7 +431,13 @@ class ThreadViewSet(
     )
     def stats(self, request):
         """Retrieve aggregated statistics for threads accessible by the user."""
-        queryset = self.get_queryset(exclude_spam=False, exclude_trashed=False)
+        # Same defaults as ``list``: a counter must describe exactly the set of
+        # threads the folder will show. Keeping spam/trash in here made badges
+        # count threads the list then filtered out — e.g. a thread whose first
+        # message is spam (``Thread.is_spam``) but which still has an active
+        # one (``has_active``). The Spam and Trash folders pass ``is_spam=1`` /
+        # ``has_trashed=1`` explicitly, so they keep their own counts.
+        queryset = self.get_queryset()
         stats_fields_param = request.query_params.get("stats_fields", "")
 
         if not stats_fields_param:
@@ -436,7 +448,12 @@ class ThreadViewSet(
 
         requested_fields = [field.strip() for field in stats_fields_param.split(",")]
 
-        # Define valid base fields that can be counted
+        # Define valid base fields that can be counted.
+        # ``is_spam`` is deliberately absent: the queryset excludes spam by
+        # default, so the counter could only ever return 0 — or, with an
+        # explicit ``is_spam=1``, a duplicate of ``all``. Folders scope their
+        # counts through that query parameter instead (the Spam folder asks
+        # for ``is_spam=1&stats_fields=all_unread``).
         valid_base_fields = {
             "has_trashed",
             "has_archived",
@@ -451,7 +468,6 @@ class ThreadViewSet(
             "has_mention",
             "has_assigned_to_me",
             "has_unassigned",
-            "is_spam",
             "has_messages",
         }
 

--- a/src/backend/core/tests/api/test_thread_filter_assignment.py
+++ b/src/backend/core/tests/api/test_thread_filter_assignment.py
@@ -265,6 +265,42 @@ class TestThreadStatsAssignment:
         assert response.status_code == status.HTTP_200_OK
         assert response.data["has_unassigned"] == 1
 
+    def test_stats_has_unassigned_matches_list(self, api_client):
+        """The "Unassigned" badge must count exactly what the folder lists.
+
+        A thread whose first message is spam keeps ``has_active=True`` when a
+        later message is not spam, so it stays out of the list but used to be
+        counted by the badge — a counter pointing at an empty folder.
+        """
+        user, mailbox, thread = setup_user_with_thread_access()
+        api_client.force_authenticate(user=user)
+        thread.has_active = True
+        thread.save()
+
+        spam_thread = factories.ThreadFactory(has_active=True, is_spam=True)
+        factories.ThreadAccessFactory(
+            mailbox=mailbox,
+            thread=spam_thread,
+            role=enums.ThreadAccessRoleChoices.EDITOR,
+        )
+
+        params = {
+            "mailbox_id": str(mailbox.id),
+            "has_unassigned": "1",
+            "has_active": "1",
+        }
+        stats_response = api_client.get(
+            reverse("threads-stats"), {**params, "stats_fields": "all"}
+        )
+        list_response = api_client.get(reverse("threads-list"), params)
+
+        assert stats_response.status_code == status.HTTP_200_OK
+        assert list_response.status_code == status.HTTP_200_OK
+        assert stats_response.data["all"] == list_response.data["count"] == 1
+        assert [item["id"] for item in list_response.data["results"]] == [
+            str(thread.id)
+        ]
+
     def test_stats_all_with_assigned_to_me_filter(self, api_client):
         """Stats with all field and has_assigned_to_me filter should return correct total."""
         user, mailbox, thread1 = setup_user_with_thread_access()

--- a/src/backend/core/tests/api/test_threads_list.py
+++ b/src/backend/core/tests/api/test_threads_list.py
@@ -933,6 +933,90 @@ class TestThreadStatsAPI:
         # Get all threads
         assert response.data == {"has_messages": 2}
 
+    def test_stats_excludes_spam_and_trashed_by_default(self, api_client, url):
+        """Stats must apply the same spam/trash defaults as the list endpoint.
+
+        Otherwise every sidebar badge over-counts: spam and trashed threads
+        contribute to the number while the folder they point at hides them.
+        """
+        user = UserFactory()
+        api_client.force_authenticate(user=user)
+        mailbox = MailboxFactory(users_read=[user])
+
+        for thread in [
+            ThreadFactory(has_messages=True),
+            ThreadFactory(has_messages=True, is_spam=True),
+            ThreadFactory(has_messages=True, is_trashed=True),
+        ]:
+            ThreadAccessFactory(
+                mailbox=mailbox,
+                thread=thread,
+                role=enums.ThreadAccessRoleChoices.EDITOR,
+            )
+
+        response = api_client.get(
+            url, {"mailbox_id": str(mailbox.id), "stats_fields": "has_messages"}
+        )
+
+        assert response.status_code == 200
+        assert response.data == {"has_messages": 1}
+
+    def test_stats_counts_spam_when_explicitly_requested(self, api_client, url):
+        """The Spam folder passes ``is_spam=1``, so its own count is preserved."""
+        user = UserFactory()
+        api_client.force_authenticate(user=user)
+        mailbox = MailboxFactory(users_read=[user])
+
+        for thread in [
+            ThreadFactory(has_messages=True),
+            ThreadFactory(has_messages=True, is_spam=True),
+        ]:
+            ThreadAccessFactory(
+                mailbox=mailbox,
+                thread=thread,
+                role=enums.ThreadAccessRoleChoices.EDITOR,
+            )
+
+        response = api_client.get(
+            url,
+            {
+                "mailbox_id": str(mailbox.id),
+                "is_spam": "1",
+                "stats_fields": "has_messages",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.data == {"has_messages": 1}
+
+    def test_stats_counts_trashed_when_explicitly_requested(self, api_client, url):
+        """The Trash folder passes ``has_trashed=1``, so its own count is preserved."""
+        user = UserFactory()
+        api_client.force_authenticate(user=user)
+        mailbox = MailboxFactory(users_read=[user])
+
+        for thread in [
+            ThreadFactory(has_messages=True),
+            ThreadFactory(has_messages=True, has_trashed=True, is_trashed=True),
+        ]:
+            ThreadAccessFactory(
+                mailbox=mailbox,
+                thread=thread,
+                role=enums.ThreadAccessRoleChoices.EDITOR,
+            )
+
+        response = api_client.get(
+            url,
+            {
+                "mailbox_id": str(mailbox.id),
+                "has_trashed": "1",
+                "stats_fields": "has_messages",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.data == {"has_messages": 1}
+
     def test_stats_specific_fields(self, api_client, url):
         """Test retrieving stats for specific fields."""
 
@@ -1277,8 +1361,6 @@ class TestThreadStatsAPI:
                     "has_starred_unread,"
                     "has_sender,"
                     "has_sender_unread,"
-                    "is_spam,"
-                    "is_spam_unread,"
                     "has_active,"
                     "has_active_unread"
                 ),
@@ -1291,8 +1373,8 @@ class TestThreadStatsAPI:
             "has_starred_unread": 1,  # Only thread1 is starred AND unread
             "has_sender": 2,  # thread1 and thread2 have has_sender=True
             "has_sender_unread": 1,  # Only thread1 is sender AND unread
-            "is_spam": 1,  # Only thread3 is spam
-            "is_spam_unread": 0,  # thread3 has no messaged_at so not unread
+            # thread3 is spam: excluded from the default scope, exactly as the
+            # list excludes it.
             "has_active": 2,  # thread1 and thread2 have has_active=True
             "has_active_unread": 1,  # Only thread1 is active AND unread
         }
@@ -1388,6 +1470,20 @@ class TestThreadStatsAPI:
         assert response.status_code == 400
         assert (
             "Invalid field requested in stats_fields: invalid_field"
+            in response.data["detail"]
+        )
+
+    def test_stats_rejects_is_spam(self, api_client, url):
+        """`is_spam` is not countable: spam is scoped through the query param."""
+
+        user = UserFactory()
+        api_client.force_authenticate(user=user)
+        MailboxFactory(users_read=[user])
+
+        response = api_client.get(url, {"stats_fields": "all_unread,is_spam"})
+        assert response.status_code == 400
+        assert (
+            "Invalid field requested in stats_fields: is_spam"
             in response.data["detail"]
         )
 

--- a/src/frontend/src/features/api/gen/models/threads_stats_retrieve_params.ts
+++ b/src/frontend/src/features/api/gen/models/threads_stats_retrieve_params.ts
@@ -53,6 +53,10 @@ export type ThreadsStatsRetrieveParams = {
    */
   has_unread_mention?: number;
   /**
+   * Filter threads that are spam (1=true, 0=false).
+   */
+  is_spam?: number;
+  /**
    * Filter threads by label slug.
    */
   label_slug?: string;
@@ -68,9 +72,9 @@ export type ThreadsStatsRetrieveParams = {
  * Comma-separated list of fields to aggregate.
                 Special values: 'all' (count all threads), 'all_unread' (count all unread threads).
                 Boolean fields: has_trashed, has_draft, has_starred, has_attachments, has_archived,
-                has_sender, has_active, has_delivery_pending, has_delivery_failed, is_spam, has_messages, has_unread_mention, has_mention, has_assigned_to_me, has_unassigned.
+                has_sender, has_active, has_delivery_pending, has_delivery_failed, has_messages, has_unread_mention, has_mention, has_assigned_to_me, has_unassigned.
                 Unread variants ('_unread' suffix): count threads where the condition is true AND the thread is unread.
-                Examples: 'all,all_unread', 'has_starred,has_starred_unread', 'is_spam,is_spam_unread'
+                Examples: 'all,all_unread', 'has_starred,has_starred_unread'
  */
   stats_fields: ThreadsStatsRetrieveStatsFields;
 };

--- a/src/frontend/src/features/layouts/components/thread-panel/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-panel/_index.scss
@@ -4,6 +4,9 @@
     max-height: 100%;
     background-color: var(--c--contextuals--background--surface--secondary);
     height: 100%;
+    // Named container so descendants can adapt to the resizable panel width
+    // instead of the viewport width.
+    container: thread-panel / inline-size;
 
     &__header {
         padding: var(--c--globals--spacings--sm) var(--c--globals--spacings--base);

--- a/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-panel/components/thread-item/_index.scss
@@ -163,7 +163,7 @@
 
 .thread-item__column:has(.thread-item__sender + .thread-item__message-count) {
     align-items: baseline;
-    gap: var(--c--globals--spacings--2xs);
+    gap: var(--c--globals--spacings--3xs);
 }
 
 .thread-item__snippet {
@@ -179,6 +179,7 @@
 .thread-item__column--metadata {
     align-items: center;
     gap: var(--c--globals--spacings--3xs);
+    margin-left: var(--c--globals--spacings--xs);
 }
 
 .thread-item__label-bullets {
@@ -210,6 +211,14 @@
     overflow: hidden;
     font-weight: 500;
     font-size: var(--c--globals--font--sizes--sm);
+}
+
+// In a narrow panel, cap the sender so the message count next to it keeps
+// its room instead of being pushed out by a long name.
+@container thread-panel (max-width: 320px) {
+    .thread-item__sender {
+        max-width: 70%;
+    }
 }
 
 .thread-item[data-unread="true"] .thread-item__sender {

--- a/src/frontend/src/features/layouts/components/thread-view/_index.scss
+++ b/src/frontend/src/features/layouts/components/thread-view/_index.scss
@@ -103,7 +103,7 @@
     padding-block: var(--c--globals--spacings--b) var(--c--globals--spacings--base);
     background: linear-gradient(to top, var(--c--globals--colors--black-000), var(--c--contextuals--background--surface--tertiary) 15px, var(--c--contextuals--background--surface--tertiary) 100%);
     z-index: 10;
-    container-type: inline-size;
+    container: thread-view-header / inline-size;
 }
 
 .thread-view__header__top {
@@ -119,7 +119,7 @@
     // Switch to a stacked layout before the title is squeezed down to a few
     // orphan letters on its first line. Using a container query (not a media
     // query) keeps the trigger in sync with the resizable thread panel width.
-    @container (max-width: 35rem) {
+    @container thread-view-header (max-width: 35rem) {
         display: flex;
         flex-direction: column;
         gap: var(--c--globals--spacings--xs);


### PR DESCRIPTION
## Purpose

Fix a filter bug on the stats endpoints. Exclude spam and trashed thread
by default to stats. A spammed trashed can have active message and we don't want to
count them by default

Improve thread panel layout by stretching thread sender width
when thread panel has a width less than 320px. It prevents to
stick the number of thread's messages next to the thread date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thread statistics now exclude spam and fully trashed threads by default, matching folder list counts.
  * Explicit spam or trashed views continue to report accurate counts.
  * Corrected unread and unassigned badge totals for filtered threads.
  * The statistics API now uses the spam filter for spam counts rather than accepting spam as a statistics field.

* **UI Improvements**
  * Improved thread item spacing and sender layout in narrow, resizable panels.
  * Thread view headers adapt more reliably to available width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->