### PR TITLE
✨(submit) pass the api_key channel to enable channel tags on submitted mail

### DIFF
--- a/src/backend/core/api/viewsets/submit.py
+++ b/src/backend/core/api/viewsets/submit.py
@@ -159,6 +159,7 @@ class SubmitRawEmailView(APIView):
                 raw_data=raw_mime,
                 mailbox=mailbox,
                 is_outbound=True,
+                channel=request.auth,
             )
             if not message:
                 # Roll back so any partial writes from the failed creation


### PR DESCRIPTION
The `/api/v1.0/submit/` view calls `_create_message_from_inbound(..., is_outbound=True)` without a `channel=` argument. As a result the channel-tags labeling (`channel.settings["tags"]`, applied inside `_create_message_from_inbound`) never fires for messages submitted via the API.

`request.auth` is already the authenticated `api_key` Channel used for the scope check, so this passes it through — a one-liner. The tags block is not gated by `is_outbound`, so no further change is needed.

## Use case

An integration (e.g. an Odoo connector) submits outbound mail through a dedicated `api_key` channel and wants every submitted message auto-tagged with a fixed label so it is recognizable in the mailbox. Setting `channel.settings["tags"] = [label_uuid]` then applies that label, without any header- or content-based rules.

## Note

The label must exist in the sending mailbox (`Label.objects.get(id=tag_id, mailbox=mailbox)`); unknown ids are logged and skipped, consistent with the existing inbound behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Outbound messages created from submitted raw emails now record the channel used to create them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->